### PR TITLE
Cached `main_chain` count query

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/cache/CaffeineAsyncCache.scala
+++ b/app/src/main/scala/org/alephium/explorer/cache/CaffeineAsyncCache.scala
@@ -1,0 +1,64 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.cache
+
+import java.util.concurrent.CompletableFuture
+
+import scala.concurrent.Future
+import scala.jdk.CollectionConverters._
+import scala.jdk.FutureConverters._
+
+import com.github.benmanes.caffeine.cache.AsyncLoadingCache
+
+object CaffeineAsyncCache {
+
+  @inline def apply[K, V](cache: AsyncLoadingCache[K, V]): CaffeineAsyncCache[K, V] =
+    new CaffeineAsyncCache[K, V](cache)
+
+}
+
+/** A wrapper around [[AsyncLoadingCache]] to convert Java types to Scala. */
+class CaffeineAsyncCache[K, V](cache: AsyncLoadingCache[K, V]) {
+
+  def get(key: K): Future[V] =
+    cache.get(key).asScala
+
+  def getIfPresent(key: K): Option[Future[V]] = {
+    val valueOrNull = cache.getIfPresent(key)
+    if (valueOrNull == null) {
+      None
+    } else {
+      Some(valueOrNull.asScala)
+    }
+  }
+
+  def put(key: K, value: V): Unit =
+    cache.put(key, CompletableFuture.completedFuture(value))
+
+  def put(key: K, value: Future[V]): Unit =
+    cache.put(key, value.asJava.toCompletableFuture)
+
+  def invalidate(key: K): Unit =
+    cache.synchronous().invalidate(key)
+
+  def invalidateAll(key: Iterable[K]): Unit =
+    cache.synchronous().invalidateAll(key.asJava)
+
+  def invalidateAll(): Unit =
+    cache.synchronous().invalidateAll()
+
+}

--- a/app/src/main/scala/org/alephium/explorer/cache/CaffeineAsyncCache.scala
+++ b/app/src/main/scala/org/alephium/explorer/cache/CaffeineAsyncCache.scala
@@ -19,7 +19,6 @@ package org.alephium.explorer.cache
 import java.util.concurrent.CompletableFuture
 
 import scala.concurrent.Future
