### PR TITLE
Remove unused and duplicate function in various places

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/persistence/dao/BlockDao.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/dao/BlockDao.scala
@@ -89,28 +89,6 @@ object BlockDao {
         cache.invalidateRowCount(mainChainQuery)
       }
 
-  def listMainChain(pagination: Pagination)(
-      implicit ec: ExecutionContext,
-      dc: DatabaseConfig[PostgresProfile]): Future[(Seq[BlockEntryLite], Int)] = {
-    val mainChain = BlockHeaderSchema.table.filter(_.mainChain)
-    val action =
-      for {
-        headers <- listMainChainHeaders(mainChain, pagination)
-        total   <- mainChain.length.result
-      } yield (headers.map(_.toLiteApi), total)
-
-    run(action)
-  }
-
-  /** SQL version of [[listMainChain]] */
-  def listMainChainSQL(pagination: Pagination)(
-      implicit ec: ExecutionContext,
-      dc: DatabaseConfig[PostgresProfile]): Future[(Seq[BlockEntryLite], Int)] = {
-    val blockEntries = run(listMainChainHeadersWithTxnNumberSQL(pagination))
-    val count        = run(countMainChain().result)
-    blockEntries.zip(count)
-  }
-
   def listMainChainSQLCached(pagination: Pagination)(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile],

--- a/app/src/main/scala/org/alephium/explorer/persistence/dao/TransactionDao.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/dao/TransactionDao.scala
@@ -33,23 +33,10 @@ object TransactionDao {
       dc: DatabaseConfig[PostgresProfile]): Future[Option[Transaction]] =
     run(getTransactionAction(hash))
 
