### PR TITLE
Split JMH states to dedicated files

### DIFF
--- a/benchmark/src/main/scala/org/alephium/explorer/benchmark/db/state/ByteaReadState.scala
+++ b/benchmark/src/main/scala/org/alephium/explorer/benchmark/db/state/ByteaReadState.scala
@@ -1,0 +1,59 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.benchmark.db.state
+
+import org.openjdk.jmh.annotations.{Scope, State}
+
+import org.alephium.explorer.Hash
+import org.alephium.explorer.benchmark.db.BenchmarkSettings._
+import org.alephium.explorer.benchmark.db.DBExecutor
+import org.alephium.explorer.benchmark.db.table.TableByteSchema
+
+/**
+  * JMH state for benchmarking reads to [[TableByteSchema]].
+  *
+  * @param testDataCount total number of rows to generate in [[TableByteSchema]]
+  */
+@State(Scope.Thread)
+@SuppressWarnings(Array("org.wartremover.warts.Overloading"))
+class ByteaReadState(testDataCount: Int, val db: DBExecutor)
+    extends ReadBenchmarkState[Array[Byte]](testDataCount = testDataCount, db = db)
+    with TableByteSchema {
+
+  import config.profile.api._
+
+  //Overload: default constructor required by JMH. Uses Postgres as target DB.
+  def this() = {
+    this(testDataCount = readDataCount, db = DBExecutor.forPostgres(dbName, dbHost, dbPort))
+  }
+
+  def generateData(): Array[Byte] =
+    Hash.generate.bytes.toArray
+
+  def persist(data: Array[Array[Byte]]): Unit = {
+    //create a fresh table and insert the data
+    val query =
+      tableByteaQuery.schema.dropIfExists
+        .andThen(tableByteaQuery.schema.create)
+        .andThen(tableByteaQuery ++= data)
+
+    val _ = db.runNow(
+      action  = query,
+      timeout = batchWriteTimeout //set this according to the value of testDataCount
+    )
+  }
+}

--- a/benchmark/src/main/scala/org/alephium/explorer/benchmark/db/state/ByteaWriteState.scala
+++ b/benchmark/src/main/scala/org/alephium/explorer/benchmark/db/state/ByteaWriteState.scala
@@ -1,0 +1,51 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.benchmark.db.state
+
+import org.openjdk.jmh.annotations.{Scope, State}
+
+import org.alephium.explorer.Hash
+import org.alephium.explorer.benchmark.db.BenchmarkSettings._
+import org.alephium.explorer.benchmark.db.DBExecutor
+import org.alephium.explorer.benchmark.db.table.TableByteSchema
+
+/**
+  * JMH state for benchmarking writes to [[TableByteSchema]].
+  */
+@State(Scope.Thread)
+@SuppressWarnings(Array("org.wartremover.warts.Overloading"))
+class ByteaWriteState(val db: DBExecutor)
+    extends WriteBenchmarkState[Array[Byte]](db)
+    with TableByteSchema {
+
+  import config.profile.api._
+
+  //Overload: default constructor required by JMH. Uses Postgres as target DB.
+  def this() = {
+    this(DBExecutor.forPostgres(dbName, dbHost, dbPort))
+  }
+
+  def generateData(): Array[Byte] =
+    Hash.generate.bytes.toArray
+
+  def beforeAll(): Unit =
+    db.runNow(
+      //action = create a fresh table
+      action  = tableByteaQuery.schema.dropIfExists.andThen(tableByteaQuery.schema.create),
+      timeout = requestTimeout
+    )
+}

--- a/benchmark/src/main/scala/org/alephium/explorer/benchmark/db/state/ReadBenchmarkState.scala
+++ b/benchmark/src/main/scala/org/alephium/explorer/benchmark/db/state/ReadBenchmarkState.scala
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the library. If not, see <http://www.gnu.org/licenses/>.
 
-package org.alephium.explorer.benchmark.db
+package org.alephium.explorer.benchmark.db.state
 
 import scala.annotation.tailrec
 import scala.reflect.ClassTag
@@ -23,6 +23,8 @@ import com.typesafe.scalalogging.StrictLogging
 import org.openjdk.jmh.annotations._
 import slick.basic.DatabaseConfig
 import slick.jdbc.JdbcProfile
