### PR TITLE
Stateless `SanityChecker`

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/AppServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/AppServer.scala
@@ -32,12 +32,12 @@ import org.alephium.explorer.web._
 // scalastyle:off magic.number
 class AppServer(blockService: BlockService,
                 transactionService: TransactionService,
-                tokenSupplyService: TokenSupplyService,
-                sanityChecker: SanityChecker)(implicit executionContext: ExecutionContext,
-                                              dc: DatabaseConfig[PostgresProfile],
-                                              blockCache: BlockCache,
-                                              transactionCache: TransactionCache,
-                                              groupSetting: GroupSetting)
+                tokenSupplyService: TokenSupplyService)(implicit executionContext: ExecutionContext,
+                                                        dc: DatabaseConfig[PostgresProfile],
+                                                        blockFlowClient: BlockFlowClient,
+                                                        blockCache: BlockCache,
+                                                        transactionCache: TransactionCache,
+                                                        groupSetting: GroupSetting)
     extends StrictLogging {
 
   val blockServer: BlockServer = new BlockServer(blockService)
@@ -47,7 +47,7 @@ class AppServer(blockService: BlockService,
     new TransactionServer(transactionService)
   val infosServer: InfosServer =
     new InfosServer(tokenSupplyService, blockService, transactionService)
-  val utilsServer: UtilsServer   = new UtilsServer(sanityChecker)
+  val utilsServer: UtilsServer   = new UtilsServer()
   val chartsServer: ChartsServer = new ChartsServer()
 
   val route: Route =

--- a/app/src/main/scala/org/alephium/explorer/Application.scala
+++ b/app/src/main/scala/org/alephium/explorer/Application.scala
@@ -67,7 +67,7 @@ class Application(host: String,
     awaitService(TransactionCache())
 
   //Services
-  val blockFlowClient: BlockFlowClient =
+  implicit val blockFlowClient: BlockFlowClient =
     BlockFlowClient(blockFlowUri, groupNum, maybeBlockFlowApiKey)
 
   val blockFlowSyncService: BlockFlowSyncService =
@@ -76,11 +76,8 @@ class Application(host: String,
   val mempoolSyncService: MempoolSyncService =
     MempoolSyncService(syncPeriod = syncPeriod, blockFlowClient, UnconfirmedTxDao)
 
-  val sanityChecker: SanityChecker =
-    new SanityChecker(groupNum, blockFlowClient)
-
   val server: AppServer =
-    new AppServer(BlockService, TransactionService, TokenSupplyService, sanityChecker)
+    new AppServer(BlockService, TransactionService, TokenSupplyService)
 
   private val bindingPromise: Promise[Http.ServerBinding] = Promise()
 

--- a/app/src/main/scala/org/alephium/explorer/web/UtilsServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/UtilsServer.scala
@@ -16,19 +16,28 @@
 
 package org.alephium.explorer.web
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 import akka.http.scaladsl.server.Route
+import slick.basic.DatabaseConfig
+import slick.jdbc.PostgresProfile
 
+import org.alephium.explorer.{sideEffect, GroupSetting}
 import org.alephium.explorer.api.UtilsEndpoints
-import org.alephium.explorer.service.SanityChecker
-import org.alephium.explorer.sideEffect
+import org.alephium.explorer.cache.BlockCache
+import org.alephium.explorer.service.{BlockFlowClient, SanityChecker}
 
-class UtilsServer(sanityChecker: SanityChecker) extends Server with UtilsEndpoints {
+class UtilsServer()(implicit ec: ExecutionContext,
+                    dc: DatabaseConfig[PostgresProfile],
+                    blockFlowClient: BlockFlowClient,
+                    blockCache: BlockCache,
+                    groupSetting: GroupSetting)
+    extends Server
+    with UtilsEndpoints {
 
   val route: Route =
     toRoute(sanityCheck) { _ =>
-      sideEffect(sanityChecker.check())
+      sideEffect(SanityChecker.check())
       Future.successful(Right(()))
     }
 }


### PR DESCRIPTION
- Towards #201
- Stacked PR of previous un-merged PR #240
- Stateless `SanityChecker`

`SanityChecker` has mutable vars `running`, `i`, `totalNbOfBlocks` which from a quick look can be removed and implemented immutably. Is this something we want done?

# Pending stateless services

Two more left - `BlockFlowSyncService` and `MempoolSyncService`.