### PR TITLE
Rename `scriptHint` to `hint`

### DIFF
--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -1176,12 +1176,12 @@
       },
       "Ref": {
         "required": [
-          "scriptHint",
+          "hint",
           "key"
         ],
         "type": "object",
         "properties": {
-          "scriptHint": {
+          "hint": {
             "type": "integer"
           },
           "key": {

--- a/app/src/main/scala/org/alephium/explorer/api/model/Output.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/Output.scala
@@ -31,7 +31,7 @@ final case class Output(
 )
 
 object Output {
-  final case class Ref(scriptHint: Int, key: Hash)
+  final case class Ref(hint: Int, key: Hash)
 
   object Ref {
     implicit val readWriter: ReadWriter[Ref] = macroRW

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/InputEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/InputEntity.scala
@@ -24,14 +24,14 @@ final case class InputEntity(
     blockHash: BlockEntry.Hash,
     txHash: Transaction.Hash,
     timestamp: TimeStamp,
-    scriptHint: Int,
+    hint: Int,
     outputRefKey: Hash,
     unlockScript: Option[String],
     mainChain: Boolean
 ) {
   def toApi(outputRef: OutputEntity): Input =
     Input(
-      Output.Ref(scriptHint, outputRefKey),
+      Output.Ref(hint, outputRefKey),
       unlockScript,
       outputRef.txHash,
       outputRef.address,

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/UInputEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/UInputEntity.scala
@@ -21,12 +21,12 @@ import org.alephium.explorer.api.model.{Output, Transaction, UInput}
 
 final case class UInputEntity(
     txHash: Transaction.Hash,
-    scriptHint: Int,
+    hint: Int,
     outputRefKey: Hash,
     unlockScript: Option[String]
 ) {
   lazy val toApi: UInput = UInput(
-    Output.Ref(scriptHint, outputRefKey),
+    Output.Ref(hint, outputRefKey),
     unlockScript
   )
 }

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/UnconfirmedTxEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/UnconfirmedTxEntity.scala
@@ -39,7 +39,7 @@ object UnconfirmedTxEntity {
      utx.inputs.map { input =>
        UInputEntity(
          utx.hash,
-         input.outputRef.scriptHint,
+         input.outputRef.hint,
          input.outputRef.key,
          input.unlockScript
        )

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
@@ -143,7 +143,7 @@ trait TransactionQueries
       .map {
         case (input, output) =>
           (input.txHash,
-           (input.scriptHint,
+           (input.hint,
             input.outputRefKey,
             input.unlockScript,
             output.txHash,
@@ -229,7 +229,7 @@ trait TransactionQueries
       .on(_.outputRefKey === _.key)
       .map {
         case (input, output) =>
-          (input.scriptHint,
+          (input.hint,
            input.outputRefKey,
            input.unlockScript,
            output.txHash,
@@ -280,13 +280,13 @@ trait TransactionQueries
     getBalanceQuery(address).result.map(_.getOrElse(U256.Zero))
 
   private val toApiInput = {
-    (scriptHint: Int,
+    (hint: Int,
      key: Hash,
      unlockScript: Option[String],
      txHash: Transaction.Hash,
      address: Address,
      amount: U256) =>
-      Input(Output.Ref(scriptHint, key), unlockScript, txHash, address, amount)
+      Input(Output.Ref(hint, key), unlockScript, txHash, address, amount)
   }.tupled
 
   private val toApiOutput = (Output.apply _).tupled

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/InputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/InputSchema.scala
@@ -31,10 +31,11 @@ trait InputSchema extends CustomTypes {
   import config.profile.api._
 
   class Inputs(tag: Tag) extends Table[InputEntity](tag, "inputs") {
-    def blockHash: Rep[BlockEntry.Hash]   = column[BlockEntry.Hash]("block_hash")
-    def txHash: Rep[Transaction.Hash]     = column[Transaction.Hash]("tx_hash")
-    def timestamp: Rep[TimeStamp]         = column[TimeStamp]("timestamp")
-    def scriptHint: Rep[Int]              = column[Int]("script_hint")
+    def blockHash: Rep[BlockEntry.Hash] = column[BlockEntry.Hash]("block_hash")
+    def txHash: Rep[Transaction.Hash]   = column[Transaction.Hash]("tx_hash")
+    def timestamp: Rep[TimeStamp]       = column[TimeStamp]("timestamp")
+    //TODO Rename column field when we release a version that have to dump data.
+    def hint: Rep[Int]                    = column[Int]("script_hint")
     def outputRefKey: Rep[Hash]           = column[Hash]("output_ref_key")
     def unlockScript: Rep[Option[String]] = column[Option[String]]("unlock_script")
     def mainChain: Rep[Boolean]           = column[Boolean]("main_chain")
@@ -46,7 +47,7 @@ trait InputSchema extends CustomTypes {
     def outputRefKeyIdx: Index = index("inputs_output_ref_key_idx", outputRefKey)
 
     def * : ProvenShape[InputEntity] =
-      (blockHash, txHash, timestamp, scriptHint, outputRefKey, unlockScript, mainChain)
+      (blockHash, txHash, timestamp, hint, outputRefKey, unlockScript, mainChain)
         .<>((InputEntity.apply _).tupled, InputEntity.unapply)
   }
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/UInputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/UInputSchema.scala
@@ -30,8 +30,9 @@ trait UInputSchema extends CustomTypes {
   import config.profile.api._
 
   class UInputs(tag: Tag) extends Table[UInputEntity](tag, "uinputs") {
-    def txHash: Rep[Transaction.Hash]     = column[Transaction.Hash]("tx_hash")
-    def scriptHint: Rep[Int]              = column[Int]("script_hint")
+    def txHash: Rep[Transaction.Hash] = column[Transaction.Hash]("tx_hash")
+    //TODO Rename column field when we release a version that have to dump data.
+    def hint: Rep[Int]                    = column[Int]("script_hint")
     def outputRefKey: Rep[Hash]           = column[Hash]("output_ref_key")
     def unlockScript: Rep[Option[String]] = column[Option[String]]("unlock_script")
 
@@ -40,7 +41,7 @@ trait UInputSchema extends CustomTypes {
     def uinputsTxHashIdx: Index = index("uinputs_tx_hash_idx", txHash)
 
     def * : ProvenShape[UInputEntity] =
-      (txHash, scriptHint, outputRefKey, unlockScript)
+      (txHash, hint, outputRefKey, unlockScript)
         .<>((UInputEntity.apply _).tupled, UInputEntity.unapply)
   }
 

--- a/app/src/test/scala/org/alephium/explorer/Generators.scala
+++ b/app/src/test/scala/org/alephium/explorer/Generators.scala
@@ -118,9 +118,9 @@ trait Generators {
   } yield Output.Ref(hint, key)
 
   lazy val outputRefProtocolGen: Gen[protocolApi.OutputRef] = for {
-    scriptHint <- arbitrary[Int]
-    key        <- hashGen
-  } yield protocolApi.OutputRef(scriptHint, key)
+    hint <- arbitrary[Int]
+    key  <- hashGen
+  } yield protocolApi.OutputRef(hint, key)
 
   lazy val inputProtocolGen: Gen[protocolApi.Input] = for {
     outputRef    <- outputRefProtocolGen

--- a/app/src/test/scala/org/alephium/explorer/api/model/ApiModelSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/api/model/ApiModelSpec.scala
@@ -47,7 +47,7 @@ class ApiModelSpec() extends AlephiumSpec with Generators {
     forAll(outputRefGen) { outputRef =>
       val expected = s"""
      |{
-     |  "scriptHint": ${outputRef.scriptHint},
+     |  "hint": ${outputRef.hint},
      |  "key": "${outputRef.key.toHexString}"
      |}""".stripMargin
       check(outputRef, expected)

--- a/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
@@ -143,7 +143,7 @@ class TransactionServiceSpec
     val input1 = InputEntity(blockHash1,
                              tx1.hash,
                              timestamp    = ts1,
-                             scriptHint   = 0,
+                             hint         = 0,
                              outputRefKey = output0.key,
                              None,
                              true)


### PR DESCRIPTION
We don't change yet the db column name, to avoid a restart from scratch.
We'll change it the next time we have an heavy release that require a
dump of the data.

I tested locally with latest explorer and everything is fine. In alephium-js it's still defined as `scriptHint` but as we don't use it it just works fine. I'll anyway make the change in alephium-js