### PR TITLE
Updated `DBInitializer` to be stateless

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/Application.scala
+++ b/app/src/main/scala/org/alephium/explorer/Application.scala
@@ -34,20 +34,18 @@ import org.alephium.protocol.model.NetworkId
 import org.alephium.util.Duration
 
 // scalastyle:off magic.number
-class Application(
-    host: String,
-    port: Int,
-    readOnly: Boolean,
-    blockFlowUri: Uri,
-    groupNum: Int,
-    blockflowFetchMaxAge: Duration,
-    networkId: NetworkId,
-    databaseConfig: DatabaseConfig[PostgresProfile],
-    maybeBlockFlowApiKey: Option[ApiKey],
-    syncPeriod: Duration)(implicit system: ActorSystem, executionContext: ExecutionContext)
+class Application(host: String,
+                  port: Int,
+                  readOnly: Boolean,
+                  blockFlowUri: Uri,
+                  groupNum: Int,
+                  blockflowFetchMaxAge: Duration,
+                  networkId: NetworkId,
+                  maybeBlockFlowApiKey: Option[ApiKey],
+                  syncPeriod: Duration)(implicit system: ActorSystem,
+                                        executionContext: ExecutionContext,
+                                        databaseConfig: DatabaseConfig[PostgresProfile])
     extends StrictLogging {
-
-  val dbInitializer: DBInitializer = DBInitializer(databaseConfig)
 
   val blockDao: BlockDao                = BlockDao(groupNum, databaseConfig)
   val transactionDao: TransactionDao    = TransactionDao(databaseConfig)
@@ -113,7 +111,7 @@ class Application(
   private def startTasksForReadWriteApp(): Future[Unit] = {
     if (!readOnly) {
       for {
-        _ <- dbInitializer.initialize()
+        _ <- DBInitializer.initialize()
         _ <- startSyncService()
       } yield ()
 

--- a/app/src/main/scala/org/alephium/explorer/Main.scala
+++ b/app/src/main/scala/org/alephium/explorer/Main.scala
@@ -69,7 +69,7 @@ object Main extends App with StrictLogging {
   val readOnly: Boolean    = config.getBoolean("explorer.readOnly")
   val syncPeriod: Duration = Duration.from(config.getDuration("explorer.syncPeriod")).get
 
-  val databaseConfig: DatabaseConfig[PostgresProfile] =
+  implicit val databaseConfig: DatabaseConfig[PostgresProfile] =
     DatabaseConfig.forConfig[PostgresProfile]("db")
 
   val app: Application =
@@ -80,7 +80,6 @@ object Main extends App with StrictLogging {
                     groupNum,
                     blockflowFetchMaxAge,
                     networkId,
-                    databaseConfig,
                     blockflowApiKey,
                     syncPeriod)
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/DBRunner.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/DBRunner.scala
@@ -41,4 +41,13 @@ object DBRunner {
       case error => throw new RuntimeException(error)
     }
 
+  /** Temporary function until all things are made stateless */
+  @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
+  def run[R, E <: Effect](action: DBAction[R, E])(
+      implicit executionContext: ExecutionContext,
+      databaseConfig: DatabaseConfig[PostgresProfile]): Future[R] =
+    databaseConfig.db.run(action).recoverWith {
+      case error => Future.failed(new RuntimeException(error))
+    }
+
 }

--- a/app/src/test/scala/org/alephium/explorer/ApplicationSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/ApplicationSpec.scala
@@ -103,7 +103,6 @@ trait ApplicationSpec
     groupNum,
     blockflowFetchMaxAge,
     networkId,
-    databaseConfig,
     None,
     Duration.ofSecondsUnsafe(5)
   )

--- a/app/src/test/scala/org/alephium/explorer/persistence/DatabaseFixture.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/DatabaseFixture.scala
@@ -16,7 +16,7 @@
 
 package org.alephium.explorer.persistence
 
-import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutor}
+import scala.concurrent.{Await, ExecutionContext}
 import scala.jdk.CollectionConverters._
 
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
@@ -41,7 +41,7 @@ object DatabaseFixture {
     DatabaseConfig.forConfig[PostgresProfile]("db", config)
 
   def dropCreateTables()(implicit databaseConfig: DatabaseConfig[PostgresProfile]) = {
-    implicit val ec: ExecutionContextExecutor = ExecutionContext.global
+    implicit val ec: ExecutionContext = ExecutionContext.global
 
     Await.result(DBInitializer.dropTables(), Duration.ofSecondsUnsafe(10).asScala)
     Await.result(DBInitializer.initialize(), Duration.ofSecondsUnsafe(10).asScala)

--- a/app/src/test/scala/org/alephium/explorer/persistence/DatabaseFixture.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/DatabaseFixture.scala
@@ -16,7 +16,7 @@
 
 package org.alephium.explorer.persistence
 
-import scala.concurrent.{Await, ExecutionContext}
+import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutor}
 import scala.jdk.CollectionConverters._
 
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
@@ -40,10 +40,10 @@ object DatabaseFixture {
   def createDatabaseConfig(): DatabaseConfig[PostgresProfile] =
     DatabaseConfig.forConfig[PostgresProfile]("db", config)
 
-  def dropCreateTables(databaseConfig: DatabaseConfig[PostgresProfile]) = {
-    val dbInitializer: DBInitializer = new DBInitializer(databaseConfig)(ExecutionContext.global)
+  def dropCreateTables()(implicit databaseConfig: DatabaseConfig[PostgresProfile]) = {
+    implicit val ec: ExecutionContextExecutor = ExecutionContext.global
 
-    Await.result(dbInitializer.dropTables(), Duration.ofSecondsUnsafe(10).asScala)
-    Await.result(dbInitializer.initialize(), Duration.ofSecondsUnsafe(10).asScala)
+    Await.result(DBInitializer.dropTables(), Duration.ofSecondsUnsafe(10).asScala)
+    Await.result(DBInitializer.initialize(), Duration.ofSecondsUnsafe(10).asScala)
   }
 }

--- a/app/src/test/scala/org/alephium/explorer/persistence/DatabaseFixtureForAll.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/DatabaseFixtureForAll.scala
@@ -25,12 +25,12 @@ import slick.jdbc.PostgresProfile
   */
 trait DatabaseFixtureForAll extends BeforeAndAfterAll { this: Suite =>
 
-  val databaseConfig: DatabaseConfig[PostgresProfile] =
+  implicit val databaseConfig: DatabaseConfig[PostgresProfile] =
     DatabaseFixture.createDatabaseConfig()
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    DatabaseFixture.dropCreateTables(databaseConfig)
+    DatabaseFixture.dropCreateTables()
   }
 
   override def afterAll(): Unit = {

--- a/app/src/test/scala/org/alephium/explorer/persistence/DatabaseFixtureForEach.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/DatabaseFixtureForEach.scala
@@ -25,12 +25,12 @@ import slick.jdbc.PostgresProfile
   */
 trait DatabaseFixtureForEach extends BeforeAndAfterEach { this: Suite =>
 
-  var databaseConfig: DatabaseConfig[PostgresProfile] = _
+  implicit var databaseConfig: DatabaseConfig[PostgresProfile] = _
 
   override def beforeEach(): Unit = {
     super.beforeEach()
     databaseConfig = DatabaseFixture.createDatabaseConfig()
-    DatabaseFixture.dropCreateTables(databaseConfig)
+    DatabaseFixture.dropCreateTables()
   }
 
   override def afterEach(): Unit = {

--- a/benchmark/src/main/scala/org/alephium/explorer/benchmark/db/state/BlockEntityWriteState.scala
+++ b/benchmark/src/main/scala/org/alephium/explorer/benchmark/db/state/BlockEntityWriteState.scala
@@ -16,9 +16,11 @@
 
 package org.alephium.explorer.benchmark.db.state
 
-import scala.concurrent.{Await, ExecutionContext}
+import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutor}
 
 import org.openjdk.jmh.annotations.{Scope, State}
+import slick.basic.DatabaseConfig
+import slick.jdbc.PostgresProfile
 
 import org.alephium.explorer.benchmark.db.{DataGenerator, DBConnectionPool, DBExecutor}
 import org.alephium.explorer.benchmark.db.BenchmarkSettings._
@@ -41,9 +43,11 @@ class BlockEntityWriteState(val db: DBExecutor) extends WriteBenchmarkState[Bloc
     DataGenerator.genBlockEntity()
 
   def beforeAll(): Unit = {
-    val dbInitializer: DBInitializer = new DBInitializer(config)(ExecutionContext.global)
-    Await.result(dbInitializer.dropTables(), Duration.ofSecondsUnsafe(10).asScala)
-    Await.result(dbInitializer.initialize(), Duration.ofSecondsUnsafe(10).asScala)
+    implicit val ec: ExecutionContextExecutor        = ExecutionContext.global
+    implicit val dc: DatabaseConfig[PostgresProfile] = config
+
+    Await.result(DBInitializer.dropTables(), Duration.ofSecondsUnsafe(10).asScala)
+    Await.result(DBInitializer.initialize(), Duration.ofSecondsUnsafe(10).asScala)
   }
 }
 


### PR DESCRIPTION
- First PR for a series of other PRs working towards #201
- Updates `DBInitializer` to be stateless

The issue #201 can be implemented framework-less if majority of the code is made stateless. Previously statefulness was required because of H2 dependency, that got resolved by Thomas in #163. 

Being simple objects a plain function our services would be just a function (`syncOnce`) that's executed periodically by a `Scheduler` (implemented in one of the commits in the screenshot) making the code much simpler.

The following types are the only global parameters required by 90% of the code and there is no mutation.
- `ExecutionContext` 
- `DatabaseConfig[PostgresProfile]`
- `GroupConfig` (for some)

Mutation occurs only in caches which is encapsulated and managed in a dedicated class.

I've got the following commits that will be submitted in individual PRs so its easier to review. 

![image](https://user-images.githubusercontent.com/1773953/167573372-e434c449-6f55-4a09-9963-3b383239999f.png)
