### PR TITLE
Add two endpoints to manage log level

### DIFF
--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -2113,6 +2113,193 @@
           }
         }
       }
+    },
+    "/utils/update-global-loglevel": {
+      "put": {
+        "tags": [
+          "Utils"
+        ],
+        "description": "Update global log level, accepted: TRACE, DEBUG, INFO, WARN, ERROR",
+        "operationId": "putUtilsUpdate-global-loglevel",
+        "requestBody": {
+          "content": {
+            "text/plain": {
+              "schema": {
+                "type": "string",
+                "enum": [
+                  "TRACE",
+                  "DEBUG",
+                  "INFO",
+                  "WARN",
+                  "ERROR"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            
+          },
+          "400": {
+            "description": "BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequest"
+                },
+                "example": {
+                  "detail": "Something bad in the request"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                },
+                "example": {
+                  "detail": "Ouch"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFound"
+                },
+                "example": {
+                  "resource": "wallet-name",
+                  "detail": "wallet-name not found"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailable"
+                },
+                "example": {
+                  "detail": "Self clique unsynced"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unauthorized"
+                },
+                "example": {
+                  "detail": "You shall not pass"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/utils/update-log-config": {
+      "put": {
+        "tags": [
+          "Utils"
+        ],
+        "description": "Update logging file, only logback.xml is accepted",
+        "operationId": "putUtilsUpdate-log-config",
+        "requestBody": {
+          "content": {
+            "text/plain": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            
+          },
+          "400": {
+            "description": "BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequest"
+                },
+                "example": {
+                  "detail": "Something bad in the request"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                },
+                "example": {
+                  "detail": "Ouch"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFound"
+                },
+                "example": {
+                  "resource": "wallet-name",
+                  "detail": "wallet-name not found"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailable"
+                },
+                "example": {
+                  "detail": "Self clique unsynced"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unauthorized"
+                },
+                "example": {
+                  "detail": "You shall not pass"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/app/src/main/scala/org/alephium/explorer/api/Schemas.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/Schemas.scala
@@ -14,22 +14,13 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the library. If not, see <http://www.gnu.org/licenses/>.
 
-package org.alephium.explorer.api.model
+package org.alephium.explorer.api
 
-import org.alephium.explorer.api.Json.u256ReadWriter
-import org.alephium.json.Json._
-import org.alephium.util.U256
+// import sttp.tapir.Schema
+// import sttp.tapir.SchemaType.SString
 
-@SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
-final case class Input(
-    outputRef: OutputRef,
-    unlockScript: Option[String] = None,
-    txHashRef: Transaction.Hash,
-    address: Address,
-    amount: U256
-)
+// import org.alephium.explorer.api.model.LogbackValue
 
-object Input {
-  implicit val readWriter: ReadWriter[Input] = macroRW
-
+object Schemas {
+  //implicit val logbackLevel: Schema[LogbackValue.Level] = Schema(SString())
 }

--- a/app/src/main/scala/org/alephium/explorer/api/UtilsEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/UtilsEndpoints.scala
@@ -28,8 +28,23 @@ trait UtilsEndpoints extends BaseEndpoint with QueryParams {
       .tag("Utils")
       .in("utils")
 
+  private val logLevels    = List("TRACE", "DEBUG", "INFO", "WARN", "ERROR")
+  private val logLevelsStr = logLevels.mkString(", ")
+
   val sanityCheck: BaseEndpoint[Unit, Unit] =
     utilsEndpoint.put
       .in("sanity-check")
       .description("Perform a sanity check")
+
+  val changeGlobalLogLevel: BaseEndpoint[String, Unit] =
+    utilsEndpoint.put
+      .in("update-global-loglevel")
+      .in(plainBody[String].validate(Validator.enumeration(logLevels)))
+      .description(s"Update global log level, accepted: $logLevelsStr")
+
+  val changeLogConfig: BaseEndpoint[String, Unit] =
+    utilsEndpoint.put
+      .in("update-log-config")
+      .in(plainBody[String])
+      .description("Update logging file, only logback.xml is accepted")
 }

--- a/app/src/main/scala/org/alephium/explorer/api/UtilsEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/UtilsEndpoints.scala
@@ -17,8 +17,11 @@
 package org.alephium.explorer.api
 
 import sttp.tapir._
+import sttp.tapir.generic.auto._
 
+import org.alephium.api.{alphJsonBody => jsonBody}
 import org.alephium.explorer.api.BaseEndpoint
+import org.alephium.explorer.api.model.LogbackValue
 
 // scalastyle:off magic.number
 trait UtilsEndpoints extends BaseEndpoint with QueryParams {
@@ -42,9 +45,9 @@ trait UtilsEndpoints extends BaseEndpoint with QueryParams {
       .in(plainBody[String].validate(Validator.enumeration(logLevels)))
       .description(s"Update global log level, accepted: $logLevelsStr")
 
-  val changeLogConfig: BaseEndpoint[String, Unit] =
+  val changeLogConfig: BaseEndpoint[Seq[LogbackValue], Unit] =
     utilsEndpoint.put
       .in("update-log-config")
-      .in(plainBody[String])
-      .description("Update logging file, only logback.xml is accepted")
+      .in(jsonBody[Seq[LogbackValue]])
+      .description("Update logback values")
 }

--- a/app/src/main/scala/org/alephium/explorer/api/model/LogbackValue.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/LogbackValue.scala
@@ -1,0 +1,71 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.api.model
+
+import sttp.tapir.{Schema, Validator}
+import upickle.core.Abort
+
+import org.alephium.json.Json._
+
+final case class LogbackValue(
+    name: String,
+    level: LogbackValue.Level
+)
+
+object LogbackValue {
+  implicit val readWriter: ReadWriter[LogbackValue] = macroRW
+
+  sealed trait Level
+
+  object Level {
+    case object Trace extends Level {
+      override def toString(): String = "TRACE"
+    }
+    case object Debug extends Level {
+      override def toString(): String = "DEBUG"
+    }
+    case object Info extends Level {
+      override def toString(): String = "INFO"
+    }
+    case object Warn extends Level {
+      override def toString(): String = "WARN"
+    }
+    case object Error extends Level {
+      override def toString(): String = "ERROR"
+    }
+
+    @SuppressWarnings(
+      Array("org.wartremover.warts.JavaSerializable",
+            "org.wartremover.warts.Product",
+            "org.wartremover.warts.Serializable")) // Wartremover is complaining, don't now why :/
+    val levels: Seq[Level] = Seq(Trace, Debug, Info, Warn, Error)
+
+    implicit val levelReadWriter: ReadWriter[Level] = readwriter[String].bimap(
+      _.toString, {
+        case "TRACE" => Trace
+        case "DEBUG" => Debug
+        case "INFO"  => Info
+        case "WARN"  => Warn
+        case "ERROR" => Error
+        case _       => throw new Abort(s"Cannot decode level, expected one of: ${levels}")
+      }
+    )
+
+    implicit def levelSchema: Schema[Level] =
+      Schema.string.validate(Validator.enumeration(levels.toList))
+  }
+}

--- a/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
+++ b/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
@@ -51,7 +51,9 @@ trait Documentation
       getHashrates,
       getAllChainsTxCount,
       getPerChainTxCount,
-      sanityCheck
+      sanityCheck,
+      changeGlobalLogLevel,
+      changeLogConfig
     ),
     "Alephium Explorer API",
     "1.0"

--- a/app/src/main/scala/org/alephium/explorer/web/UtilsServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/UtilsServer.scala
@@ -63,7 +63,7 @@ class UtilsServer()(implicit val executionContext: ExecutionContext,
         logger.info(s"Logging level updated to $level.")
         Right(())
       case Failure(error) =>
-        val errorMessage = s"Cannot apply logback configuation: $error"
+        val errorMessage = s"Cannot apply logback configuration: $error"
         logger.error(errorMessage)
         Left(ApiError.BadRequest(errorMessage))
     }
@@ -92,8 +92,8 @@ class UtilsServer()(implicit val executionContext: ExecutionContext,
             val init = new ContextInitializer(logbackCtx)
             init.autoConfig
             logger.warn(
-              s"Cannot apply logback configuation, Logback configuration reset to what is defined on the class path or system properties: ${e.getMessage}")
-            Left(ApiError.BadRequest(s"Cannot apply logback configuation: ${e.getMessage}"))
+              s"Cannot apply logback configuration, Logback configuration reset to what is defined on the class path or system properties: ${e.getMessage}")
+            Left(ApiError.BadRequest(s"Cannot apply logback configuration: ${e.getMessage}"))
         }
       case _ =>
         val message = "Can't update logging configuration, only logback is supported"

--- a/app/src/main/scala/org/alephium/explorer/web/UtilsServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/UtilsServer.scala
@@ -17,11 +17,19 @@
 package org.alephium.explorer.web
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util._
 
+import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
+import ch.qos.logback.classic.{Level, Logger, LoggerContext}
+import ch.qos.logback.classic.joran.JoranConfigurator
+import ch.qos.logback.classic.util.ContextInitializer
+import org.slf4j.LoggerFactory
 import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
+import sttp.model.StatusCode
 
+import org.alephium.api.ApiError
 import org.alephium.explorer.{sideEffect, GroupSetting}
 import org.alephium.explorer.api.UtilsEndpoints
 import org.alephium.explorer.cache.BlockCache
@@ -39,5 +47,58 @@ class UtilsServer()(implicit val executionContext: ExecutionContext,
     toRoute(sanityCheck.serverLogicSuccess[Future] { _ =>
       sideEffect(SanityChecker.check())
       Future.successful(())
-    })
+    }) ~
+      toRoute(changeGlobalLogLevel.serverLogic[Future] { level =>
+        Future.successful(updateGlobalLevel(level))
+      }) ~
+      toRoute(changeLogConfig.serverLogic[Future] { logbackConfig =>
+        Future.successful(updateLoggerContext(logbackConfig))
+      })
+
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
+  private def updateGlobalLevel(level: String): Either[ApiError[_ <: StatusCode], Unit] = {
+    val root = LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME).asInstanceOf[Logger];
+    Try(root.setLevel(Level.valueOf(level))) match {
+      case Success(_) =>
+        logger.info(s"Logging level updated to $level.")
+        Right(())
+      case Failure(error) =>
+        val errorMessage = s"Cannot apply logback configuation: $error"
+        logger.error(errorMessage)
+        Left(ApiError.BadRequest(errorMessage))
+    }
+  }
+
+  private def updateLoggerContext(
+      logbackConfig: String): Either[ApiError[_ <: StatusCode], Unit] = {
+
+    val loggerFactory = LoggerFactory.getILoggerFactory()
+
+    loggerFactory match {
+      case logbackCtx: LoggerContext =>
+        val configurator = new JoranConfigurator();
+        logbackCtx.reset
+        configurator.setContext(logbackCtx);
+
+        val stream = new java.io.ByteArrayInputStream(
+          logbackConfig.trim().getBytes(java.nio.charset.StandardCharsets.UTF_8.name)
+        )
+
+        Try(configurator.doConfigure(stream)) match {
+          case Success(_) =>
+            logger.info("Logback configuration updated OK.")
+            Right(())
+          case Failure(e) =>
+            val init = new ContextInitializer(logbackCtx)
+            init.autoConfig
+            logger.warn(
+              s"Cannot apply logback configuation, Logback configuration reset to what is defined on the class path or system properties: ${e.getMessage}")
+            Left(ApiError.BadRequest(s"Cannot apply logback configuation: ${e.getMessage}"))
+        }
+      case _ =>
+        val message = "Can't update logging configuration, only logback is supported"
+        logger.error(message)
+        Left(ApiError.BadRequest(message))
+    }
+  }
 }

--- a/app/src/test/scala/org/alephium/explorer/web/UtilsServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/UtilsServerSpec.scala
@@ -1,0 +1,97 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.web
+
+import scala.io.Source
+
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCodes}
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import de.heikoseeberger.akkahttpupickle.UpickleCustomizationSupport
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.concurrent.ScalaFutures
+
+import org.alephium.api.ApiError
+import org.alephium.explorer.{AlephiumSpec, Generators, GroupSetting, Main}
+import org.alephium.explorer.cache.{BlockCache, TransactionCache}
+import org.alephium.explorer.persistence.DatabaseFixtureForEach
+import org.alephium.explorer.service._
+import org.alephium.explorer.util.TestUtils._
+import org.alephium.json.Json
+
+@SuppressWarnings(Array("org.wartremover.warts.Var"))
+class UtilsServerSpec()
+    extends AlephiumSpec
+    with AkkaDecodeFailureHandler
+    with DatabaseFixtureForEach
+    with ScalaFutures
+    with ScalatestRouteTest
+    with UpickleCustomizationSupport
+    with MockFactory {
+  override type Api = Json.type
+
+  override def api: Api = Json
+
+  it should "update global loglevel" in new Fixture {
+    List("TRACE", "DEBUG", "INFO", "WARN", "ERROR").foreach { level =>
+      val entity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, level)
+      Put(s"/utils/update-global-loglevel", entity) ~> server.route ~> check {
+        status is StatusCodes.OK
+      }
+    }
+    List("Trace", "debug", "yop").foreach { level =>
+      val entity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, level)
+      Put(s"/utils/update-global-loglevel", entity) ~> server.route ~> check {
+        responseAs[ApiError.BadRequest] is ApiError.BadRequest(
+          s"Invalid value for: body (expected value to be within List(TRACE, DEBUG, INFO, WARN, ERROR), but was '$level')")
+      }
+    }
+  }
+
+  it should "update logback file" in new Fixture {
+    val logbackFile =
+      using(
+        Source.fromFile(name = Main.getClass.getResource("/logback.xml").getPath, enc = "UTF-8")
+      )(_.getLines().toList).mkString("\n")
+
+    val entity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, logbackFile)
+    Put(s"/utils/update-log-config", entity) ~> server.route ~> check {
+      status is StatusCodes.OK
+    }
+
+    val wrongConfig = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <configuration>
+        <configuration>
+    """
+    val wrongEntity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, wrongConfig)
+
+    Put(s"/utils/update-log-config", wrongEntity) ~> server.route ~> check {
+      responseAs[ApiError.BadRequest] is ApiError.BadRequest(
+        s"Cannot apply logback configuation: Problem parsing XML document. See previously reported errors.")
+    }
+  }
+
+  trait Fixture extends Generators {
+    implicit val blockFlowClient: BlockFlowClient   = mock[BlockFlowClient]
+    implicit val groupSettings: GroupSetting        = GroupSetting(groupNum)
+    implicit val blockCache: BlockCache             = BlockCache()
+    implicit val transactionCache: TransactionCache = TransactionCache()
+
+    val server =
+      new UtilsServer()
+  }
+}


### PR DESCRIPTION
Resolves: #196

`update-global-loglevel` takes a single string to update our global log
level (e.g: DEBUG)

`update-log-config` takes a full `logback.xml` file