### PR TITLE
#283: Remove unneeded index `deps_hash_idx`

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/BlockDepsSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/BlockDepsSchema.scala
@@ -31,7 +31,6 @@ object BlockDepsSchema extends Schema[BlockDepEntity]("block_deps") {
     def depOrder: Rep[Int]         = column[Int]("dep_order")
 
     def pk: PrimaryKey = primaryKey("hash_deps_pk", (hash, dep))
-    def hashIdx: Index = index("deps_hash_idx", hash)
     def depIdx: Index  = index("deps_dep_idx", dep)
 
     def * : ProvenShape[BlockDepEntity] =


### PR DESCRIPTION
#283: Removes `deps_hash_idx` from table `block_deps`, already indexed in primary key index `hash_deps_pk`.