### PR TITLE
#249: Initialise database first

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/util/FutureUtil.scala
+++ b/app/src/main/scala/org/alephium/explorer/util/FutureUtil.scala
@@ -14,18 +14,18 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the library. If not, see <http://www.gnu.org/licenses/>.
 
-package org.alephium.explorer.benchmark
+package org.alephium.explorer.util
 
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 
-object BenchmarkUtils {
+object FutureUtil {
 
   implicit class AwaitUtils[T](f: => Future[T]) {
 
     //Convenience function to wait on a future
     @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
-    def await(seconds: FiniteDuration = 5.seconds): T =
+    @inline def await(seconds: FiniteDuration = 5.seconds): T =
       Await.result(f, seconds)
 
   }


### PR DESCRIPTION
Quick fix #249. Blocking-ly Initialises database first on `Application` boot-up before the cache is initialised. 

Or we can wait for a proper fix when #201 gets resolved with updates to `Application.scala` & `Main.scala`?