### PR TITLE
#210: Remove `lazy val` 

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/persistence/DBInitializer.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/DBInitializer.scala
@@ -87,11 +87,11 @@ object DBInitializer extends StrictLogging {
     logger.info("Create Indexes")
     run(for {
       _ <- BlockHeaderSchema.createBlockHeadersIndexesSQL()
-      _ <- TransactionSchema.createMainChainIndex
-      _ <- InputSchema.createMainChainIndex
-      _ <- OutputSchema.createMainChainIndex
-      _ <- TransactionPerAddressSchema.createMainChainIndex
-      _ <- OutputSchema.createNonSpentIndex
+      _ <- TransactionSchema.createMainChainIndex()
+      _ <- InputSchema.createMainChainIndex()
+      _ <- OutputSchema.createMainChainIndex()
+      _ <- TransactionPerAddressSchema.createMainChainIndex()
+      _ <- OutputSchema.createNonSpentIndex()
     } yield ())
   }
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/AppStateSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/AppStateSchema.scala
@@ -23,7 +23,7 @@ import slick.lifted.ProvenShape
 import org.alephium.explorer.persistence.model.AppState
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 
-object AppStateSchema extends SchemaMainChain[AppState]("app_state") {
+object AppStateSchema extends Schema[AppState]("app_state") {
 
   class AppStates(tag: Tag) extends Table[AppState](tag, name) {
     def key: Rep[String]       = column[String]("key", O.PrimaryKey)

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/BlockHeaderSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/BlockHeaderSchema.scala
@@ -86,7 +86,7 @@ object BlockHeaderSchema extends SchemaMainChain[BlockHeader]("block_headers") {
     * Joins all indexes created via raw SQL
     */
   def createBlockHeadersIndexesSQL(): DBIO[Unit] =
-    DBIO.seq(fullIndexSQL(), createMainChainIndex)
+    DBIO.seq(fullIndexSQL(), createMainChainIndex())
 
   val table: TableQuery[BlockHeaders] = TableQuery[BlockHeaders]
 }

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/OutputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/OutputSchema.scala
@@ -68,7 +68,7 @@ object OutputSchema extends SchemaMainChain[OutputEntity]("outputs") {
         .<>((OutputEntity.apply _).tupled, OutputEntity.unapply)
   }
 
-  lazy val createNonSpentIndex: DBActionW[Int] =
+  def createNonSpentIndex(): DBActionW[Int] =
     sqlu"create unique index if not exists non_spent_output_idx on #${name} (address, main_chain, key, block_hash) where spent_finalized IS NULL;"
 
   val table: TableQuery[Outputs] = TableQuery[Outputs]

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/SchemaMainChain.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/SchemaMainChain.scala
@@ -20,6 +20,6 @@ import slick.jdbc.PostgresProfile.api._
 import slick.sql.SqlAction
 
 abstract class SchemaMainChain[A](name: String) extends Schema[A](name) {
-  lazy val createMainChainIndex: SqlAction[Int, NoStream, Effect] =
+  def createMainChainIndex(): SqlAction[Int, NoStream, Effect] =
     sqlu"create index if not exists #${name}_main_chain_idx on #${name} (main_chain) where main_chain = true;"
 }

--- a/benchmark/src/main/scala/org/alephium/explorer/benchmark/db/state/AddressReadState.scala
+++ b/benchmark/src/main/scala/org/alephium/explorer/benchmark/db/state/AddressReadState.scala
@@ -177,11 +177,11 @@ class AddressReadState(val db: DBExecutor)
         .andThen(TransactionPerAddressSchema.table.schema.create)
         .andThen(AppStateSchema.table.schema.create)
         .andThen(BlockHeaderSchema.createBlockHeadersIndexesSQL())
-        .andThen(TransactionSchema.createMainChainIndex)
-        .andThen(InputSchema.createMainChainIndex)
-        .andThen(OutputSchema.createMainChainIndex)
-        .andThen(TransactionPerAddressSchema.createMainChainIndex)
-        .andThen(OutputSchema.createNonSpentIndex)
+        .andThen(TransactionSchema.createMainChainIndex())
+        .andThen(InputSchema.createMainChainIndex())
+        .andThen(OutputSchema.createMainChainIndex())
+        .andThen(TransactionPerAddressSchema.createMainChainIndex())
+        .andThen(OutputSchema.createNonSpentIndex())
 
     val _ = db.runNow(
       action  = createTable,

--- a/benchmark/src/main/scala/org/alephium/explorer/benchmark/db/state/ListBlocksReadState.scala
+++ b/benchmark/src/main/scala/org/alephium/explorer/benchmark/db/state/ListBlocksReadState.scala
@@ -125,7 +125,7 @@ class ListBlocksReadState(reverse: Boolean,
     //Persist transactions
     val persistTransactions =
       TransactionSchema.table.schema.create
-        .andThen(TransactionSchema.createMainChainIndex)
+        .andThen(TransactionSchema.createMainChainIndex())
         .andThen(TransactionSchema.table ++= transactions)
 
     val _ = db.runNow(


### PR DESCRIPTION
- Removed `AppStateSchema` extending `SchemaMainChain` because it does not create `main_chain` column or index. 
- #210: Removed `lazy val` from `create*Index` because they are not concurrently initialised or need to be kept alive throughout the application. Should be discarded by GC after DB is initialised.