### PR TITLE
Added main chain index

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/persistence/DBInitializer.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/DBInitializer.scala
@@ -73,7 +73,7 @@ class DBInitializer(val config: DatabaseConfig[JdbcProfile])(
         })
       }
       .flatMap { _ =>
-        run(createBlockHeadersFullIndexSQL())
+        run(createBlockHeadersIndexesSQL())
       }
       .map(_ => ())
   }

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/BlockHeaderSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/BlockHeaderSchema.scala
@@ -51,7 +51,6 @@ trait BlockHeaderSchema extends CustomTypes {
 
     def timestampIdx: Index = index("blocks_timestamp_idx", timestamp)
     def heightIdx: Index    = index("blocks_height_idx", height)
-    def mainChainIdx: Index = index("blocks_main_chain_idx", mainChain)
 
     def * : ProvenShape[BlockHeader] =
       (hash,
@@ -70,17 +69,36 @@ trait BlockHeaderSchema extends CustomTypes {
   }
 
   /**
-    * Builds index for all columns of this table so that
-    * index scan is enough for the query to return results.
+    * Indexes all columns of this table so that `INDEX ONLY SCAN`
+    * is enough for queries to return results.
     *
     * @see PR <a href="https://github.com/alephium/explorer-backend/pull/112">#112</a>.
     */
-  def createBlockHeadersFullIndexSQL(): SqlAction[Int, NoStream, Effect] = {
+  private def fullIndexSQL(): SqlAction[Int, NoStream, Effect] =
     sqlu"""
       create unique index if not exists block_headers_full_index
           on block_headers (main_chain asc, timestamp desc, hash asc, chain_from asc, chain_to asc, height asc);
       """
-  }
+
+  /**
+    * Builds partial index for column `main_chain` when `true` for performant
+    * [[org.alephium.explorer.persistence.dao.BlockDao.listMainChain]] queries.
+    *
+    * @see PR <a href="https://github.com/alephium/explorer-backend/pull/116">#116</a> for benchmarks
+    */
+  private def mainChainIndexSQL(): SqlAction[Int, NoStream, Effect] =
+    if (config.profile == slick.jdbc.H2Profile) {
+      //h2 doesn't support partial indexes
+      sqlu"create index if not exists blocks_main_chain_idx on block_headers (main_chain)"
+    } else {
+      sqlu"create index if not exists blocks_main_chain_idx on block_headers (main_chain) where main_chain = true;"
+    }
+
+  /**
+    * Joins all indexes created via raw SQL
+    */
+  def createBlockHeadersIndexesSQL(): DBIO[Unit] =
+    DBIO.seq(fullIndexSQL(), mainChainIndexSQL())
 
   val blockHeadersTable: TableQuery[BlockHeaders] = TableQuery[BlockHeaders]
 }

--- a/benchmark/src/main/scala/org/alephium/explorer/benchmark/db/DBBenchmark.scala
+++ b/benchmark/src/main/scala/org/alephium/explorer/benchmark/db/DBBenchmark.scala
@@ -83,14 +83,14 @@ class DBBenchmark {
   }
 
   @Benchmark
-  def readWithMainChainIndex(state: BlockHeaderWithMainChainReadState): Unit = {
+  def readMainChainIndex(state: BlockHeaderWithMainChainReadState): Unit = {
     import state.config.profile.api._
     val _ =
       state.db.runNow(state.blockHeadersTable.filter(_.mainChain).length.result, requestTimeout)
   }
 
   @Benchmark
-  def readWithoutMainChainIndex(state: BlockHeaderWithoutMainChainReadState): Unit = {
+  def readNoMainChainIndex(state: BlockHeaderWithoutMainChainReadState): Unit = {
     import state.config.profile.api._
     val _ =
       state.db.runNow(state.blockHeadersTable.filter(_.mainChain).length.result, requestTimeout)

--- a/benchmark/src/main/scala/org/alephium/explorer/benchmark/db/state/BlockHeaderMainChainReadState.scala
+++ b/benchmark/src/main/scala/org/alephium/explorer/benchmark/db/state/BlockHeaderMainChainReadState.scala
@@ -64,7 +64,7 @@ class BlockHeaderMainChainReadState(dropMainChainIndex: Boolean,
     val query =
       blockHeadersTable.schema.dropIfExists
         .andThen(blockHeadersTable.schema.create)
-        .andThen(createBlockHeadersFullIndexSQL())
+        .andThen(createBlockHeadersIndexesSQL())
         .andThen {
           //drop main_chain if dropMainChainIndex is true
           if (dropMainChainIndex) {


### PR DESCRIPTION
Parent issue: #110

JMH benchmark shows nearly 3x performance with this index. 

![image](https://user-images.githubusercontent.com/1773953/150406716-a00d73c6-890a-4eed-b175-2cdd3317b89b.png)

This index is required for calculating `total`

![image](https://user-images.githubusercontent.com/1773953/150407138-64a83456-50cf-4e61-82db-f8b4ed595686.png)

A 1000 queries (`BlockDAO.listMainChain`) sequentially from page 1 to 1000 (on the same data generated by the above JMH test (no `transactions`)) took 
- `80.375303 seconds` without the index 
- `26.225076 seconds` with the index

To create index in production we can use (CC: @killerwhile)

```sql
create index blocks_main_chain_idx
    on block_headers (main_chain);
```