-  def getByAddress(address: Address, pagination: Pagination)(
-      implicit ec: ExecutionContext,
-      dc: DatabaseConfig[PostgresProfile]): Future[Seq[Transaction]] =
-    run(getTransactionsByAddress(address, pagination))
-
   def getByAddressSQL(address: Address, pagination: Pagination)(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[Seq[Transaction]] =
     run(getTransactionsByAddressSQL(address, pagination))
-
-  def getNumberByAddress(address: Address)(implicit ec: ExecutionContext,
-                                           dc: DatabaseConfig[PostgresProfile]): Future[Int] =
-    run(countAddressTransactions(address))
-
-  def getNumberByAddressSQL(address: Address)(implicit ec: ExecutionContext,
-                                              dc: DatabaseConfig[PostgresProfile]): Future[Int] =
-    run(countAddressTransactionsSQL(address)).map(_.headOption.getOrElse(0))
 
   def getNumberByAddressSQLNoJoin(address: Address)(
       implicit ec: ExecutionContext,

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
@@ -156,10 +156,6 @@ object BlockQueries extends StrictLogging {
       .as[BlockEntryLite](blockEntryListGetResult)
   }
 
-  /** Counts main_chain Blocks */
-  def countMainChain(): Rep[Int] =
-    BlockHeaderSchema.table.filter(_.mainChain).length
-
   def updateMainChainStatusAction(hash: BlockEntry.Hash, isMainChain: Boolean)(
       implicit ec: ExecutionContext): DBActionRWT[Unit] = {
     val query =

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/InputQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/InputQueries.scala
@@ -138,28 +138,6 @@ object InputQueries {
     }
   }
 
-  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-  def inputsFromTxs(txHashes: Seq[Transaction.Hash]) = {
-    mainInputs
-      .filter(_.txHash inSet txHashes)
-      .join(mainOutputs)
-      .on {
-        case (input, outputs) =>
-          input.outputRefKey === outputs.key
-      }
-      .map {
-        case (input, output) =>
-          (input.txHash,
-           input.inputOrder,
-           input.hint,
-           input.outputRefKey,
-           input.unlockScript,
-           output.txHash,
-           output.address,
-           output.amount)
-      }
-  }
-
   // format: off
   def inputsFromTxsSQL(txHashes: Seq[Transaction.Hash]):
     DBActionR[Seq[(Transaction.Hash, Int, Int, Hash, Option[String], Transaction.Hash, Address, U256)]] = {

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/OutputQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/OutputQueries.scala
@@ -31,8 +31,7 @@ import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.util.{TimeStamp, U256}
 
 object OutputQueries {
-  private val mainInputs  = InputSchema.table.filter(_.mainChain)
-  private val mainOutputs = OutputSchema.table.filter(_.mainChain)
+  private val mainInputs = InputSchema.table.filter(_.mainChain)
 
   /** Inserts outputs or ignore rows with primary key conflict */
   // scalastyle:off magic.number
@@ -95,28 +94,6 @@ object OutputQueries {
     } else {
       DBIOAction.successful(0)
     }
-  }
-
-  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-  def outputsFromTxs(txHashes: Seq[Transaction.Hash]) = {
-    mainOutputs
-      .filter(_.txHash inSet txHashes)
-      .joinLeft(mainInputs)
-      .on {
-        case (out, inputs) =>
-          out.key === inputs.outputRefKey
-      }
-      .map {
-        case (output, input) =>
-          (output.txHash,
-           output.outputOrder,
-           output.hint,
-           output.key,
-           output.amount,
-           output.address,
-           output.lockTime,
-           input.map(_.txHash))
-      }
   }
 
   // format: off

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
@@ -39,9 +39,7 @@ import org.alephium.util.{TimeStamp, U256}
 object TransactionQueries extends StrictLogging {
 
   @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-  val mainTransactions    = TransactionSchema.table.filter(_.mainChain)
-  private val mainInputs  = InputSchema.table.filter(_.mainChain)
-  private val mainOutputs = OutputSchema.table.filter(_.mainChain)
+  val mainTransactions = TransactionSchema.table.filter(_.mainChain)
 
   def insertAll(transactions: Seq[TransactionEntity],
                 outputs: Seq[OutputEntity],
@@ -105,9 +103,6 @@ object TransactionQueries extends StrictLogging {
   def countBlockHashTransactions(blockHash: BlockEntry.Hash): DBActionR[Int] =
     countBlockHashTransactionsQuery(blockHash).result
 
-  def countAddressTransactions(address: Address): DBActionR[Int] =
-    getTxNumberByAddressQuery(address).result
-
   private val getTransactionQuery = Compiled { txHash: Rep[Transaction.Hash] =>
     mainTransactions
       .filter(_.hash === txHash)
@@ -139,78 +134,12 @@ object TransactionQueries extends StrictLogging {
         .take(limit)
   }
 
-  private val getTxNumberByAddressQuery = Compiled { (address: Rep[Address]) =>
-    mainInputs
-      .join(mainOutputs)
-      .on(_.outputRefKey === _.key)
-      .filter(_._2.address === address)
-      .map { case (input, _) => input.txHash }
-      .union(
-        mainOutputs
-          .filter(_.address === address)
-          .map(out => out.txHash)
-      )
-      .length
-  }
-
-  def countAddressTransactionsSQL(address: Address): DBActionSR[Int] = {
-    sql"""
-    SELECT COUNT(*)
-    FROM (
-      (SELECT inputs.tx_hash
-        FROM inputs
-        JOIN outputs ON  outputs.main_chain = true AND inputs.output_ref_key = outputs.key AND outputs.address = $address
-        WHERE inputs.main_chain = true)
-    UNION
-    SELECT tx_hash from outputs WHERE main_chain = true AND address = $address
-    ) tx_hashes
-    """.as[Int]
-  }
-
   def countAddressTransactionsSQLNoJoin(address: Address): DBActionSR[Int] = {
     sql"""
     SELECT COUNT(*)
     FROM transaction_per_addresses
     WHERE main_chain = true AND address = $address
     """.as[Int]
-  }
-
-  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-  val getTxHashesByAddressQuery = Compiled {
-    (address: Rep[Address], toDrop: ConstColumn[Long], limit: ConstColumn[Long]) =>
-      mainInputs
-        .join(mainOutputs)
-        .on(_.outputRefKey === _.key)
-        .filter(_._2.address === address)
-        .map { case (input, _) => (input.txHash, input.blockHash, input.timestamp, input.txOrder) }
-        .union(
-          mainOutputs
-            .filter(_.address === address)
-            .map(out => (out.txHash, out.blockHash, out.timestamp, out.txOrder))
-        )
-        .sortBy { case (_, _, timestamp, txOrder) => (timestamp.desc, txOrder) }
-        .drop(toDrop)
-        .take(limit)
-  }
-
-  def getTxHashesByAddressQuerySQL(
-      address: Address,
-      offset: Int,
-      limit: Int): DBActionSR[(Transaction.Hash, BlockEntry.Hash, TimeStamp, Int)] = {
-    sql"""
-    (
-      SELECT inputs.tx_hash, inputs.block_hash, inputs.block_timestamp, inputs.tx_order
-      FROM inputs
-      JOIN outputs ON outputs.main_chain = true AND inputs.output_ref_key = outputs.key AND outputs.address = $address
-      WHERE inputs.main_chain = true
-      UNION
-      SELECT tx_hash, block_hash, block_timestamp, tx_order from outputs
-      WHERE main_chain = true AND address = $address
-    )
-    ORDER BY block_timestamp DESC, tx_order
-    LIMIT $limit
-    OFFSET $offset
-    """.as
   }
 
   def getTxHashesByAddressQuerySQLNoJoin(
@@ -231,7 +160,7 @@ object TransactionQueries extends StrictLogging {
       implicit ec: ExecutionContext): DBActionR[Seq[Transaction]] = {
     for {
       txHashesTs <- getTxHashesByBlockHashQuery(blockHash).result
-      txs        <- getTransactions(txHashesTs)
+      txs        <- getTransactionsSQL(txHashesTs)
     } yield txs
   }
 
@@ -242,18 +171,7 @@ object TransactionQueries extends StrictLogging {
     val toDrop = offset * limit
     for {
       txHashesTs <- getTxHashesByBlockHashWithPaginationQuery((blockHash, toDrop, limit)).result
-      txs        <- getTransactions(txHashesTs)
-    } yield txs
-  }
-
-  def getTransactionsByAddress(address: Address, pagination: Pagination)(
-      implicit ec: ExecutionContext): DBActionR[Seq[Transaction]] = {
-    val offset = pagination.offset.toLong
-    val limit  = pagination.limit.toLong
-    val toDrop = offset * limit
-    for {
-      txHashesTs <- getTxHashesByAddressQuery((address, toDrop, limit)).result
-      txs        <- getTransactions(txHashesTs)
+      txs        <- getTransactionsSQL(txHashesTs)
     } yield txs
   }
 
@@ -266,18 +184,6 @@ object TransactionQueries extends StrictLogging {
       txHashesTs <- getTxHashesByAddressQuerySQLNoJoin(address, toDrop, limit)
       txs        <- getTransactionsSQL(txHashesTs)
     } yield txs
-  }
-
-  def getTransactions(txHashesTs: Seq[(Transaction.Hash, BlockEntry.Hash, TimeStamp, Int)])(
-      implicit ec: ExecutionContext): DBActionR[Seq[Transaction]] = {
-    val txHashes = txHashesTs.map(_._1)
-    for {
-      inputs  <- inputsFromTxs(txHashes).result
-      outputs <- outputsFromTxs(txHashes).result
-      gases   <- gasFromTxs(txHashes).result
-    } yield {
-      buildTransaction(txHashesTs, inputs, outputs, gases)
-    }
   }
 
   def getTransactionsSQL(txHashesTs: Seq[(Transaction.Hash, BlockEntry.Hash, TimeStamp, Int)])(
@@ -330,11 +236,6 @@ object TransactionQueries extends StrictLogging {
     }
   }
 
-  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-  def gasFromTxs(txHashes: Seq[Transaction.Hash]) = {
-    mainTransactions.filter(_.hash inSet txHashes).map(tx => (tx.hash, tx.gasAmount, tx.gasPrice))
-  }
-
   def gasFromTxsSQL(
       txHashes: Seq[Transaction.Hash]): DBActionR[Seq[(Transaction.Hash, Int, U256)]] = {
     if (txHashes.nonEmpty) {
@@ -367,37 +268,6 @@ object TransactionQueries extends StrictLogging {
                   gasAmount,
                   gasPrice)
     }
-
-  def getBalanceQueryDEPRECATED(address: Address): DBActionSR[(U256, Option[TimeStamp])] = {
-    sql"""
-        SELECT outputs.amount, outputs.lock_time
-        FROM outputs
-        LEFT JOIN inputs
-        ON outputs.key = inputs.output_ref_key
-        WHERE outputs.main_chain = true
-        AND outputs.address = $address
-        AND inputs.block_hash IS NULL
-      """.as[(U256, Option[TimeStamp])]
-  }
-
-  private def sumBalance(outputs: Seq[(U256, Option[TimeStamp])]): (U256, U256) = {
-    val now = TimeStamp.now()
-    outputs.foldLeft((U256.Zero, U256.Zero)) {
-      case ((total, locked), (amount, lockTime)) =>
-        val newTotal = total.addUnsafe(amount)
-        val newLocked = if (lockTime.forall(_.isBefore(now))) {
-          locked
-        } else {
-          locked.addUnsafe(amount)
-        }
-        (newTotal, newLocked)
-    }
-  }
-
-  def getBalanceActionDEPRECATED(address: Address)(
-      implicit ec: ExecutionContext): DBActionR[(U256, U256)] = {
-    getBalanceQueryDEPRECATED(address).map(sumBalance)
-  }
 
   def getBalanceAction(address: Address)(implicit ec: ExecutionContext): DBActionR[(U256, U256)] =
     getBalanceUntilLockTime(

--- a/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
@@ -31,10 +31,6 @@ trait TransactionService {
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[Option[TransactionLike]]
 
-  def getTransactionsByAddress(address: Address, pagination: Pagination)(
-      implicit ec: ExecutionContext,
-      dc: DatabaseConfig[PostgresProfile]): Future[Seq[Transaction]]
-
   def getTransactionsByAddressSQL(address: Address, pagination: Pagination)(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[Seq[Transaction]]
@@ -58,11 +54,6 @@ object TransactionService extends TransactionService {
       case None     => UnconfirmedTxDao.get(transactionHash)
       case Some(tx) => Future.successful(Some(ConfirmedTransaction.from(tx)))
     }
-
-  def getTransactionsByAddress(address: Address, pagination: Pagination)(
-      implicit ec: ExecutionContext,
-      dc: DatabaseConfig[PostgresProfile]): Future[Seq[Transaction]] =
-    TransactionDao.getByAddress(address, pagination)
 
   def getTransactionsByAddressSQL(address: Address, pagination: Pagination)(
       implicit ec: ExecutionContext,

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/TransactionQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/TransactionQueriesSpec.scala
@@ -64,14 +64,10 @@ class TransactionQueriesSpec
     run(OutputSchema.table ++= Seq(output1, output2, output3, output4)).futureValue
 
     val (total, locked) = run(TransactionQueries.getBalanceAction(address)).futureValue
-    val (totalDEPRECATED, lockedDEPRECATED) =
-      run(TransactionQueries.getBalanceActionDEPRECATED(address)).futureValue
 
     total is ALPH.alph(10)
     locked is ALPH.alph(7)
 
-    totalDEPRECATED is ALPH.alph(10)
-    lockedDEPRECATED is ALPH.alph(7)
   }
 
   it should "get balance should only return unpent outputs" in new Fixture {
@@ -84,22 +80,16 @@ class TransactionQueriesSpec
     run(InputSchema.table += input1).futureValue
 
     val (total, _) = run(TransactionQueries.getBalanceAction(address)).futureValue
-    val (totalDEPRECATED, _) =
-      run(TransactionQueries.getBalanceActionDEPRECATED(address)).futureValue
 
     total is ALPH.alph(1)
-    totalDEPRECATED is ALPH.alph(1)
 
     val from = TimeStamp.zero
     val to   = timestampMaxValue
     FinalizerService.finalizeOutputsWith(from, to, to.deltaUnsafe(from)).futureValue
 
     val (totalFinalized, _) = run(TransactionQueries.getBalanceAction(address)).futureValue
-    val (totalFinalizedDEPRECATED, _) =
-      run(TransactionQueries.getBalanceActionDEPRECATED(address)).futureValue
 
     totalFinalized is ALPH.alph(1)
-    totalFinalizedDEPRECATED is ALPH.alph(1)
   }
 
   it should "get balance should only take main chain outputs" in new Fixture {
@@ -112,11 +102,8 @@ class TransactionQueriesSpec
     run(InputSchema.table += input1).futureValue
 
     val (total, _) = run(TransactionQueries.getBalanceAction(address)).futureValue
-    val (totalDEPRECATED, _) =
-      run(TransactionQueries.getBalanceActionDEPRECATED(address)).futureValue
 
     total is ALPH.alph(1)
-    totalDEPRECATED is ALPH.alph(1)
   }
 
   it should "txs count" in new Fixture {
@@ -134,14 +121,10 @@ class TransactionQueriesSpec
     run(TransactionQueries.insertAll(Seq.empty, outputs, inputs)).futureValue
     run(TransactionQueries.updateTransactionPerAddressAction(outputs, inputs)).futureValue
 
-    val total    = run(TransactionQueries.countAddressTransactions(address)).futureValue
-    val totalSQL = run(TransactionQueries.countAddressTransactionsSQL(address)).futureValue.head
     val totalSQLNoJoin =
       run(TransactionQueries.countAddressTransactionsSQLNoJoin(address)).futureValue.head
 
     //tx of output1, output2 and input1
-    total is 3
-    totalSQL is 3
     totalSQLNoJoin is 3
   }
 
@@ -187,9 +170,6 @@ class TransactionQueriesSpec
     run(TransactionQueries.insertAll(Seq.empty, outputs, inputs)).futureValue
     run(TransactionQueries.updateTransactionPerAddressAction(outputs, inputs)).futureValue
 
-    val hashes =
-      run(TransactionQueries.getTxHashesByAddressQuery((address, 0, 10)).result).futureValue
-    val hashesSQL = run(TransactionQueries.getTxHashesByAddressQuerySQL(address, 0, 10)).futureValue
     val hashesSQLNoJoin =
       run(TransactionQueries.getTxHashesByAddressQuerySQLNoJoin(address, 0, 10)).futureValue
 
@@ -199,8 +179,6 @@ class TransactionQueriesSpec
       (input1.txHash, input1.blockHash, input1.timestamp, 0)
     ).sortBy(_._3).reverse
 
-    hashes is expected
-    hashesSQL is expected.toVector
     hashesSQLNoJoin is expected.toVector
   }
 
@@ -238,7 +216,6 @@ class TransactionQueriesSpec
       res(output3, None)
     ).sortBy(_._1.toString)
 
-    run(outputsFromTxs(txHashes).result).futureValue.sortBy(_._1.toString) is expected
     run(outputsFromTxsSQL(txHashes)).futureValue.sortBy(_._1.toString) is expected.toVector
   }
 
@@ -271,7 +248,6 @@ class TransactionQueriesSpec
          output.amount)
     }
 
-    run(inputsFromTxs(txHashes).result).futureValue is expected
     run(inputsFromTxsSQL(txHashes)).futureValue is expected.toVector
   }
 
@@ -303,8 +279,6 @@ class TransactionQueriesSpec
       )
     }
 
-    val txs =
-      run(TransactionQueries.getTransactionsByAddress(address, Pagination.unsafe(0, 10))).futureValue
     val txsSQL =
       run(TransactionQueries.getTransactionsByAddressSQL(address, Pagination.unsafe(0, 10))).futureValue
 
@@ -314,10 +288,7 @@ class TransactionQueriesSpec
       tx(output4, None, Seq(input1.toApi(output2)))
     ).sortBy(_.timestamp).reverse
 
-    txs.size is 3
     txsSQL.size is 3
-
-    txs is expected
     txsSQL is expected
   }
 

