### PR TITLE
#206: Transactional `BlockDao.updateInputs`

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/persistence/dao/BlockDao.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/dao/BlockDao.scala
@@ -178,9 +178,9 @@ object BlockDao {
     }
   }
 
-  def updateInputs(inputs: Seq[InputEntity])(implicit ec: ExecutionContext,
-                                             dc: DatabaseConfig[PostgresProfile]): Future[Int] =
-    run(
-      DBIOAction.sequence(inputs.map(insertTxPerAddressFromInput))
-    ).map(_.sum)
+  def updateInputs(inputs: Seq[InputEntity])(implicit ec: ExecutionContext): DBActionT[Int] =
+    DBIOAction
+      .sequence(inputs.map(insertTxPerAddressFromInput))
+      .map(_.sum)
+      .transactionally
 }

--- a/app/src/main/scala/org/alephium/explorer/persistence/package.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/package.scala
@@ -23,6 +23,7 @@ package object persistence {
   type DBAction[A, E <: Effect] = DBIOAction[A, NoStream, E]
   type DBActionR[A]             = DBIOAction[A, NoStream, Effect.Read]
   type DBActionW[A]             = DBIOAction[A, NoStream, Effect.Write]
+  type DBActionT[A]             = DBIOAction[A, NoStream, Effect.Write with Effect.Transactional] //Transaction DBAction
   type DBActionRW[A]            = DBIOAction[A, NoStream, Effect.Read with Effect.Write]
   type DBActionRWT[A] =
     DBIOAction[A, NoStream, Effect.Read with Effect.Write with Effect.Transactional]

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/InputQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/InputQueries.scala
@@ -115,7 +115,7 @@ object InputQueries {
     sqlu"""
       INSERT INTO transaction_per_addresses (address, hash, block_hash, block_timestamp, tx_order, main_chain)
       (SELECT address, ${input.txHash}, ${input.blockHash}, ${input.timestamp}, ${input.txOrder}, main_chain FROM outputs WHERE key = ${input.outputRefKey})
-      ON CONFLICT (hash, block_hash, address) DO NOTHING
+      ON CONFLICT ON CONSTRAINT txs_per_address_pk DO NOTHING
     """
   }
 

--- a/app/src/test/scala/org/alephium/explorer/GenModel.scala
+++ b/app/src/test/scala/org/alephium/explorer/GenModel.scala
@@ -1,0 +1,55 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+package org.alephium.explorer
+
+import org.scalacheck.Gen
+
+import org.alephium.explorer.persistence.model._
+
+/** Test-data generators for types in package [[org.alephium.explorer.persistence.model]]  */
+object GenModel extends Generators {
+
+  /** Generates and [[org.alephium.explorer.persistence.model.InputEntity]] for the given
+    * [[org.alephium.explorer.persistence.model.OutputEntity]] generator */
+  @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
+  def genInputOutput(
+      outputGen: Gen[OutputEntity] = outputEntityGen): Gen[(InputEntity, OutputEntity)] =
+    for {
+      output <- outputGen
+      input  <- inputEntityGen(output)
+    } yield (input, output)
+
+  /** Convert input-output to [[org.alephium.explorer.persistence.model.TransactionPerAddressEntity]] */
+  def toTransactionPerAddressEntity(input: InputEntity,
+                                    output: OutputEntity): TransactionPerAddressEntity =
+    TransactionPerAddressEntity(
+      hash      = output.txHash,
+      address   = output.address,
+      blockHash = output.blockHash,
+      timestamp = output.timestamp,
+      txOrder   = input.txOrder,
+      mainChain = output.mainChain
+    )
+
+  /** Convert multiple input-outputs to [[org.alephium.explorer.persistence.model.TransactionPerAddressEntity]] */
+  def toTransactionPerAddressEntities(
+      inputOutputs: Iterable[(InputEntity, OutputEntity)]): Iterable[TransactionPerAddressEntity] =
+    inputOutputs map {
+      case (input, output) =>
+        toTransactionPerAddressEntity(input, output)
+    }
+
+}

--- a/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
@@ -27,7 +27,7 @@ import org.scalatest.time.{Minutes, Span}
 import org.alephium.explorer.{AlephiumSpec, BlockHash, Generators, GroupSetting}
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.cache.BlockCache
-import org.alephium.explorer.persistence.DatabaseFixtureForEach
+import org.alephium.explorer.persistence.{DatabaseFixtureForEach, DBRunner}
 import org.alephium.explorer.persistence.dao.{BlockDao, UnconfirmedTxDao}
 import org.alephium.explorer.persistence.model._
 import org.alephium.protocol.ALPH
@@ -195,7 +195,7 @@ class TransactionServiceSpec
     Future.sequence(blocks.map(BlockDao.insert)).futureValue
     val inputsToUpdate =
       Future.sequence(blocks.map(BlockDao.updateTransactionPerAddress)).futureValue.flatten
-    BlockDao.updateInputs(inputsToUpdate).futureValue
+    DBRunner.run(BlockDao.updateInputs(inputsToUpdate)).futureValue
 
     val t0 = Transaction(
       tx0.hash,


### PR DESCRIPTION
- #206 - Updated `BlockDao.updateInputs` to be transactional.
- Added test-cases for above.
- Updated query `insertTxPerAddressFromInput` to use primary key constraint `txs_per_address_pk`.