### PR TITLE
Updated `trait`s to be plain `object`s

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/persistence/dao/BlockDao.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/dao/BlockDao.scala
@@ -37,6 +37,7 @@ import org.alephium.explorer.persistence.model._
 import org.alephium.explorer.persistence.queries._
 import org.alephium.explorer.persistence.queries.InputQueries._
 import org.alephium.explorer.persistence.schema._
+import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.protocol.config.GroupConfig
 import org.alephium.protocol.model.ChainIndex
 import org.alephium.util.{Duration, TimeStamp}
@@ -75,7 +76,6 @@ object BlockDao {
   class Impl(groupNum: Int, val databaseConfig: DatabaseConfig[PostgresProfile])(
       implicit val executionContext: ExecutionContext)
       extends BlockDao
-      with CustomTypes
       with BlockQueries
       with TransactionQueries
       with DBRunner

--- a/app/src/main/scala/org/alephium/explorer/persistence/dao/UnconfirmedTxDao.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/dao/UnconfirmedTxDao.scala
@@ -27,6 +27,7 @@ import org.alephium.explorer.api.model._
 import org.alephium.explorer.persistence.{DBActionW, DBRunner}
 import org.alephium.explorer.persistence.model._
 import org.alephium.explorer.persistence.schema._
+import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 
 trait UnconfirmedTxDao {
   def get(hash: Transaction.Hash): Future[Option[UnconfirmedTransaction]]
@@ -45,7 +46,6 @@ object UnconfirmedTxDao {
   private class Impl(val databaseConfig: DatabaseConfig[PostgresProfile])(
       implicit val executionContext: ExecutionContext)
       extends UnconfirmedTxDao
-      with CustomTypes
       with DBRunner {
 
     def get(hash: Transaction.Hash): Future[Option[UnconfirmedTransaction]] = {

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
@@ -31,10 +31,11 @@ import org.alephium.explorer.persistence.queries.InputQueries.insertInputs
 import org.alephium.explorer.persistence.queries.OutputQueries.insertOutputs
 import org.alephium.explorer.persistence.schema._
 import org.alephium.explorer.persistence.schema.CustomGetResult._
+import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.util.TimeStamp
 
-trait BlockQueries extends TransactionQueries with CustomTypes with StrictLogging {
+trait BlockQueries extends TransactionQueries with StrictLogging {
 
   val block_headers = BlockHeaderSchema.table.baseTableRow.tableName //block_headers table name
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
@@ -30,6 +30,7 @@ import org.alephium.explorer.persistence.queries.BlockDepQueries.insertBlockDeps
 import org.alephium.explorer.persistence.queries.InputQueries.insertInputs
 import org.alephium.explorer.persistence.queries.OutputQueries.insertOutputs
 import org.alephium.explorer.persistence.schema._
+import org.alephium.explorer.persistence.schema.CustomGetResult._
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.util.TimeStamp
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/HashrateQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/HashrateQueries.scala
@@ -22,12 +22,11 @@ import slick.jdbc.PostgresProfile.api._
 
 import org.alephium.explorer.api.model.IntervalType
 import org.alephium.explorer.persistence._
-import org.alephium.explorer.persistence.schema._
 import org.alephium.explorer.persistence.schema.CustomGetResult._
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.util.TimeStamp
 
-trait HashrateQueries extends CustomTypes {
+trait HashrateQueries {
 
   def getHashratesQuery(from: TimeStamp,
                         to: TimeStamp,

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/HashrateQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/HashrateQueries.scala
@@ -23,6 +23,7 @@ import slick.jdbc.PostgresProfile.api._
 import org.alephium.explorer.api.model.IntervalType
 import org.alephium.explorer.persistence._
 import org.alephium.explorer.persistence.schema._
+import org.alephium.explorer.persistence.schema.CustomGetResult._
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.util.TimeStamp
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/InputQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/InputQueries.scala
@@ -28,10 +28,11 @@ import org.alephium.explorer.persistence._
 import org.alephium.explorer.persistence.model._
 import org.alephium.explorer.persistence.schema._
 import org.alephium.explorer.persistence.schema.CustomGetResult._
+import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.util.U256
 
-object InputQueries extends CustomTypes {
+object InputQueries {
 
   private val mainInputs  = InputSchema.table.filter(_.mainChain)
   private val mainOutputs = OutputSchema.table.filter(_.mainChain)

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/InputQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/InputQueries.scala
@@ -27,6 +27,7 @@ import org.alephium.explorer.api.model._
 import org.alephium.explorer.persistence._
 import org.alephium.explorer.persistence.model._
 import org.alephium.explorer.persistence.schema._
+import org.alephium.explorer.persistence.schema.CustomGetResult._
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.util.U256
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/OutputQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/OutputQueries.scala
@@ -25,6 +25,7 @@ import org.alephium.explorer.api.model._
 import org.alephium.explorer.persistence._
 import org.alephium.explorer.persistence.model._
 import org.alephium.explorer.persistence.schema._
+import org.alephium.explorer.persistence.schema.CustomGetResult._
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.util.{TimeStamp, U256}
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/OutputQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/OutputQueries.scala
@@ -26,10 +26,11 @@ import org.alephium.explorer.persistence._
 import org.alephium.explorer.persistence.model._
 import org.alephium.explorer.persistence.schema._
 import org.alephium.explorer.persistence.schema.CustomGetResult._
+import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.util.{TimeStamp, U256}
 
-object OutputQueries extends CustomTypes {
+object OutputQueries {
   private val mainInputs  = InputSchema.table.filter(_.mainChain)
   private val mainOutputs = OutputSchema.table.filter(_.mainChain)
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
@@ -31,10 +31,11 @@ import org.alephium.explorer.persistence.queries.InputQueries._
 import org.alephium.explorer.persistence.queries.OutputQueries._
 import org.alephium.explorer.persistence.schema._
 import org.alephium.explorer.persistence.schema.CustomGetResult._
+import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.util.{TimeStamp, U256}
 
-trait TransactionQueries extends CustomTypes with StrictLogging {
+trait TransactionQueries extends StrictLogging {
 
   implicit def executionContext: ExecutionContext
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
@@ -30,6 +30,7 @@ import org.alephium.explorer.persistence.model._
 import org.alephium.explorer.persistence.queries.InputQueries._
 import org.alephium.explorer.persistence.queries.OutputQueries._
 import org.alephium.explorer.persistence.schema._
+import org.alephium.explorer.persistence.schema.CustomGetResult._
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.util.{TimeStamp, U256}
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/BlockDepsSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/BlockDepsSchema.scala
@@ -21,6 +21,7 @@ import slick.lifted.{Index, PrimaryKey, ProvenShape}
 
 import org.alephium.explorer.api.model.BlockEntry
 import org.alephium.explorer.persistence.model.BlockDepEntity
+import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 
 object BlockDepsSchema extends Schema[BlockDepEntity]("block_deps") {
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/BlockHeaderSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/BlockHeaderSchema.scala
@@ -26,6 +26,7 @@ import slick.sql.SqlAction
 import org.alephium.explorer.Hash
 import org.alephium.explorer.api.model.{BlockEntry, GroupIndex, Height}
 import org.alephium.explorer.persistence.model.BlockHeader
+import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.util.TimeStamp
 
 object BlockHeaderSchema extends SchemaMainChain[BlockHeader]("block_headers") {

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomGetResult.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomGetResult.scala
@@ -31,56 +31,56 @@ object CustomGetResult {
   /**
     * GetResult types
     */
-  implicit lazy val blockEntryHashGetResult: GetResult[BlockEntry.Hash] =
+  implicit val blockEntryHashGetResult: GetResult[BlockEntry.Hash] =
     (result: PositionedResult) =>
       new BlockEntry.Hash(new BlockHash(ByteString.fromArrayUnsafe(result.nextBytes())))
 
-  implicit lazy val txHashGetResult: GetResult[Transaction.Hash] =
+  implicit val txHashGetResult: GetResult[Transaction.Hash] =
     (result: PositionedResult) =>
       new Transaction.Hash(new Hash(ByteString.fromArrayUnsafe(result.nextBytes())))
 
-  implicit lazy val optionTxHashGetResult: GetResult[Option[Transaction.Hash]] =
+  implicit val optionTxHashGetResult: GetResult[Option[Transaction.Hash]] =
     (result: PositionedResult) =>
       result
         .nextBytesOption()
         .map(bytes => new Transaction.Hash(new Hash(ByteString.fromArrayUnsafe(bytes))))
 
-  implicit lazy val optionBlockEntryHashGetResult: GetResult[Option[BlockEntry.Hash]] =
+  implicit val optionBlockEntryHashGetResult: GetResult[Option[BlockEntry.Hash]] =
     (result: PositionedResult) =>
       result
         .nextBytesOption()
         .map(bytes => new BlockEntry.Hash(new BlockHash(ByteString.fromArrayUnsafe(bytes))))
 
-  implicit lazy val timestampGetResult: GetResult[TimeStamp] =
+  implicit val timestampGetResult: GetResult[TimeStamp] =
     (result: PositionedResult) => TimeStamp.unsafe(result.nextLong())
 
-  implicit lazy val optionTimestampGetResult: GetResult[Option[TimeStamp]] =
+  implicit val optionTimestampGetResult: GetResult[Option[TimeStamp]] =
     (result: PositionedResult) => result.nextLongOption().map(TimeStamp.unsafe)
 
-  implicit lazy val groupIndexGetResult: GetResult[GroupIndex] =
+  implicit val groupIndexGetResult: GetResult[GroupIndex] =
     (result: PositionedResult) => GroupIndex.unsafe(result.nextInt())
 
-  implicit lazy val heightGetResult: GetResult[Height] =
+  implicit val heightGetResult: GetResult[Height] =
     (result: PositionedResult) => Height.unsafe(result.nextInt())
 
-  implicit lazy val bigIntegerGetResult: GetResult[BigInteger] =
+  implicit val bigIntegerGetResult: GetResult[BigInteger] =
     (result: PositionedResult) => result.nextBigDecimal().toBigInt.bigInteger
 
-  implicit lazy val bytestringGetResult: GetResult[ByteString] =
+  implicit val byteStringGetResult: GetResult[ByteString] =
     (result: PositionedResult) => ByteString.fromArrayUnsafe(result.nextBytes())
 
-  implicit lazy val hashGetResult: GetResult[Hash] =
+  implicit val hashGetResult: GetResult[Hash] =
     (result: PositionedResult) => Hash.unsafe(ByteString.fromArrayUnsafe(result.nextBytes()))
 
-  implicit lazy val addressGetResult: GetResult[Address] =
+  implicit val addressGetResult: GetResult[Address] =
     (result: PositionedResult) => Address.unsafe(result.nextString())
 
-  implicit lazy val u256GetResult: GetResult[U256] =
+  implicit val u256GetResult: GetResult[U256] =
     (result: PositionedResult) => {
       U256.unsafe(result.nextBigDecimal().toBigInt.bigInteger)
     }
 
-  implicit lazy val optionU256GetResult: GetResult[Option[U256]] =
+  implicit val optionU256GetResult: GetResult[Option[U256]] =
     (result: PositionedResult) => {
       result.nextBigDecimalOption().map(bigDecimal => U256.unsafe(bigDecimal.toBigInt.bigInteger))
     }

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomGetResult.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomGetResult.scala
@@ -1,0 +1,126 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.persistence.schema
+
+import java.math.BigInteger
+
+import akka.util.ByteString
+import slick.jdbc.{GetResult, PositionedResult}
+
+import org.alephium.explorer.{BlockHash, Hash}
+import org.alephium.explorer.api.model._
+import org.alephium.explorer.persistence.model.BlockHeader
+import org.alephium.util.{TimeStamp, U256}
+
+object CustomGetResult {
+
+  /**
+    * GetResult types
+    */
+  implicit lazy val blockEntryHashGetResult: GetResult[BlockEntry.Hash] =
+    (result: PositionedResult) =>
+      new BlockEntry.Hash(new BlockHash(ByteString.fromArrayUnsafe(result.nextBytes())))
+
+  implicit lazy val txHashGetResult: GetResult[Transaction.Hash] =
+    (result: PositionedResult) =>
+      new Transaction.Hash(new Hash(ByteString.fromArrayUnsafe(result.nextBytes())))
+
+  implicit lazy val optionTxHashGetResult: GetResult[Option[Transaction.Hash]] =
+    (result: PositionedResult) =>
+      result
+        .nextBytesOption()
+        .map(bytes => new Transaction.Hash(new Hash(ByteString.fromArrayUnsafe(bytes))))
+
+  implicit lazy val optionBlockEntryHashGetResult: GetResult[Option[BlockEntry.Hash]] =
+    (result: PositionedResult) =>
+      result
+        .nextBytesOption()
+        .map(bytes => new BlockEntry.Hash(new BlockHash(ByteString.fromArrayUnsafe(bytes))))
+
+  implicit lazy val timestampGetResult: GetResult[TimeStamp] =
+    (result: PositionedResult) => TimeStamp.unsafe(result.nextLong())
+
+  implicit lazy val optionTimestampGetResult: GetResult[Option[TimeStamp]] =
+    (result: PositionedResult) => result.nextLongOption().map(TimeStamp.unsafe)
+
+  implicit lazy val groupIndexGetResult: GetResult[GroupIndex] =
+    (result: PositionedResult) => GroupIndex.unsafe(result.nextInt())
+
+  implicit lazy val heightGetResult: GetResult[Height] =
+    (result: PositionedResult) => Height.unsafe(result.nextInt())
+
+  implicit lazy val bigIntegerGetResult: GetResult[BigInteger] =
+    (result: PositionedResult) => result.nextBigDecimal().toBigInt.bigInteger
+
+  implicit lazy val bytestringGetResult: GetResult[ByteString] =
+    (result: PositionedResult) => ByteString.fromArrayUnsafe(result.nextBytes())
+
+  implicit lazy val hashGetResult: GetResult[Hash] =
+    (result: PositionedResult) => Hash.unsafe(ByteString.fromArrayUnsafe(result.nextBytes()))
+
+  implicit lazy val addressGetResult: GetResult[Address] =
+    (result: PositionedResult) => Address.unsafe(result.nextString())
+
+  implicit lazy val u256GetResult: GetResult[U256] =
+    (result: PositionedResult) => {
+      U256.unsafe(result.nextBigDecimal().toBigInt.bigInteger)
+    }
+
+  implicit lazy val optionU256GetResult: GetResult[Option[U256]] =
+    (result: PositionedResult) => {
+      result.nextBigDecimalOption().map(bigDecimal => U256.unsafe(bigDecimal.toBigInt.bigInteger))
+    }
+
+  /**
+    * GetResult type for BlockEntryLite
+    *
+    * @note The order in which the query returns the column values matters.
+    *       For example: Getting (`.<<`) `chainTo` before `chainFrom` when
+    *       `chainFrom` is before `chainTo` in the query result would compile
+    *       but would result in incorrect data.
+    */
+  val blockEntryListGetResult: GetResult[BlockEntryLite] =
+    (result: PositionedResult) =>
+      BlockEntryLite(hash      = result.<<,
+                     timestamp = result.<<,
+                     chainFrom = result.<<,
+                     chainTo   = result.<<,
+                     height    = result.<<,
+                     mainChain = result.<<,
+                     hashRate  = result.<<,
+                     txNumber  = result.<<)
+
+  val blockHeaderGetResult: GetResult[BlockHeader] =
+    (result: PositionedResult) =>
+      BlockHeader(
+        hash         = result.<<,
+        timestamp    = result.<<,
+        chainFrom    = result.<<,
+        chainTo      = result.<<,
+        height       = result.<<,
+        mainChain    = result.<<,
+        nonce        = result.<<,
+        version      = result.<<,
+        depStateHash = result.<<,
+        txsHash      = result.<<,
+        txsCount     = result.<<,
+        target       = result.<<,
+        hashrate     = result.<<,
+        parent       = result.<<?
+    )
+
+}

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomJdbcTypes.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomJdbcTypes.scala
@@ -22,13 +22,14 @@ import scala.reflect.ClassTag
 
 import akka.util.ByteString
 import slick.jdbc._
+import slick.jdbc.PostgresProfile._
 import slick.jdbc.PostgresProfile.api._
 
 import org.alephium.explorer._
 import org.alephium.explorer.api.model._
 import org.alephium.util.{TimeStamp, U256}
 
-trait CustomTypes extends PostgresProfile {
+object CustomJdbcTypes {
 
   private def buildHashTypes[H: ClassTag](from: Hash => H, to: H => Hash): JdbcType[H] =
     MappedJdbcType.base[H, Array[Byte]](

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomTypes.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomTypes.scala
@@ -26,7 +26,6 @@ import slick.jdbc.PostgresProfile.api._
 
 import org.alephium.explorer._
 import org.alephium.explorer.api.model._
-import org.alephium.explorer.persistence.model.BlockHeader
 import org.alephium.util.{TimeStamp, U256}
 
 trait CustomTypes extends PostgresProfile {
@@ -101,98 +100,4 @@ trait CustomTypes extends PostgresProfile {
       IntervalType.unsafe
     )
 
-  /**
-    * GetResult types
-    */
-  implicit lazy val blockEntryHashGetResult: GetResult[BlockEntry.Hash] =
-    (result: PositionedResult) =>
-      new BlockEntry.Hash(new BlockHash(ByteString.fromArrayUnsafe(result.nextBytes())))
-
-  implicit lazy val txHashGetResult: GetResult[Transaction.Hash] =
-    (result: PositionedResult) =>
-      new Transaction.Hash(new Hash(ByteString.fromArrayUnsafe(result.nextBytes())))
-
-  implicit lazy val optionTxHashGetResult: GetResult[Option[Transaction.Hash]] =
-    (result: PositionedResult) =>
-      result
-        .nextBytesOption()
-        .map(bytes => new Transaction.Hash(new Hash(ByteString.fromArrayUnsafe(bytes))))
-
-  implicit lazy val optionBlockEntryHashGetResult: GetResult[Option[BlockEntry.Hash]] =
-    (result: PositionedResult) =>
-      result
-        .nextBytesOption()
-        .map(bytes => new BlockEntry.Hash(new BlockHash(ByteString.fromArrayUnsafe(bytes))))
-
-  implicit lazy val timestampGetResult: GetResult[TimeStamp] =
-    (result: PositionedResult) => TimeStamp.unsafe(result.nextLong())
-
-  implicit lazy val optionTimestampGetResult: GetResult[Option[TimeStamp]] =
-    (result: PositionedResult) => result.nextLongOption().map(TimeStamp.unsafe)
-
-  implicit lazy val groupIndexGetResult: GetResult[GroupIndex] =
-    (result: PositionedResult) => GroupIndex.unsafe(result.nextInt())
-
-  implicit lazy val heightGetResult: GetResult[Height] =
-    (result: PositionedResult) => Height.unsafe(result.nextInt())
-
-  implicit lazy val bigIntegerGetResult: GetResult[BigInteger] =
-    (result: PositionedResult) => result.nextBigDecimal().toBigInt.bigInteger
-
-  implicit lazy val bytestringGetResult: GetResult[ByteString] =
-    (result: PositionedResult) => ByteString.fromArrayUnsafe(result.nextBytes())
-
-  implicit lazy val hashGetResult: GetResult[Hash] =
-    (result: PositionedResult) => Hash.unsafe(ByteString.fromArrayUnsafe(result.nextBytes()))
-
-  implicit lazy val addressGetResult: GetResult[Address] =
-    (result: PositionedResult) => Address.unsafe(result.nextString())
-
-  implicit lazy val u256GetResult: GetResult[U256] =
-    (result: PositionedResult) => {
-      U256.unsafe(result.nextBigDecimal().toBigInt.bigInteger)
-    }
-
-  implicit lazy val optionU256GetResult: GetResult[Option[U256]] =
-    (result: PositionedResult) => {
-      result.nextBigDecimalOption().map(bigDecimal => U256.unsafe(bigDecimal.toBigInt.bigInteger))
-    }
-
-  /**
-    * GetResult type for BlockEntryLite
-    *
-    * @note The order in which the query returns the column values matters.
-    *       For example: Getting (`.<<`) `chainTo` before `chainFrom` when
-    *       `chainFrom` is before `chainTo` in the query result would compile
-    *       but would result in incorrect data.
-    */
-  val blockEntryListGetResult: GetResult[BlockEntryLite] =
-    (result: PositionedResult) =>
-      BlockEntryLite(hash      = result.<<,
-                     timestamp = result.<<,
-                     chainFrom = result.<<,
-                     chainTo   = result.<<,
-                     height    = result.<<,
-                     mainChain = result.<<,
-                     hashRate  = result.<<,
-                     txNumber  = result.<<)
-
-  val blockHeaderGetResult: GetResult[BlockHeader] =
-    (result: PositionedResult) =>
-      BlockHeader(
-        hash         = result.<<,
-        timestamp    = result.<<,
-        chainFrom    = result.<<,
-        chainTo      = result.<<,
-        height       = result.<<,
-        mainChain    = result.<<,
-        nonce        = result.<<,
-        version      = result.<<,
-        depStateHash = result.<<,
-        txsHash      = result.<<,
-        txsCount     = result.<<,
-        target       = result.<<,
-        hashrate     = result.<<,
-        parent       = result.<<?
-    )
 }

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/HashrateSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/HashrateSchema.scala
@@ -21,6 +21,7 @@ import slick.lifted.{Index, PrimaryKey, ProvenShape}
 
 import org.alephium.explorer.api.model.IntervalType
 import org.alephium.explorer.persistence.model.HashrateEntity
+import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.util.TimeStamp
 
 object HashrateSchema extends Schema[HashrateEntity]("hashrates") {

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/InputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/InputSchema.scala
@@ -22,6 +22,7 @@ import slick.lifted.{Index, PrimaryKey, ProvenShape}
 import org.alephium.explorer.Hash
 import org.alephium.explorer.api.model.{BlockEntry, Transaction}
 import org.alephium.explorer.persistence.model.InputEntity
+import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.util.TimeStamp
 
 object InputSchema extends SchemaMainChain[InputEntity]("inputs") {

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/LatestBlockSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/LatestBlockSchema.scala
@@ -24,6 +24,7 @@ import slick.lifted.{PrimaryKey, ProvenShape}
 
 import org.alephium.explorer.api.model.{BlockEntry, GroupIndex, Height}
 import org.alephium.explorer.persistence.model.LatestBlock
+import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.util.TimeStamp
 
 object LatestBlockSchema extends Schema[LatestBlock]("latest_blocks") {

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/OutputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/OutputSchema.scala
@@ -22,6 +22,7 @@ import slick.lifted.{Index, PrimaryKey, ProvenShape}
 import org.alephium.explorer.Hash
 import org.alephium.explorer.api.model.{Address, BlockEntry, Transaction}
 import org.alephium.explorer.persistence.model.OutputEntity
+import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.util.{TimeStamp, U256}
 
 object OutputSchema extends SchemaMainChain[OutputEntity]("outputs") {

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/Schema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/Schema.scala
@@ -19,6 +19,6 @@ package org.alephium.explorer.persistence.schema
 import slick.jdbc.PostgresProfile.api._
 import slick.lifted.AbstractTable
 
-abstract class Schema[A](val name: String) extends CustomTypes {
+abstract class Schema[A](val name: String) {
   val table: TableQuery[_ <: AbstractTable[A]]
 }

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenSupplySchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenSupplySchema.scala
@@ -20,6 +20,7 @@ import slick.jdbc.PostgresProfile.api._
 import slick.lifted.ProvenShape
 
 import org.alephium.explorer.persistence.model.TokenSupplyEntity
+import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.util.{TimeStamp, U256}
 
 object TokenSupplySchema extends Schema[TokenSupplyEntity]("token_supply") {

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionPerAddressSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionPerAddressSchema.scala
@@ -21,6 +21,7 @@ import slick.lifted.{Index, PrimaryKey, ProvenShape}
 
 import org.alephium.explorer.api.model.{Address, BlockEntry, Transaction}
 import org.alephium.explorer.persistence.model.TransactionPerAddressEntity
+import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.util.TimeStamp
 
 object TransactionPerAddressSchema

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionSchema.scala
@@ -21,6 +21,7 @@ import slick.lifted.{Index, PrimaryKey, ProvenShape}
 
 import org.alephium.explorer.api.model.{BlockEntry, GroupIndex, Transaction}
 import org.alephium.explorer.persistence.model.TransactionEntity
+import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.util.{TimeStamp, U256}
 
 object TransactionSchema extends SchemaMainChain[TransactionEntity]("transactions") {

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/UInputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/UInputSchema.scala
@@ -22,6 +22,7 @@ import slick.lifted.{Index, PrimaryKey, ProvenShape}
 import org.alephium.explorer.Hash
 import org.alephium.explorer.api.model.Transaction
 import org.alephium.explorer.persistence.model.UInputEntity
+import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 
 object UInputSchema extends Schema[UInputEntity]("uinputs") {
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/UOutputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/UOutputSchema.scala
@@ -21,6 +21,7 @@ import slick.lifted.{Index, PrimaryKey, ProvenShape}
 
 import org.alephium.explorer.api.model.{Address, Transaction}
 import org.alephium.explorer.persistence.model.UOutputEntity
+import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.util.{TimeStamp, U256}
 
 object UOutputSchema extends Schema[UOutputEntity]("uoutputs") {

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/UTransactionSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/UTransactionSchema.scala
@@ -21,6 +21,7 @@ import slick.lifted.ProvenShape
 
 import org.alephium.explorer.api.model.{GroupIndex, Transaction}
 import org.alephium.explorer.persistence.model.UnconfirmedTxEntity
+import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.util.U256
 
 object UnconfirmedTxSchema extends Schema[UnconfirmedTxEntity]("utransactions") {

--- a/app/src/main/scala/org/alephium/explorer/service/HashrateService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/HashrateService.scala
@@ -31,6 +31,7 @@ import org.alephium.explorer.persistence._
 import org.alephium.explorer.persistence.model.HashrateEntity
 import org.alephium.explorer.persistence.queries.HashrateQueries
 import org.alephium.explorer.persistence.schema._
+import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.protocol.ALPH
 import org.alephium.util.{Duration, TimeStamp}
 

--- a/app/src/main/scala/org/alephium/explorer/service/SanityChecker.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/SanityChecker.scala
@@ -30,6 +30,7 @@ import org.alephium.explorer.persistence._
 import org.alephium.explorer.persistence.dao.BlockDao
 import org.alephium.explorer.persistence.queries.BlockQueries
 import org.alephium.explorer.persistence.schema.BlockHeaderSchema
+import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 
 @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.TraversableOps"))
 class SanityChecker(groupNum: Int,

--- a/app/src/main/scala/org/alephium/explorer/service/TokenSupplyService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/TokenSupplyService.scala
@@ -33,6 +33,7 @@ import org.alephium.explorer.persistence._
 import org.alephium.explorer.persistence.model.TokenSupplyEntity
 import org.alephium.explorer.persistence.queries.TransactionQueries
 import org.alephium.explorer.persistence.schema._
+import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.protocol.ALPH
 import org.alephium.util.{Duration, TimeStamp, U256}
 

--- a/app/src/test/scala/org/alephium/explorer/persistence/dao/BlockDaoSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/dao/BlockDaoSpec.scala
@@ -32,6 +32,7 @@ import org.alephium.explorer.api.model.{BlockEntry, BlockEntryLite, GroupIndex, 
 import org.alephium.explorer.persistence.{DatabaseFixture, DBRunner}
 import org.alephium.explorer.persistence.model._
 import org.alephium.explorer.persistence.schema._
+import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.explorer.service.BlockFlowClient
 import org.alephium.explorer.util.TestUtils._
 import org.alephium.json.Json._
@@ -269,7 +270,7 @@ class BlockDaoSpec extends AlephiumSpec with ScalaFutures with Generators with E
     }
   }
 
-  trait Fixture extends DatabaseFixture with DBRunner with CustomTypes with ApiModelCodec {
+  trait Fixture extends DatabaseFixture with DBRunner with ApiModelCodec {
     val blockflowFetchMaxAge: Duration = Duration.ofMinutesUnsafe(30)
 
     val blockDao = new BlockDao.Impl(groupNum, databaseConfig)

--- a/app/src/test/scala/org/alephium/explorer/persistence/dao/UnconfirmedTxDaoSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/dao/UnconfirmedTxDaoSpec.scala
@@ -29,6 +29,7 @@ import org.alephium.explorer.api.model.Transaction
 import org.alephium.explorer.persistence.DatabaseFixture
 import org.alephium.explorer.persistence.DBRunner
 import org.alephium.explorer.persistence.schema._
+import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 
 class UnconfirmedTxDaoSpec extends AlephiumSpec with ScalaFutures with Generators with Eventually {
   implicit val executionContext: ExecutionContext = ExecutionContext.global
@@ -88,7 +89,7 @@ class UnconfirmedTxDaoSpec extends AlephiumSpec with ScalaFutures with Generator
     }
   }
 
-  trait Fixture extends DatabaseFixture with CustomTypes with DBRunner {
+  trait Fixture extends DatabaseFixture with DBRunner {
     val utxDao = UnconfirmedTxDao(databaseConfig)
   }
 }

--- a/app/src/test/scala/org/alephium/explorer/persistence/schema/CustomJdbcTypesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/schema/CustomJdbcTypesSpec.scala
@@ -26,11 +26,12 @@ import slick.lifted.ProvenShape
 import org.alephium.explorer.AlephiumSpec
 import org.alephium.explorer.persistence.{DatabaseFixture, DBRunner}
 import org.alephium.explorer.persistence.schema.CustomGetResult._
+import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.protocol.ALPH
 import org.alephium.util._
 
-class CustomTypesSpec extends AlephiumSpec with ScalaFutures with Eventually {
+class CustomJdbcTypesSpec extends AlephiumSpec with ScalaFutures with Eventually {
   implicit val executionContext: ExecutionContext = ExecutionContext.global
   override implicit val patienceConfig            = PatienceConfig(timeout = Span(1, Minutes))
 
@@ -69,7 +70,7 @@ class CustomTypesSpec extends AlephiumSpec with ScalaFutures with Eventually {
     run(timestampTable.filter(_.timestamp <= t1).result).futureValue is Seq(t1, t2)
   }
 
-  trait Fixture extends CustomTypes with DatabaseFixture with DBRunner {
+  trait Fixture extends DatabaseFixture with DBRunner {
 
     def ts(str: String): TimeStamp = TimeStamp.unsafe(java.time.Instant.parse(str).toEpochMilli)
 

--- a/app/src/test/scala/org/alephium/explorer/persistence/schema/CustomTypesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/schema/CustomTypesSpec.scala
@@ -25,6 +25,7 @@ import slick.lifted.ProvenShape
 
 import org.alephium.explorer.AlephiumSpec
 import org.alephium.explorer.persistence.{DatabaseFixture, DBRunner}
+import org.alephium.explorer.persistence.schema.CustomGetResult._
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.protocol.ALPH
 import org.alephium.util._


### PR DESCRIPTION
- Adds to PR #163
- Moved Slick's `GetResult` types from `trait CustomTypes` to `object CustomGetResult`
- Updated & renamed `trait CustomTypes` to `object CustomJdbcTypes`
