### PR TITLE
Allows configuration to be overwritten via environment variables

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,13 +1,16 @@
 explorer {
     port = 9090
     host = "localhost"
+    host = ${?EXPLORER_HOST}
 }
 
 blockflow {
     host = "127.0.0.1"
+    host = ${?BLOCKFLOW_HOST}
     port = 12973
 
     network-type = "testnet"
+    network-type = ${?BLOCKFLOW_NETWORK}
     groupNum = 4
     blockflow-fetch-max-age = 30 minutes
 }
@@ -16,10 +19,14 @@ db = {
   profile = "slick.jdbc.PostgresProfile$"
   db {
     name     = "explorer"
+    name     = ${?DB_NAME}
     host     = "localhost"
+    host     = ${?DB_HOST}
     port     = 5432
     url      = "jdbc:postgresql://"${db.db.host}":"${db.db.port}"/"${db.db.name}
     user     = "postgres"
+    user     = ${?DB_USER}
     password = "postgres"
+    password = ${?DB_PASSWORD}
   }
 }


### PR DESCRIPTION
Injecting environment variables inside a container is trivial, and framework such as Spring supports this out of the box. This small PR manually maps some environment variables to the config attributes that must be changed.

One limitation though is that only strings can be injected from the config, so integers can't be injected out of the box.

