### PR TITLE
Prepared-statement `getBlockHeaderAction`

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockDepQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockDepQueries.scala
@@ -17,12 +17,21 @@
 package org.alephium.explorer.persistence.queries
 
 import slick.jdbc.{PositionedParameters, SetParameter, SQLActionBuilder}
+import slick.jdbc.PostgresProfile.api._
 
+import org.alephium.explorer.api.model.BlockEntry
 import org.alephium.explorer.persistence.DBActionW
 import org.alephium.explorer.persistence.model.BlockDepEntity
+import org.alephium.explorer.persistence.schema.BlockDepsSchema
+import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
 
 object BlockDepQueries {
+
+  @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
+  val getDepsForBlock = Compiled { blockHash: Rep[BlockEntry.Hash] =>
+    BlockDepsSchema.table.filter(_.hash === blockHash).sortBy(_.depOrder).map(_.dep)
+  }
 
   /**
     * Insert block_deps or ignore if there is a primary key conflict.

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
@@ -69,7 +69,7 @@ object BlockQueries extends StrictLogging {
     sql"""
        |SELECT *
        |FROM #$block_headers
-       |WHERE hash = decode(${hash.toString()}, 'hex')
+       |WHERE hash = $hash
        |""".stripMargin
       .as[BlockHeader](blockHeaderGetResult)
       .headOption

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
@@ -69,15 +69,14 @@ object BlockQueries extends StrictLogging {
       blocks  <- DBIOAction.sequence(headers.map(buildBlockEntryAction))
     } yield blocks.headOption
 
-  def getBlockHeaderAction(hash: BlockEntry.Hash): DBActionR[Option[BlockHeader]] = {
+  def getBlockHeaderAction(hash: BlockEntry.Hash): DBActionR[Option[BlockHeader]] =
     sql"""
        |SELECT *
        |FROM #$block_headers
-       |WHERE hash = '\x#${hash.toString()}'
+       |WHERE hash = decode(${hash.toString()}, 'hex')
        |""".stripMargin
       .as[BlockHeader](blockHeaderGetResult)
       .headOption
-  }
 
   def getAtHeightAction(fromGroup: GroupIndex, toGroup: GroupIndex, height: Height)(
       implicit ec: ExecutionContext): DBActionR[Seq[BlockEntry]] =

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockQueriesSpec.scala
@@ -21,16 +21,14 @@ import scala.concurrent.ExecutionContext
 import org.scalacheck.Gen
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Minutes, Span}
-import org.scalatest.wordspec.AnyWordSpec
 import slick.jdbc.PostgresProfile.api._
 
-import org.alephium.explorer.AlephiumSpec._
-import org.alephium.explorer.Generators
+import org.alephium.explorer.{AlephiumSpec, Generators}
 import org.alephium.explorer.persistence.{DatabaseFixtureForEach, DBRunner}
 import org.alephium.explorer.persistence.schema._
 
 class BlockQueriesSpec
-    extends AnyWordSpec
+    extends AlephiumSpec
     with DatabaseFixtureForEach
     with DBRunner
     with Generators


### PR DESCRIPTION
- Removed splicing from `getBlockHeaderAction` to favour prepared-statements.
- Added test-cases for above.
- fix typo: ingored => ignored.
- Moved `blockDepsQuery` from `BlockQueries` to `BlockDepQueries` and renamed it to `getDepsForBlock`.