### PR TITLE
Fix missing tx with only one output

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -4,7 +4,7 @@ explorer {
 }
 
 blockflow {
-    host = localhost
+    host = "127.0.0.1"
     port = 12973
 
     network-type = "mainnet"

--- a/src/main/scala/org/alephium/explorer/persistence/model/InputEntity.scala
+++ b/src/main/scala/org/alephium/explorer/persistence/model/InputEntity.scala
@@ -18,10 +18,12 @@ package org.alephium.explorer.persistence.model
 
 import org.alephium.explorer.Hash
 import org.alephium.explorer.api.model.{BlockEntry, Input, Output, Transaction}
+import org.alephium.util.TimeStamp
 
 final case class InputEntity(
     bockHash: BlockEntry.Hash,
     txHash: Transaction.Hash,
+    timestamp: TimeStamp,
     scriptHint: Int,
     outputRefKey: Hash,
     unlockScript: Option[String],

--- a/src/main/scala/org/alephium/explorer/persistence/schema/InputSchema.scala
+++ b/src/main/scala/org/alephium/explorer/persistence/schema/InputSchema.scala
@@ -23,6 +23,7 @@ import slick.lifted.{Index, PrimaryKey, ProvenShape}
 import org.alephium.explorer.Hash
 import org.alephium.explorer.api.model.{BlockEntry, Transaction}
 import org.alephium.explorer.persistence.model.InputEntity
+import org.alephium.util.TimeStamp
 
 trait InputSchema extends CustomTypes {
   val config: DatabaseConfig[JdbcProfile]
@@ -32,6 +33,7 @@ trait InputSchema extends CustomTypes {
   class Inputs(tag: Tag) extends Table[InputEntity](tag, "inputs") {
     def blockHash: Rep[BlockEntry.Hash]   = column[BlockEntry.Hash]("block_hash")
     def txHash: Rep[Transaction.Hash]     = column[Transaction.Hash]("tx_hash")
+    def timestamp: Rep[TimeStamp]         = column[TimeStamp]("timestamp")
     def scriptHint: Rep[Int]              = column[Int]("script_hint")
     def outputRefKey: Rep[Hash]           = column[Hash]("output_ref_key")
     def unlockScript: Rep[Option[String]] = column[Option[String]]("unlock_script")
@@ -44,7 +46,7 @@ trait InputSchema extends CustomTypes {
     def outputRefKeyIdx: Index = index("inputs_output_ref_key_idx", outputRefKey)
 
     def * : ProvenShape[InputEntity] =
-      (blockHash, txHash, scriptHint, outputRefKey, unlockScript, mainChain)
+      (blockHash, txHash, timestamp, scriptHint, outputRefKey, unlockScript, mainChain)
         .<>((InputEntity.apply _).tupled, InputEntity.unapply)
   }
 

--- a/src/main/scala/org/alephium/explorer/service/BlockFlowClient.scala
+++ b/src/main/scala/org/alephium/explorer/service/BlockFlowClient.scala
@@ -158,7 +158,8 @@ object BlockFlowClient {
       Height.unsafe(block.height),
       block.deps.map(new BlockEntry.Hash(_)).toSeq,
       transactions.map(txToEntity(_, hash, block.timestamp)),
-      transactions.flatMap(tx => tx.inputs.toSeq.map(inputToEntity(_, hash, tx.id, false))),
+      transactions.flatMap(tx =>
+        tx.inputs.toSeq.map(inputToEntity(_, hash, tx.id, block.timestamp, false))),
       transactions.flatMap(tx =>
         tx.outputs.toSeq.zipWithIndex.map {
           case (out, index) => outputToEntity(out, hash, tx.id, index, block.timestamp, false)
@@ -179,10 +180,12 @@ object BlockFlowClient {
   private def inputToEntity(input: api.model.Input,
                             blockHash: BlockEntry.Hash,
                             txId: Hash,
+                            timestamp: TimeStamp,
                             mainChain: Boolean): InputEntity =
     InputEntity(
       blockHash,
       new Transaction.Hash(txId),
+      timestamp,
       input.outputRef.scriptHint,
       input.outputRef.key,
       input.unlockScript.map(Hex.toHexString),


### PR DESCRIPTION
When listing tx for a given address, if the address was not present in
the output (dropping all money from the inputs), the tx was not
returned.