--- a/app/src/test/scala/org/alephium/explorer/service/BlockFlowSyncServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/BlockFlowSyncServiceSpec.scala
@@ -295,7 +295,7 @@ class BlockFlowSyncServiceSpec
 
     def checkMainChain(mainChain: Seq[BlockEntry.Hash]) = {
       val result = BlockDao
-        .listMainChain(Pagination.unsafe(0, blocks.size))
+        .listMainChainSQLCached(Pagination.unsafe(0, blocks.size))
         .futureValue
         ._1
         .filter(block =>

--- a/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
@@ -119,11 +119,6 @@ class AddressServerSpec()
           dc: DatabaseConfig[PostgresProfile]): Future[Option[TransactionLike]] =
         Future.successful(None)
 
-      override def getTransactionsByAddress(address: Address, pagination: Pagination)(
-          implicit ec: ExecutionContext,
-          dc: DatabaseConfig[PostgresProfile]): Future[Seq[Transaction]] =
-        Future.successful(Seq.empty)
-
       override def getTransactionsNumberByAddress(address: Address)(
           implicit ec: ExecutionContext,
           dc: DatabaseConfig[PostgresProfile]): Future[Int] =

--- a/app/src/test/scala/org/alephium/explorer/web/InfosServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/InfosServerSpec.scala
@@ -188,11 +188,6 @@ class InfosServerSpec()
           dc: DatabaseConfig[PostgresProfile]): Future[Option[TransactionLike]] =
         Future.successful(None)
 
-      override def getTransactionsByAddress(address: Address, pagination: Pagination)(
-          implicit ec: ExecutionContext,
-          dc: DatabaseConfig[PostgresProfile]): Future[Seq[Transaction]] =
-        Future.successful(Seq.empty)
-
       override def getTransactionsNumberByAddress(address: Address)(
           implicit ec: ExecutionContext,
           dc: DatabaseConfig[PostgresProfile]): Future[Int] =


### PR DESCRIPTION
We kept lots of functions that were written in `slick` just to validate
that the new corresponding SQL functions were correct.

I think we ran everything in prod for long enough to validate it's correct.

This was also getting annoying to maintain as soon as we are adding a column somewhere.