+
+import org.alephium.explorer.benchmark.db.DBExecutor
 
 /**
   * Base implementation for JMH states, for benchmarking reads queries to the target database.

--- a/benchmark/src/main/scala/org/alephium/explorer/benchmark/db/state/VarcharReadState.scala
+++ b/benchmark/src/main/scala/org/alephium/explorer/benchmark/db/state/VarcharReadState.scala
@@ -1,0 +1,59 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.benchmark.db.state
+
+import org.openjdk.jmh.annotations.{Scope, State}
+
+import org.alephium.explorer.Hash
+import org.alephium.explorer.benchmark.db.BenchmarkSettings._
+import org.alephium.explorer.benchmark.db.DBExecutor
+import org.alephium.explorer.benchmark.db.table.TableVarcharSchema
+
+/**
+  * JMH state for benchmarking reads to [[TableByteSchema]].
+  *
+  * @param testDataCount total number of rows to generate in [[TableByteSchema]]
+  */
+@State(Scope.Thread)
+@SuppressWarnings(Array("org.wartremover.warts.Overloading"))
+class VarcharReadState(testDataCount: Int, val db: DBExecutor)
+    extends ReadBenchmarkState[String](testDataCount = testDataCount, db = db)
+    with TableVarcharSchema {
+
+  import config.profile.api._
+
+  //Overload: default constructor required by JMH. Uses Postgres as target DB.
+  def this() = {
+    this(testDataCount = readDataCount, db = DBExecutor.forPostgres(dbName, dbHost, dbPort))
+  }
+
+  def generateData(): String =
+    Hash.generate.toHexString
+
+  def persist(data: Array[String]): Unit = {
+    //create a fresh table and insert the data
+    val query =
+      tableVarcharQuery.schema.dropIfExists
+        .andThen(tableVarcharQuery.schema.create)
+        .andThen(tableVarcharQuery ++= data)
+
+    val _ = db.runNow(
+      action  = query,
+      timeout = batchWriteTimeout
+    )
+  }
+}

--- a/benchmark/src/main/scala/org/alephium/explorer/benchmark/db/state/VarcharWriteState.scala
+++ b/benchmark/src/main/scala/org/alephium/explorer/benchmark/db/state/VarcharWriteState.scala
@@ -1,0 +1,51 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.benchmark.db.state
+
+import org.openjdk.jmh.annotations.{Scope, State}
+
+import org.alephium.explorer.Hash
+import org.alephium.explorer.benchmark.db.BenchmarkSettings._
+import org.alephium.explorer.benchmark.db.DBExecutor
+import org.alephium.explorer.benchmark.db.table.TableVarcharSchema
+
+/**
+  * JMH state for benchmarking writes to [[TableVarcharSchema]].
+  */
+@State(Scope.Thread)
+@SuppressWarnings(Array("org.wartremover.warts.Overloading"))
+class VarcharWriteState(val db: DBExecutor)
+    extends WriteBenchmarkState[String](db)
+    with TableVarcharSchema {
+
+  import config.profile.api._
+
+  //Overload: default constructor required by JMH. Uses Postgres as target DB.
+  def this() = {
+    this(DBExecutor.forPostgres(dbName, dbHost, dbPort))
+  }
+
+  def generateData(): String =
+    Hash.generate.toHexString
+
+  def beforeAll(): Unit =
+    db.runNow(
+      //action = create a fresh table
+      action  = tableVarcharQuery.schema.dropIfExists.andThen(tableVarcharQuery.schema.create),
+      timeout = requestTimeout
+    )
+}

--- a/benchmark/src/main/scala/org/alephium/explorer/benchmark/db/state/WriteBenchmarkState.scala
+++ b/benchmark/src/main/scala/org/alephium/explorer/benchmark/db/state/WriteBenchmarkState.scala
@@ -14,12 +14,14 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the library. If not, see <http://www.gnu.org/licenses/>.
 
-package org.alephium.explorer.benchmark.db
+package org.alephium.explorer.benchmark.db.state
 
 import com.typesafe.scalalogging.StrictLogging
 import org.openjdk.jmh.annotations.{Level, Setup, TearDown}
 import slick.basic.DatabaseConfig
 import slick.jdbc.JdbcProfile
+
+import org.alephium.explorer.benchmark.db.DBExecutor
 
 /**
   * Base implementation for JMH states, for benchmarking write queries to the target database.

--- a/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/ReadBenchmarkStateSpec.scala
+++ b/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/ReadBenchmarkStateSpec.scala
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the library. If not, see <http://www.gnu.org/licenses/>.
 
-package org.alephium.explorer.benchmark.db
+package org.alephium.explorer.benchmark.db.state
 
 import java.util.concurrent.RejectedExecutionException
 
@@ -23,6 +23,7 @@ import scala.concurrent.duration._
 import org.scalatest.concurrent.ScalaFutures
 
 import org.alephium.explorer.AlephiumSpec
+import org.alephium.explorer.benchmark.db.DBExecutor
 import org.alephium.explorer.benchmark.db.util.TestUtils._
 
 /**

--- a/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/WriteBenchmarkStateSpec.scala
+++ b/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/WriteBenchmarkStateSpec.scala
@@ -14,11 +14,12 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the library. If not, see <http://www.gnu.org/licenses/>.
 
-package org.alephium.explorer.benchmark.db
+package org.alephium.explorer.benchmark.db.state
 
 import scala.concurrent.duration._
 
 import org.alephium.explorer.AlephiumSpec
+import org.alephium.explorer.benchmark.db.DBExecutor
 import org.alephium.explorer.benchmark.db.util.TestUtils._
 
 /**


### PR DESCRIPTION
This PR is stacked on previous PR "Added main chain index" #116

[Commit](https://github.com/alephium/explorer-backend/commit/9d9f02fa19119344e52c120b9f14d79558780cc4).

It moves JMH states to their own dedicated smaller files. `DBBenchmark` would've gotten too large with few more benchmarks.