### PR TITLE
Add `/address/total-transaction` and `/address/balance` endpoint

### DIFF
--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -443,7 +443,7 @@
         "tags": [
           "Addressess"
         ],
-        "description": "Get address informations",
+        "description": "Get address information",
         "operationId": "getAddressesAddress",
         "parameters": [
           {

--- a/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
@@ -22,7 +22,7 @@ import sttp.tapir.generic.auto._
 import org.alephium.api.{alphJsonBody => jsonBody}
 import org.alephium.explorer.api.BaseEndpoint
 import org.alephium.explorer.api.Codecs
-import org.alephium.explorer.api.model.{Address, AddressInfo, Pagination, Transaction}
+import org.alephium.explorer.api.model._
 
 // scalastyle:off magic.number
 trait AddressesEndpoints extends BaseEndpoint with QueryParams {
@@ -45,4 +45,18 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
       .in(pagination)
       .out(jsonBody[Seq[Transaction]])
       .description("List transactions of a given address")
+
+  val getTotalTransactionsByAddress: BaseEndpoint[Address, Int] =
+    addressesEndpoint.get
+      .in(path[Address]("address")(Codecs.addressTapirCodec))
+      .in("total-transactions")
+      .out(jsonBody[Int])
+      .description("Get total transactions' number of a given address")
+
+  val getAddressBalance: BaseEndpoint[Address, AddressBalance] =
+    addressesEndpoint.get
+      .in(path[Address]("address")(Codecs.addressTapirCodec))
+      .in("balance")
+      .out(jsonBody[AddressBalance])
+      .description("Get address' balance")
 }

--- a/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
@@ -36,7 +36,7 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
     addressesEndpoint.get
       .in(path[Address]("address")(Codecs.addressTapirCodec))
       .out(jsonBody[AddressInfo])
-      .description("Get address informations")
+      .description("Get address information")
 
   val getTransactionsByAddress: BaseEndpoint[(Address, Pagination), Seq[Transaction]] =
     addressesEndpoint.get
@@ -51,12 +51,12 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
       .in(path[Address]("address")(Codecs.addressTapirCodec))
       .in("total-transactions")
       .out(jsonBody[Int])
-      .description("Get total transactions' number of a given address")
+      .description("Get total transactions of a given address")
 
   val getAddressBalance: BaseEndpoint[Address, AddressBalance] =
     addressesEndpoint.get
       .in(path[Address]("address")(Codecs.addressTapirCodec))
       .in("balance")
       .out(jsonBody[AddressBalance])
-      .description("Get address' balance")
+      .description("Get address balance")
 }

--- a/app/src/main/scala/org/alephium/explorer/api/model/AddressBalance.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/AddressBalance.scala
@@ -1,0 +1,27 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.api.model
+
+import org.alephium.explorer.api.Json.u256ReadWriter
+import org.alephium.json.Json._
+import org.alephium.util.U256
+
+final case class AddressBalance(balance: U256, lockedBalance: U256)
+
+object AddressBalance {
+  implicit val readWriter: ReadWriter[AddressBalance] = macroRW
+}

--- a/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
@@ -22,7 +22,7 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 
 import org.alephium.explorer.api.AddressesEndpoints
-import org.alephium.explorer.api.model.AddressInfo
+import org.alephium.explorer.api.model.{AddressBalance, AddressInfo}
 import org.alephium.explorer.service.TransactionService
 import org.alephium.util.Duration
 
@@ -44,5 +44,14 @@ class AddressServer(transactionService: TransactionService, val blockflowFetchMa
             (balance, locked) <- transactionService.getBalance(address)
             txNumber          <- transactionService.getTransactionsNumberByAddress(address)
           } yield Right(AddressInfo(balance, locked, txNumber))
+      } ~
+      toRoute(getTotalTransactionsByAddress) { address =>
+        transactionService.getTransactionsNumberByAddress(address).map(Right(_))
+      } ~
+      toRoute(getAddressBalance) { address =>
+        for {
+          (balance, locked) <- transactionService.getBalance(address)
+        } yield (Right(AddressBalance(balance, locked)))
       }
+
 }


### PR DESCRIPTION
The idea is for the front-end to call those two endpoints rather than
the one to get all info at once.

With this we could show the address details faster and also the
transactions pagination.