### PR TITLE
Add `mainChain` field in `TransactionEntity`

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/persistence/dao/BlockDao.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/dao/BlockDao.scala
@@ -217,6 +217,10 @@ object BlockDao {
                                             isMainChain: Boolean): DBActionRWT[Unit] = {
       val query =
         for {
+          _ <- transactionsTable
+            .filter(_.blockHash === hash)
+            .map(_.mainChain)
+            .update(isMainChain)
           _ <- outputsTable
             .filter(_.blockHash === hash)
             .map(_.mainChain)

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/BlockEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/BlockEntity.scala
@@ -34,9 +34,10 @@ final case class BlockEntity(
 ) extends FlowEntity {
   def updateMainChain(newMainChain: Boolean): BlockEntity = {
     this.copy(
-      mainChain = newMainChain,
-      inputs    = inputs.map(_.copy(mainChain = newMainChain)),
-      outputs   = outputs.map(_.copy(mainChain = newMainChain))
+      mainChain    = newMainChain,
+      transactions = transactions.map(_.copy(mainChain = newMainChain)),
+      inputs       = inputs.map(_.copy(mainChain = newMainChain)),
+      outputs      = outputs.map(_.copy(mainChain = newMainChain))
     )
   }
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/InputEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/InputEntity.scala
@@ -21,7 +21,7 @@ import org.alephium.explorer.api.model.{BlockEntry, Input, Output, Transaction}
 import org.alephium.util.TimeStamp
 
 final case class InputEntity(
-    bockHash: BlockEntry.Hash,
+    blockHash: BlockEntry.Hash,
     txHash: Transaction.Hash,
     timestamp: TimeStamp,
     scriptHint: Int,

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/TransactionEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/TransactionEntity.scala
@@ -25,5 +25,6 @@ final case class TransactionEntity(
     timestamp: TimeStamp,
     gasAmount: Int,
     gasPrice: U256,
-    index: Int
+    index: Int,
+    mainChain: Boolean
 )

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionSchema.scala
@@ -36,7 +36,8 @@ trait TransactionSchema extends CustomTypes {
     def gasAmount: Rep[Int]             = column[Int]("gas-amount")
     def gasPrice: Rep[U256] =
       column[U256]("gas-price", O.SqlType("DECIMAL(80,0)")) //U256.MaxValue has 78 digits
-    def txIndex: Rep[Int] = column[Int]("index")
+    def txIndex: Rep[Int]       = column[Int]("index")
+    def mainChain: Rep[Boolean] = column[Boolean]("main_chain")
 
     def pk: PrimaryKey = primaryKey("txs_pk", (hash, blockHash))
 
@@ -45,7 +46,7 @@ trait TransactionSchema extends CustomTypes {
     def blockHashIdx: Index = index("txs_block_hash_idx", blockHash)
 
     def * : ProvenShape[TransactionEntity] =
-      (hash, blockHash, timestamp, gasAmount, gasPrice, txIndex)
+      (hash, blockHash, timestamp, gasAmount, gasPrice, txIndex, mainChain)
         .<>((TransactionEntity.apply _).tupled, TransactionEntity.unapply)
   }
 

--- a/app/src/main/scala/org/alephium/explorer/service/BlockFlowClient.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/BlockFlowClient.scala
@@ -164,6 +164,7 @@ object BlockFlowClient {
 
   def blockProtocolToEntity(block: api.model.BlockEntry): BlockEntity = {
     val hash         = new BlockEntry.Hash(block.hash)
+    val mainChain    = false
     val transactions = block.transactions.toSeq
     BlockEntity(
       hash,
@@ -173,15 +174,15 @@ object BlockFlowClient {
       Height.unsafe(block.height),
       block.deps.map(new BlockEntry.Hash(_)).toSeq,
       transactions.zipWithIndex.map {
-        case (tx, index) => txToEntity(tx, hash, block.timestamp, index)
+        case (tx, index) => txToEntity(tx, hash, block.timestamp, index, mainChain)
       },
       transactions.flatMap(tx =>
-        tx.inputs.toSeq.map(inputToEntity(_, hash, tx.id, block.timestamp, false))),
+        tx.inputs.toSeq.map(inputToEntity(_, hash, tx.id, block.timestamp, mainChain))),
       transactions.flatMap(tx =>
         tx.outputs.toSeq.zipWithIndex.map {
-          case (out, index) => outputToEntity(out, hash, tx.id, index, block.timestamp, false)
+          case (out, index) => outputToEntity(out, hash, tx.id, index, block.timestamp, mainChain)
       }),
-      mainChain = false
+      mainChain = mainChain
     )
   }
 
@@ -203,14 +204,16 @@ object BlockFlowClient {
   private def txToEntity(tx: api.model.Tx,
                          blockHash: BlockEntry.Hash,
                          timestamp: TimeStamp,
-                         index: Int): TransactionEntity =
+                         index: Int,
+                         mainChain: Boolean): TransactionEntity =
     TransactionEntity(
       new Transaction.Hash(tx.id),
       blockHash,
       timestamp,
       tx.gasAmount,
       tx.gasPrice,
-      index
+      index,
+      mainChain
     )
 
   private def inputToUInput(input: api.model.Input): UInput = {


### PR DESCRIPTION
We had a bug in the case where a transaction was in two blocks, one on the
main chain and the other on a fork.

We thus had two times the transaction in db, so when we were listing the
transactions for then concerned address, we were getting two times the
tx.

We are now filtering by main chain the same way we do for inputs and
outputs.