-import scala.jdk.CollectionConverters._
 import scala.jdk.FutureConverters._
 
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache
@@ -49,14 +48,8 @@ class CaffeineAsyncCache[K, V](cache: AsyncLoadingCache[K, V]) {
   def put(key: K, value: V): Unit =
     cache.put(key, CompletableFuture.completedFuture(value))
 
-  def put(key: K, value: Future[V]): Unit =
-    cache.put(key, value.asJava.toCompletableFuture)
-
   def invalidate(key: K): Unit =
     cache.synchronous().invalidate(key)
-
-  def invalidateAll(key: Iterable[K]): Unit =
-    cache.synchronous().invalidateAll(key.asJava)
 
   def invalidateAll(): Unit =
     cache.synchronous().invalidateAll()

--- a/app/src/main/scala/org/alephium/explorer/cache/CaffeineAsyncCache.scala
+++ b/app/src/main/scala/org/alephium/explorer/cache/CaffeineAsyncCache.scala
@@ -30,7 +30,7 @@ object CaffeineAsyncCache {
 
 }
 
-/** A wrapper around [[AsyncLoadingCache]] to convert Java types to Scala. */
+/** A wrapper around [[com.github.benmanes.caffeine.cache.AsyncLoadingCache]] to convert Java types to Scala. */
 class CaffeineAsyncCache[K, V](cache: AsyncLoadingCache[K, V]) {
 
   def get(key: K): Future[V] =

--- a/app/src/main/scala/org/alephium/explorer/persistence/dao/BlockDao.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/dao/BlockDao.scala
@@ -52,6 +52,7 @@ trait BlockDao {
   def insertAll(blocks: Seq[BlockEntity]): Future[Unit]
   def listMainChain(pagination: Pagination): Future[(Seq[BlockEntryLite], Int)]
   def listMainChainSQL(pagination: Pagination): Future[(Seq[BlockEntryLite], Int)]
+  def listMainChainSQLCached(pagination: Pagination): Future[(Seq[BlockEntryLite], Int)]
   def listIncludingForks(from: TimeStamp, to: TimeStamp): Future[Seq[BlockEntryLite]]
   def maxHeight(fromGroup: GroupIndex, toGroup: GroupIndex): Future[Option[Height]]
   def updateTransactionPerAddress(block: BlockEntity): Future[Seq[InputEntity]]

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
@@ -37,6 +37,8 @@ trait BlockQueries extends TransactionQueries with CustomTypes with StrictLoggin
 
   val block_headers = BlockHeaderSchema.table.baseTableRow.tableName //block_headers table name
 
+  val mainChainQuery = BlockHeaderSchema.table.filter(_.mainChain)
+
   private val blockDepsQuery = Compiled { blockHash: Rep[BlockEntry.Hash] =>
     BlockDepsSchema.table.filter(_.hash === blockHash).sortBy(_.depOrder).map(_.dep)
   }

--- a/app/src/main/scala/org/alephium/explorer/service/BlockService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/BlockService.scala
@@ -43,7 +43,7 @@ object BlockService {
       blockDao.getTransactions(hash, pagination)
 
     def listBlocks(pagination: Pagination): Future[ListBlocks] = {
-      blockDao.listMainChainSQL(pagination).map {
+      blockDao.listMainChainSQLCached(pagination).map {
         case (blocks, total) =>
           ListBlocks(total, blocks)
       }

--- a/app/src/test/scala/org/alephium/explorer/cache/CaffeineAsyncCacheSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/cache/CaffeineAsyncCacheSpec.scala
@@ -1,0 +1,52 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.cache
+
+import java.util.concurrent.{CompletableFuture, Executor, TimeUnit}
+
+import com.github.benmanes.caffeine.cache.{AsyncCacheLoader, Caffeine}
+import org.scalatest.concurrent.ScalaFutures
+
+import org.alephium.explorer.AlephiumSpec
+
+class CaffeineAsyncCacheSpec extends AlephiumSpec with ScalaFutures {
+
+  it should "return None for getIfPresent when cache is empty (NullPointerException check)" in {
+    val cache =
+      CaffeineAsyncCache {
+        Caffeine
+          .newBuilder()
+          .expireAfterWrite(10, TimeUnit.MINUTES)
+          .maximumSize(10)
+          .buildAsync[Int, String] {
+            new AsyncCacheLoader[Int, String] {
+              override def asyncLoad(key: Int, executor: Executor): CompletableFuture[String] =
+                fail("Async load is not required for this test")
+            }
+          }
+      }
+
+    //does not throw NullPointerException
+    cache.getIfPresent(1) is None
+    //insert value for key 1
+    cache.put(1, "one")
+    //get value
+    cache.getIfPresent(1).map(_.futureValue) is Some("one")
+
+  }
+
+}

--- a/app/src/test/scala/org/alephium/explorer/persistence/dao/BlockDaoSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/dao/BlockDaoSpec.scala
@@ -117,7 +117,8 @@ class BlockDaoSpec extends AlephiumSpec with ScalaFutures with Generators with E
 
         //Assert results returned by typed and SQL query are the same
         def runAssert(page: Pagination) = {
-          val sqlResult   = blockDao.listMainChainSQL(page).futureValue
+          blockDao.invalidateCacheRowCount()
+          val sqlResult   = blockDao.listMainChainSQLCached(page).futureValue
           val typedResult = blockDao.listMainChain(page).futureValue
           sqlResult is typedResult
         }

--- a/app/src/test/scala/org/alephium/explorer/persistence/dao/BlockDaoSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/dao/BlockDaoSpec.scala
@@ -18,6 +18,7 @@ package org.alephium.explorer.persistence.dao
 
 import scala.concurrent.ExecutionContext
 import scala.io.Source
+import scala.util.Random
 
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
@@ -27,6 +28,7 @@ import slick.jdbc.PostgresProfile.api._
 
 import org.alephium.api.{model, ApiModelCodec}
 import org.alephium.explorer.{AlephiumSpec, Generators}
+import org.alephium.explorer.api.model.{BlockEntry, BlockEntryLite, Pagination}
 import org.alephium.explorer.api.model.{BlockEntry, GroupIndex, Pagination}
 import org.alephium.explorer.persistence.{DatabaseFixture, DBRunner}
 import org.alephium.explorer.persistence.model._
@@ -169,10 +171,108 @@ class BlockDaoSpec extends AlephiumSpec with ScalaFutures with Generators with E
     blockDao.getAverageBlockTime().futureValue.head is ((chainIndex, Duration.ofMinutesUnsafe(2)))
   }
 
+  it should "cache mainChainQuery's rowCount when table is empty" in new Fixture {
+    //Initially the cache is unpopulated so it should return None
+    blockDao.getRowCountFromCacheIfPresent(blockDao.mainChainQuery) is None
+
+    //dispatch listMainChainSQL on an empty table and expect the cache to be populated with 0 count
+    forAll(Gen.posNum[Int], Gen.posNum[Int], arbitrary[Boolean]) {
+      case (page, limit, reverse) =>
+        blockDao
+          .listMainChainSQLCached(Pagination.unsafe(page, limit min 1, reverse))
+          .futureValue is ((Seq.empty[BlockEntryLite], 0))
+
+        //assert the cache is populated
+        blockDao
+          .getRowCountFromCacheIfPresent(blockDao.mainChainQuery)
+          .map(_.futureValue) is Some(0)
+    }
+  }
+
+  it should "cache mainChainQuery's rowCount when table is non-empty" in new Fixture {
+    //generate some entities with random mainChain value
+    val entitiesGenerator: Gen[List[BlockEntity]] =
+      Gen
+        .listOf(genBlockEntityWithOptionalParent(randomMainChainGen = Some(arbitrary[Boolean])))
+        .map(_.map(_._1))
+
+    forAll(entitiesGenerator) { blockEntities =>
+      //clear existing data
+      run(BlockHeaderSchema.table.delete).futureValue
+
+      //insert new blockEntities and expect the cache to get invalided
+      blockDao.insertAll(blockEntities).futureValue
+      //Assert the cache is invalidated after insert
+      blockDao.getRowCountFromCacheIfPresent(blockDao.mainChainQuery) is None
+
+      //expected row count in cache
+      val expectedMainChainCount = blockEntities.count(_.mainChain)
+
+      //invoking listMainChainSQL would populate the cache with the row count
+      blockDao
+        .listMainChainSQLCached(Pagination.unsafe(0, 1))
+        .futureValue
+        ._2 is expectedMainChainCount
+
+      //check the cache directly and it should contain the row count
+      blockDao
+        .getRowCountFromCacheIfPresent(blockDao.mainChainQuery)
+        .map(_.futureValue) is Some(expectedMainChainCount)
+    }
+  }
+
+  it should "refresh row count cache of mainChainQuery when new data is inserted" in new Fixture {
+    //generate some entities with random mainChain value
+    val entitiesGenerator: Gen[List[BlockEntity]] =
+      Gen
+        .listOf(genBlockEntityWithOptionalParent(randomMainChainGen = Some(arbitrary[Boolean])))
+        .map(_.map(_._1))
+
+    def expectCacheIsInvalidated() =
+      blockDao.getRowCountFromCacheIfPresent(blockDao.mainChainQuery) is None
+
+    forAll(entitiesGenerator, entitiesGenerator) {
+      case (entities1, entities2) =>
+        //clear existing data
+        run(BlockHeaderSchema.table.delete).futureValue
+
+        /** INSERT BATCH 1 - [[entities1]] */
+        blockDao.insertAll(entities1).futureValue
+        expectCacheIsInvalidated()
+        //expected count
+        val expectedMainChainCount = entities1.count(_.mainChain)
+        //Assert the query return expected count
+        blockDao
+          .listMainChainSQLCached(Pagination.unsafe(0, 1, Random.nextBoolean()))
+          .futureValue
+          ._2 is expectedMainChainCount
+        //Assert the cache contains the right row count
+        blockDao
+          .getRowCountFromCacheIfPresent(blockDao.mainChainQuery)
+          .map(_.futureValue) is Some(expectedMainChainCount)
+
+        /** INSERT BATCH 2 - [[entities2]] */
+        //insert the next batch of block entities
+        blockDao.insertAll(entities2).futureValue
+        expectCacheIsInvalidated()
+        //Expected total row count in cache
+        val expectedMainChainCountTotal = entities2.count(_.mainChain) + expectedMainChainCount
+        //Dispatch a query so the cache get populated
+        blockDao
+          .listMainChainSQLCached(Pagination.unsafe(0, 1, Random.nextBoolean()))
+          .futureValue
+          ._2 is expectedMainChainCountTotal
+        //Dispatch a query so the cache get populated
+        blockDao
+          .getRowCountFromCacheIfPresent(blockDao.mainChainQuery)
+          .map(_.futureValue) is Some(expectedMainChainCountTotal)
+    }
+  }
+
   trait Fixture extends DatabaseFixture with DBRunner with CustomTypes with ApiModelCodec {
     val blockflowFetchMaxAge: Duration = Duration.ofMinutesUnsafe(30)
 
-    val blockDao = BlockDao(groupNum, databaseConfig)
+    val blockDao = new BlockDao.Impl(groupNum, databaseConfig)
     val blockflow: Seq[Seq[model.BlockEntry]] =
       blockFlowGen(maxChainSize = 5, startTimestamp = TimeStamp.now()).sample.get
     val blocksProtocol: Seq[model.BlockEntry] = blockflow.flatten

--- a/app/src/test/scala/org/alephium/explorer/persistence/dao/BlockDaoSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/dao/BlockDaoSpec.scala
@@ -28,8 +28,7 @@ import slick.jdbc.PostgresProfile.api._
 
 import org.alephium.api.{model, ApiModelCodec}
 import org.alephium.explorer.{AlephiumSpec, Generators}
-import org.alephium.explorer.api.model.{BlockEntry, BlockEntryLite, Pagination}
-import org.alephium.explorer.api.model.{BlockEntry, GroupIndex, Pagination}
+import org.alephium.explorer.api.model.{BlockEntry, BlockEntryLite, GroupIndex, Pagination}
 import org.alephium.explorer.persistence.{DatabaseFixture, DBRunner}
 import org.alephium.explorer.persistence.model._
 import org.alephium.explorer.persistence.schema._

--- a/benchmark/src/main/scala/org/alephium/explorer/benchmark/db/DBBenchmark.scala
+++ b/benchmark/src/main/scala/org/alephium/explorer/benchmark/db/DBBenchmark.scala
@@ -145,6 +145,12 @@ class DBBenchmark {
       Await.result(state.dao.listMainChainSQL(state.next), requestTimeout)
   }
 
+  @Benchmark
+  def listBlocks_Forward_HikariCP_SQL_Cached(state: ListBlocks_Forward_HikariCP_ReadState): Unit = {
+    val _ =
+      Await.result(state.dao.listMainChainSQLCached(state.next), requestTimeout)
+  }
+
   /**
     * Address benchmarks
     */


### PR DESCRIPTION
- Added a cache `cacheRowCount: CaffeineAsyncCache[Query[_, _, Seq], Int]` which will cache any `count` query. This PR uses it for `listMainChain` only.
- Added a wrapper `CaffeineAsyncCache` to centralise handling Caffeine's Java to Scala type conversions. 
- Resolves #119

# Benchmark

The following benchmark shows around 20% performance improvement. 

![image](https://user-images.githubusercontent.com/1773953/160564009-0637f2da-148b-4b79-800e-294a7c3fa581.png)

# Cleanup

#156 will remove deprecated apis `listMainChain` and `listMainChainSQL` with `listMainChainSQLCached`.