### PR TITLE
Stateless `BlockQueries` & `TransactionQueries`

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/persistence/dao/BlockDao.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/dao/BlockDao.scala
@@ -31,8 +31,9 @@ import org.alephium.explorer.api.model._
 import org.alephium.explorer.cache.CaffeineAsyncCache
 import org.alephium.explorer.persistence._
 import org.alephium.explorer.persistence.model._
-import org.alephium.explorer.persistence.queries._
+import org.alephium.explorer.persistence.queries.BlockQueries._
 import org.alephium.explorer.persistence.queries.InputQueries._
+import org.alephium.explorer.persistence.queries.TransactionQueries._
 import org.alephium.explorer.persistence.schema._
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.protocol.config.GroupConfig
@@ -73,8 +74,6 @@ object BlockDao {
   class Impl(groupNum: Int, val databaseConfig: DatabaseConfig[PostgresProfile])(
       implicit val executionContext: ExecutionContext)
       extends BlockDao
-      with BlockQueries
-      with TransactionQueries
       with DBRunner
       with StrictLogging {
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/dao/TransactionDao.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/dao/TransactionDao.scala
@@ -26,7 +26,7 @@ import slick.jdbc.PostgresProfile.api._
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.cache.AsyncReloadingCache
 import org.alephium.explorer.persistence.DBRunner
-import org.alephium.explorer.persistence.queries.TransactionQueries
+import org.alephium.explorer.persistence.queries.TransactionQueries._
 import org.alephium.util.U256
 
 trait TransactionDao {
@@ -48,7 +48,6 @@ object TransactionDao {
   private class Impl(val databaseConfig: DatabaseConfig[PostgresProfile])(
       implicit val executionContext: ExecutionContext)
       extends TransactionDao
-      with TransactionQueries
       with DBRunner {
 
     val cacheTxnNumber =

--- a/app/src/main/scala/org/alephium/explorer/service/SanityChecker.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/SanityChecker.scala
@@ -28,7 +28,7 @@ import org.alephium.explorer.AnyOps
 import org.alephium.explorer.api.model.{BlockEntry, GroupIndex}
 import org.alephium.explorer.persistence._
 import org.alephium.explorer.persistence.dao.BlockDao
-import org.alephium.explorer.persistence.queries.BlockQueries
+import org.alephium.explorer.persistence.queries.BlockQueries._
 import org.alephium.explorer.persistence.schema.BlockHeaderSchema
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 
@@ -38,8 +38,7 @@ class SanityChecker(groupNum: Int,
                     blockDao: BlockDao,
                     val databaseConfig: DatabaseConfig[PostgresProfile])(
     implicit val executionContext: ExecutionContext)
-    extends BlockQueries
-    with DBRunner
+    extends DBRunner
     with StrictLogging {
 
   private def findLatestBlock(from: GroupIndex, to: GroupIndex): Future[Option[BlockEntry.Hash]] = {

--- a/app/src/main/scala/org/alephium/explorer/service/TokenSupplyService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/TokenSupplyService.scala
@@ -32,7 +32,6 @@ import org.alephium.explorer.api.model.{GroupIndex, Pagination, TokenSupply}
 import org.alephium.explorer.foldFutures
 import org.alephium.explorer.persistence._
 import org.alephium.explorer.persistence.model.TokenSupplyEntity
-import org.alephium.explorer.persistence.queries.TransactionQueries
 import org.alephium.explorer.persistence.schema._
 import org.alephium.explorer.persistence.schema.CustomGetResult._
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
@@ -75,7 +74,6 @@ object TokenSupplyService {
                      val databaseConfig: DatabaseConfig[PostgresProfile],
                      groupNum: Int)(implicit val executionContext: ExecutionContext)
       extends TokenSupplyService
-      with TransactionQueries
       with DBRunner
       with StrictLogging {
 

--- a/app/src/test/scala/org/alephium/explorer/persistence/dao/BlockDaoSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/dao/BlockDaoSpec.scala
@@ -31,6 +31,7 @@ import org.alephium.explorer.{AlephiumSpec, Generators}
 import org.alephium.explorer.api.model.{BlockEntry, BlockEntryLite, GroupIndex, Pagination}
 import org.alephium.explorer.persistence.{DatabaseFixtureForEach, DBRunner}
 import org.alephium.explorer.persistence.model._
+import org.alephium.explorer.persistence.queries.BlockQueries
 import org.alephium.explorer.persistence.schema._
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.explorer.service.BlockFlowClient
@@ -180,7 +181,7 @@ class BlockDaoSpec
 
   it should "cache mainChainQuery's rowCount when table is empty" in new Fixture {
     //Initially the cache is unpopulated so it should return None
-    blockDao.getRowCountFromCacheIfPresent(blockDao.mainChainQuery) is None
+    blockDao.getRowCountFromCacheIfPresent(BlockQueries.mainChainQuery) is None
 
     //dispatch listMainChainSQL on an empty table and expect the cache to be populated with 0 count
     forAll(Gen.posNum[Int], Gen.posNum[Int], arbitrary[Boolean]) {
@@ -191,7 +192,7 @@ class BlockDaoSpec
 
         //assert the cache is populated
         blockDao
-          .getRowCountFromCacheIfPresent(blockDao.mainChainQuery)
+          .getRowCountFromCacheIfPresent(BlockQueries.mainChainQuery)
           .map(_.futureValue) is Some(0)
     }
   }
@@ -210,7 +211,7 @@ class BlockDaoSpec
       //insert new blockEntities and expect the cache to get invalided
       blockDao.insertAll(blockEntities).futureValue
       //Assert the cache is invalidated after insert
-      blockDao.getRowCountFromCacheIfPresent(blockDao.mainChainQuery) is None
+      blockDao.getRowCountFromCacheIfPresent(BlockQueries.mainChainQuery) is None
 
       //expected row count in cache
       val expectedMainChainCount = blockEntities.count(_.mainChain)
@@ -223,7 +224,7 @@ class BlockDaoSpec
 
       //check the cache directly and it should contain the row count
       blockDao
-        .getRowCountFromCacheIfPresent(blockDao.mainChainQuery)
+        .getRowCountFromCacheIfPresent(BlockQueries.mainChainQuery)
         .map(_.futureValue) is Some(expectedMainChainCount)
     }
   }
@@ -236,7 +237,7 @@ class BlockDaoSpec
         .map(_.map(_._1))
 
     def expectCacheIsInvalidated() =
-      blockDao.getRowCountFromCacheIfPresent(blockDao.mainChainQuery) is None
+      blockDao.getRowCountFromCacheIfPresent(BlockQueries.mainChainQuery) is None
 
     forAll(entitiesGenerator, entitiesGenerator) {
       case (entities1, entities2) =>
@@ -255,7 +256,7 @@ class BlockDaoSpec
           ._2 is expectedMainChainCount
         //Assert the cache contains the right row count
         blockDao
-          .getRowCountFromCacheIfPresent(blockDao.mainChainQuery)
+          .getRowCountFromCacheIfPresent(BlockQueries.mainChainQuery)
           .map(_.futureValue) is Some(expectedMainChainCount)
 
         /** INSERT BATCH 2 - [[entities2]] */
@@ -271,7 +272,7 @@ class BlockDaoSpec
           ._2 is expectedMainChainCountTotal
         //Dispatch a query so the cache get populated
         blockDao
-          .getRowCountFromCacheIfPresent(blockDao.mainChainQuery)
+          .getRowCountFromCacheIfPresent(BlockQueries.mainChainQuery)
           .map(_.futureValue) is Some(expectedMainChainCountTotal)
     }
   }

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/TransactionQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/TransactionQueriesSpec.scala
@@ -46,10 +46,10 @@ class TransactionQueriesSpec
   implicit val executionContext: ExecutionContext = ExecutionContext.global
 
   it should "compute locked balance when empty" in new Fixture {
-    val balanceOption = run(queries.getBalanceActionOption(address)).futureValue
+    val balanceOption = run(TransactionQueries.getBalanceActionOption(address)).futureValue
     balanceOption is ((None, None))
 
-    val balance = run(queries.getBalanceAction(address)).futureValue
+    val balance = run(TransactionQueries.getBalanceAction(address)).futureValue
     balance is ((U256.Zero, U256.Zero))
   }
 
@@ -63,9 +63,9 @@ class TransactionQueriesSpec
 
     run(OutputSchema.table ++= Seq(output1, output2, output3, output4)).futureValue
 
-    val (total, locked) = run(queries.getBalanceAction(address)).futureValue
+    val (total, locked) = run(TransactionQueries.getBalanceAction(address)).futureValue
     val (totalDEPRECATED, lockedDEPRECATED) =
-      run(queries.getBalanceActionDEPRECATED(address)).futureValue
+      run(TransactionQueries.getBalanceActionDEPRECATED(address)).futureValue
 
     total is ALPH.alph(10)
     locked is ALPH.alph(7)
@@ -83,8 +83,9 @@ class TransactionQueriesSpec
     run(OutputSchema.table ++= Seq(output1, output2)).futureValue
     run(InputSchema.table += input1).futureValue
 
-    val (total, _)           = run(queries.getBalanceAction(address)).futureValue
-    val (totalDEPRECATED, _) = run(queries.getBalanceActionDEPRECATED(address)).futureValue
+    val (total, _) = run(TransactionQueries.getBalanceAction(address)).futureValue
+    val (totalDEPRECATED, _) =
+      run(TransactionQueries.getBalanceActionDEPRECATED(address)).futureValue
 
     total is ALPH.alph(1)
     totalDEPRECATED is ALPH.alph(1)
@@ -93,8 +94,9 @@ class TransactionQueriesSpec
     val to   = timestampMaxValue
     FinalizerService.finalizeOutputsWith(from, to, to.deltaUnsafe(from), databaseConfig).futureValue
 
-    val (totalFinalized, _)           = run(queries.getBalanceAction(address)).futureValue
-    val (totalFinalizedDEPRECATED, _) = run(queries.getBalanceActionDEPRECATED(address)).futureValue
+    val (totalFinalized, _) = run(TransactionQueries.getBalanceAction(address)).futureValue
+    val (totalFinalizedDEPRECATED, _) =
+      run(TransactionQueries.getBalanceActionDEPRECATED(address)).futureValue
 
     totalFinalized is ALPH.alph(1)
     totalFinalizedDEPRECATED is ALPH.alph(1)
@@ -109,8 +111,9 @@ class TransactionQueriesSpec
     run(OutputSchema.table ++= Seq(output1, output2)).futureValue
     run(InputSchema.table += input1).futureValue
 
-    val (total, _)           = run(queries.getBalanceAction(address)).futureValue
-    val (totalDEPRECATED, _) = run(queries.getBalanceActionDEPRECATED(address)).futureValue
+    val (total, _) = run(TransactionQueries.getBalanceAction(address)).futureValue
+    val (totalDEPRECATED, _) =
+      run(TransactionQueries.getBalanceActionDEPRECATED(address)).futureValue
 
     total is ALPH.alph(1)
     totalDEPRECATED is ALPH.alph(1)
@@ -128,12 +131,13 @@ class TransactionQueriesSpec
 
     val outputs = Seq(output1, output2, output3, output4)
     val inputs  = Seq(input1, input2, input3)
-    run(queries.insertAll(Seq.empty, outputs, inputs)).futureValue
-    run(queries.updateTransactionPerAddressAction(outputs, inputs)).futureValue
+    run(TransactionQueries.insertAll(Seq.empty, outputs, inputs)).futureValue
+    run(TransactionQueries.updateTransactionPerAddressAction(outputs, inputs)).futureValue
 
-    val total          = run(queries.countAddressTransactions(address)).futureValue
-    val totalSQL       = run(queries.countAddressTransactionsSQL(address)).futureValue.head
-    val totalSQLNoJoin = run(queries.countAddressTransactionsSQLNoJoin(address)).futureValue.head
+    val total    = run(TransactionQueries.countAddressTransactions(address)).futureValue
+    val totalSQL = run(TransactionQueries.countAddressTransactionsSQL(address)).futureValue.head
+    val totalSQLNoJoin =
+      run(TransactionQueries.countAddressTransactionsSQLNoJoin(address)).futureValue.head
 
     //tx of output1, output2 and input1
     total is 3
@@ -152,18 +156,19 @@ class TransactionQueriesSpec
     val outputs = Seq(output1)
     val inputs  = Seq(input1, input2)
 
-    run(queries.insertAll(Seq.empty, outputs, inputs)).futureValue
+    run(TransactionQueries.insertAll(Seq.empty, outputs, inputs)).futureValue
 
-    val inputsToUpdate = run(queries.updateTransactionPerAddressAction(outputs, inputs)).futureValue
+    val inputsToUpdate =
+      run(TransactionQueries.updateTransactionPerAddressAction(outputs, inputs)).futureValue
 
     inputsToUpdate is Seq(input2)
 
-    run(queries.countAddressTransactionsSQLNoJoin(address)).futureValue.head is 2
+    run(TransactionQueries.countAddressTransactionsSQLNoJoin(address)).futureValue.head is 2
 
     run(OutputSchema.table += output2).futureValue
     run(insertTxPerAddressFromInput(inputsToUpdate.head)).futureValue is 1
 
-    run(queries.countAddressTransactionsSQLNoJoin(address)).futureValue.head is 3
+    run(TransactionQueries.countAddressTransactionsSQLNoJoin(address)).futureValue.head is 3
   }
 
   it should "get tx hashes by address" in new Fixture {
@@ -179,13 +184,14 @@ class TransactionQueriesSpec
     val outputs = Seq(output1, output2, output3, output4)
     val inputs  = Seq(input1, input2, input3)
 
-    run(queries.insertAll(Seq.empty, outputs, inputs)).futureValue
-    run(queries.updateTransactionPerAddressAction(outputs, inputs)).futureValue
+    run(TransactionQueries.insertAll(Seq.empty, outputs, inputs)).futureValue
+    run(TransactionQueries.updateTransactionPerAddressAction(outputs, inputs)).futureValue
 
-    val hashes    = run(queries.getTxHashesByAddressQuery((address, 0, 10)).result).futureValue
-    val hashesSQL = run(queries.getTxHashesByAddressQuerySQL(address, 0, 10)).futureValue
+    val hashes =
+      run(TransactionQueries.getTxHashesByAddressQuery((address, 0, 10)).result).futureValue
+    val hashesSQL = run(TransactionQueries.getTxHashesByAddressQuerySQL(address, 0, 10)).futureValue
     val hashesSQLNoJoin =
-      run(queries.getTxHashesByAddressQuerySQLNoJoin(address, 0, 10)).futureValue
+      run(TransactionQueries.getTxHashesByAddressQuerySQLNoJoin(address, 0, 10)).futureValue
 
     val expected = Seq(
       (output1.txHash, output1.blockHash, output1.timestamp, 0),
@@ -282,8 +288,8 @@ class TransactionQueriesSpec
     val inputs       = Seq(input1, input2)
     val transactions = outputs.map(transaction)
 
-    run(queries.insertAll(transactions, outputs, inputs)).futureValue
-    run(queries.updateTransactionPerAddressAction(outputs, inputs)).futureValue
+    run(TransactionQueries.insertAll(transactions, outputs, inputs)).futureValue
+    run(TransactionQueries.updateTransactionPerAddressAction(outputs, inputs)).futureValue
 
     def tx(output: OutputEntity, spent: Option[Transaction.Hash], inputs: Seq[Input]) = {
       Transaction(
@@ -297,9 +303,10 @@ class TransactionQueriesSpec
       )
     }
 
-    val txs = run(queries.getTransactionsByAddress(address, Pagination.unsafe(0, 10))).futureValue
+    val txs =
+      run(TransactionQueries.getTransactionsByAddress(address, Pagination.unsafe(0, 10))).futureValue
     val txsSQL =
-      run(queries.getTransactionsByAddressSQL(address, Pagination.unsafe(0, 10))).futureValue
+      run(TransactionQueries.getTransactionsByAddressSQL(address, Pagination.unsafe(0, 10))).futureValue
 
     val expected = Seq(
       tx(output1, None, Seq.empty),
@@ -340,7 +347,7 @@ class TransactionQueriesSpec
     run(InputSchema.table ++= Seq(input1, input2)).futureValue
     run(TransactionSchema.table ++= Seq(txEntity1)).futureValue
 
-    val tx = run(queries.getTransactionAction(tx1.hash)).futureValue.get
+    val tx = run(TransactionQueries.getTransactionAction(tx1.hash)).futureValue.get
 
     tx.outputs.size is 1 // was 2 in v1.4.1
   }
@@ -354,18 +361,18 @@ class TransactionQueriesSpec
       val updatedTransactions  = transactions.map(_._2)
 
       //insert
-      run(queries.insertTransactions(existingTransactions)).futureValue is existingTransactions.size
+      run(TransactionQueries.insertTransactions(existingTransactions)).futureValue is existingTransactions.size
       run(TransactionSchema.table.result).futureValue should contain allElementsOf existingTransactions
 
       //ignore
-      run(queries.insertTransactions(updatedTransactions)).futureValue is 0
+      run(TransactionQueries.insertTransactions(updatedTransactions)).futureValue is 0
       run(TransactionSchema.table.result).futureValue should contain allElementsOf existingTransactions
     }
   }
 
   //https://github.com/alephium/explorer-backend/issues/174
   it should "return an empty list when not transactions are found - Isssue 174" in new Fixture {
-    run(queries.getTransactionsByAddressSQL(address, Pagination.unsafe(0, 10))).futureValue is Seq.empty
+    run(TransactionQueries.getTransactionsByAddressSQL(address, Pagination.unsafe(0, 10))).futureValue is Seq.empty
   }
 
   it should "get total number of main transactions" in new Fixture {
@@ -376,15 +383,11 @@ class TransactionQueriesSpec
 
     run(TransactionSchema.table ++= Seq(tx1, tx2, tx3)).futureValue
 
-    val total = run(queries.mainTransactions.length.result).futureValue
+    val total = run(TransactionQueries.mainTransactions.length.result).futureValue
     total is 2
   }
 
   trait Fixture {
-
-    class Queries(implicit val executionContext: ExecutionContext) extends TransactionQueries
-
-    val queries = new Queries
 
     val address = addressGen.sample.get
     def now     = TimeStamp.now().plusMinutesUnsafe(scala.util.Random.nextLong(240))

--- a/benchmark/src/main/scala/org/alephium/explorer/benchmark/db/state/AddressReadState.scala
+++ b/benchmark/src/main/scala/org/alephium/explorer/benchmark/db/state/AddressReadState.scala
@@ -33,7 +33,6 @@ import org.alephium.explorer.benchmark.db.{DataGenerator, DBConnectionPool, DBEx
 import org.alephium.explorer.benchmark.db.BenchmarkSettings._
 import org.alephium.explorer.persistence.dao.{BlockDao, TransactionDao}
 import org.alephium.explorer.persistence.model._
-import org.alephium.explorer.persistence.queries.TransactionQueries
 import org.alephium.explorer.persistence.schema._
 import org.alephium.explorer.service.FinalizerService
 import org.alephium.protocol.ALPH
@@ -41,7 +40,6 @@ import org.alephium.util.{Base58, TimeStamp, U256}
 
 class Queries(val config: DatabaseConfig[PostgresProfile])(
     implicit val executionContext: ExecutionContext)
-    extends TransactionQueries
 
 /**
   * JMH state for benchmarking reads from TransactionDao
@@ -50,8 +48,7 @@ class Queries(val config: DatabaseConfig[PostgresProfile])(
 // scalastyle:off method.length
 @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
 class AddressReadState(val db: DBExecutor)
-    extends ReadBenchmarkState[OutputEntity](testDataCount = 4000, db = db)
-    with TransactionQueries {
+    extends ReadBenchmarkState[OutputEntity](testDataCount = 4000, db = db) {
 
   val ec: ExecutionContext = ExecutionContext.global
 
@@ -63,8 +60,6 @@ class AddressReadState(val db: DBExecutor)
 
   val dao: TransactionDao =
     TransactionDao(config)(db.config.db.ioExecutionContext)
-
-  val queries: TransactionQueries = new Queries(db.config)
 
   val address: Address = Address.unsafe(Base58.encode(Hash.generate.bytes))
 


### PR DESCRIPTION
- Third PR towards issue #201
- Updated `BlockQueries` & `TransactionQueries` to be stateless