### PR TITLE
Removes remaining calls to `sys.exit`

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/AkkaHttpServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/AkkaHttpServer.scala
@@ -30,7 +30,7 @@ final case class AkkaHttpServer(server: Http.ServerBinding, routes: Route, actor
     extends StrictLogging {
 
   /** Stop AkkaHttp server and terminates ActorSystem */
-  def stop()(implicit ec: ExecutionContext): Future[Unit] =
+  def close()(implicit ec: ExecutionContext): Future[Unit] =
     server //Stop server to terminate receiving http requests
       .close()
       .recoverWith { throwable =>

--- a/app/src/main/scala/org/alephium/explorer/ExplorerCloser.scala
+++ b/app/src/main/scala/org/alephium/explorer/ExplorerCloser.scala
@@ -1,0 +1,30 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/** Background services like sync requires system shutdown when they encounter an invalid state.
+  * This trait exposes only the `close` function from [[org.alephium.explorer.ExplorerState]].
+  *
+  **/
+trait ExplorerCloser {
+
+  /** Closes the explorer */
+  def close()(implicit ec: ExecutionContext): Future[Unit]
+
+}

--- a/app/src/main/scala/org/alephium/explorer/error/ExplorerError.scala
+++ b/app/src/main/scala/org/alephium/explorer/error/ExplorerError.scala
@@ -22,6 +22,7 @@ import akka.http.scaladsl.model.Uri
 
 import org.alephium.explorer.config.ApplicationConfig
 import org.alephium.protocol.model.NetworkId
+import org.alephium.serde.SerdeError
 
 /** All Explorer errors */
 sealed trait ExplorerError extends Throwable
@@ -51,6 +52,10 @@ object ExplorerError {
 
   final case class PeersNotFound(blockFlowUri: Uri)
       extends Exception(s"Peers not found. blockFlowUri: $blockFlowUri")
+      with FatalSystemExit
+
+  final case class InvalidMigrationVersion(error: SerdeError)
+      extends Exception("Invalid migration version", error)
       with FatalSystemExit
 
   /******** Group: [[ConfigError]] ********/

--- a/app/src/main/scala/org/alephium/explorer/error/ExplorerError.scala
+++ b/app/src/main/scala/org/alephium/explorer/error/ExplorerError.scala
@@ -33,8 +33,6 @@ sealed trait ConfigError extends ExplorerError
 /** Errors that lead to JVM termination */
 sealed trait FatalSystemExit extends ExplorerError
 
-//scalastyle:off null
-@SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
 object ExplorerError {
 
   /******** Group: [[FatalSystemExit]] ********/

--- a/app/src/main/scala/org/alephium/explorer/error/ExplorerError.scala
+++ b/app/src/main/scala/org/alephium/explorer/error/ExplorerError.scala
@@ -23,6 +23,7 @@ import akka.http.scaladsl.model.Uri
 import org.alephium.explorer.config.ApplicationConfig
 import org.alephium.protocol.model.NetworkId
 import org.alephium.serde.SerdeError
+import org.alephium.util.TimeStamp
 
 /** All Explorer errors */
 sealed trait ExplorerError extends Throwable
@@ -54,6 +55,11 @@ object ExplorerError {
 
   final case class InvalidMigrationVersion(error: SerdeError)
       extends Exception("Invalid migration version", error)
+      with FatalSystemExit
+
+  final case class InvalidMaxRemoveTimeStamp(remote: TimeStamp, local: TimeStamp)
+      extends Exception(
+        s"Max remote timestamp ('$remote') should not be before local timestamp ('$local')")
       with FatalSystemExit
 
   /******** Group: [[ConfigError]] ********/

--- a/app/src/main/scala/org/alephium/explorer/util/AsyncCloseable.scala
+++ b/app/src/main/scala/org/alephium/explorer/util/AsyncCloseable.scala
@@ -26,6 +26,7 @@ import com.typesafe.scalalogging.StrictLogging
 import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
 
+import org.alephium.explorer.AkkaHttpServer
 import org.alephium.explorer.util.FutureUtil._
 
 /** Type-classes for things that can be terminated asynchronously */
@@ -59,10 +60,16 @@ object AsyncCloseable extends StrictLogging {
       }
   }
 
-  /** [[AsyncCloseable]] for Akka HTTP server */
-  implicit object AkkaHttpServerAsyncCloseable extends AsyncCloseable[Http.ServerBinding] {
+  /** [[AsyncCloseable]] for Akka HTTP server binding */
+  implicit object HttpServerBindingAsyncCloseable extends AsyncCloseable[Http.ServerBinding] {
     override def close(closeable: Http.ServerBinding)(implicit ec: ExecutionContext): Future[Unit] =
       closeable.unbind().mapSyncToUnit()
+  }
+
+  /** [[AsyncCloseable]] for Akka HTTP server binding */
+  implicit object AkkaHttpServerAsyncCloseable extends AsyncCloseable[AkkaHttpServer] {
+    override def close(closeable: AkkaHttpServer)(implicit ec: ExecutionContext): Future[Unit] =
+      closeable.close()
   }
 
   /** [[AsyncCloseable]] for Akka ActorSystem */

--- a/app/src/test/scala/org/alephium/explorer/service/BlockFlowSyncServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/BlockFlowSyncServiceSpec.scala
@@ -24,7 +24,7 @@ import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.time.{Seconds, Span}
 
 import org.alephium.api.model.{ChainInfo, ChainParams, HashesAtHeight, SelfClique}
-import org.alephium.explorer.{AlephiumSpec, BlockHash, Generators, GroupSetting}
+import org.alephium.explorer.{AlephiumSpec, BlockHash, ExplorerCloser, Generators, GroupSetting}
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.cache.BlockCache
 import org.alephium.explorer.persistence.DatabaseFixtureForEach
@@ -70,6 +70,12 @@ class BlockFlowSyncServiceSpec
 
   it should "fetch and build timestamp range" in new Fixture {
 
+    implicit val terminator: ExplorerCloser =
+      new ExplorerCloser {
+        override def close()(implicit ec: ExecutionContext): Future[Unit] =
+          fail("Unexpected call to close")
+      }
+
     def th(ts: TimeStamp, height: Int) = Future.successful(Option((ts, height)))
 
     BlockFlowSyncService
@@ -87,6 +93,12 @@ class BlockFlowSyncServiceSpec
 
   it should "start/sync/stop" in new Fixture {
     using(Scheduler("")) { implicit scheduler =>
+      implicit val terminator: ExplorerCloser =
+        new ExplorerCloser {
+          override def close()(implicit ec: ExecutionContext): Future[Unit] =
+            fail("Unexpected call to close")
+        }
+
       checkBlocks(Seq.empty)
       BlockFlowSyncService.start(Seq(""), 1.second)
 


### PR DESCRIPTION
- Resolves #246
- Removes the last two remaining calls to `sys.exit`.
- Rearranged the order of startup sequence so background services like `sync` can get access to `ExplorerCloser`.