### PR TITLE
Switch to `AnyWordSpec`

### DIFF
--- a/app/src/test/scala/org/alephium/explorer/AlephiumActorSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/AlephiumActorSpec.scala
@@ -24,9 +24,9 @@ import org.scalatest.BeforeAndAfterAll
 class AlephiumActorSpec(val name: String) extends AlephiumActorSpecLike
 
 trait AlephiumActorSpecLike
-    extends TestKitBase
+    extends AlephiumSpec
+    with TestKitBase
     with ImplicitSender
-    with AlephiumSpec
     with BeforeAndAfterAll {
 
   def name: String

--- a/app/src/test/scala/org/alephium/explorer/AlephiumSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/AlephiumSpec.scala
@@ -22,12 +22,12 @@ import org.scalacheck.Shrink
 import org.scalactic.Equality
 import org.scalactic.source.Position
 import org.scalatest.Assertion
-import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.dsl.ResultOfATypeInvocation
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-trait AlephiumSpec extends AnyFlatSpecLike with ScalaCheckDrivenPropertyChecks with Matchers {
+trait AlephiumSpec extends AnyWordSpec with ScalaCheckDrivenPropertyChecks with Matchers {
   @nowarn protected implicit def noShrink[A]: Shrink[A] = Shrink(_ => Stream.empty)
 
   // scalastyle:off no.should
@@ -40,5 +40,3 @@ trait AlephiumSpec extends AnyFlatSpecLike with ScalaCheckDrivenPropertyChecks w
     // scalastyle:on scalatest-matcher
   }
 }
-
-object AlephiumSpec extends AlephiumSpec

--- a/app/src/test/scala/org/alephium/explorer/ExplorerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/ExplorerSpec.scala
@@ -113,7 +113,7 @@ trait ExplorerSpec
   val routes: Route = null //app.server.route
   //scalastyle:on null
 
-  ignore should "get a block by its id" in {
+  "get a block by its id" ignore {
 //    initApp(app)
 
     forAll(Gen.oneOf(blocks)) { block =>
@@ -136,7 +136,7 @@ trait ExplorerSpec
     }
   }
 
-  ignore should "get block's transactions" in {
+  "get block's transactions" ignore {
     forAll(Gen.oneOf(blocks)) { block =>
       Get(s"/blocks/${block.hash.value.toHexString}/transactions") ~> routes ~> check {
         val txs = responseAs[Seq[Transaction]]
@@ -147,7 +147,7 @@ trait ExplorerSpec
     }
   }
 
-  ignore should "list blocks" in {
+  "list blocks" ignore {
     forAll(Gen.choose(1, 3), Gen.choose(2, 4)) {
       case (page, limit) =>
         Get(s"/blocks?page=$page&limit=$limit") ~> routes ~> check {
@@ -218,7 +218,7 @@ trait ExplorerSpec
     }
   }
 
-  ignore should "get a transaction by its id" in {
+  "get a transaction by its id" ignore {
     forAll(Gen.oneOf(transactions)) { transaction =>
       Get(s"/transactions/${transaction.hash.value.toHexString}") ~> routes ~> check {
         //TODO Validate full transaction when we have a valid blockchain generator
@@ -234,7 +234,7 @@ trait ExplorerSpec
     }
   }
 
-  ignore should "get address' info" in {
+  "get address' info" ignore {
     forAll(Gen.oneOf(addresses)) { address =>
       Get(s"/addresses/${address}") ~> routes ~> check {
         val expectedTransactions =
@@ -258,7 +258,7 @@ trait ExplorerSpec
     }
   }
 
-  ignore should "get all address' transactions" in {
+  "get all address' transactions" ignore {
     forAll(Gen.oneOf(addresses)) { address =>
       Get(s"/addresses/${address}/transactions") ~> routes ~> check {
         val expectedTransactions =
@@ -272,7 +272,7 @@ trait ExplorerSpec
     }
   }
 
-  ignore should "generate the documentation" in {
+  "generate the documentation" ignore {
     Get("/docs") ~> routes ~> check {
       status is StatusCodes.PermanentRedirect
     }
@@ -420,7 +420,7 @@ class ReadOnlyExplorerSpec extends ExplorerSpec {
 
 //  override lazy val app: Application = createApp(true)
 
-  ignore should "not have started syncing services" in {
+  "not have started syncing services" ignore {
 //    whenReady(app.blockFlowSyncService.stop().failed) { exception =>
 //      exception is a[IllegalStateException]
 //    }

--- a/app/src/test/scala/org/alephium/explorer/ExplorerV2Spec.scala
+++ b/app/src/test/scala/org/alephium/explorer/ExplorerV2Spec.scala
@@ -25,12 +25,10 @@ import org.scalatest.TryValues._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Seconds, Span}
-import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
 
-import org.alephium.explorer.AlephiumSpec._
 import org.alephium.explorer.GenCoreApi._
 import org.alephium.explorer.GenCoreProtocol._
 import org.alephium.explorer.config.{ApplicationConfig, ExplorerConfig}
@@ -40,7 +38,7 @@ import org.alephium.explorer.service.BlockFlowClient
 
 /** Temporary placeholder. These tests should be merged into ApplicationSpec  */
 class ExplorerV2Spec
-    extends AnyWordSpec
+    extends AlephiumSpec
     with Matchers
     with ScalaCheckDrivenPropertyChecks
     with ScalaFutures

--- a/app/src/test/scala/org/alephium/explorer/api/model/ApiModelSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/api/model/ApiModelSpec.scala
@@ -26,12 +26,12 @@ class ApiModelSpec() extends AlephiumSpec with Generators {
     read[T](jsonRaw) is data
   }
 
-  it should "IntervalType" in {
+  "IntervalType" in {
     check[IntervalType](IntervalType.Hourly, s""""hourly"""")
     check[IntervalType](IntervalType.Daily, s""""daily"""")
   }
 
-  it should "Transaction" in {
+  "Transaction" in {
     forAll(transactionGen) { tx =>
       val expected = s"""
        |{
@@ -47,7 +47,7 @@ class ApiModelSpec() extends AlephiumSpec with Generators {
     }
   }
 
-  it should "ConfirmedTransaction" in {
+  "ConfirmedTransaction" in {
     forAll(transactionGen) { tx =>
       val expected = s"""
        |{
@@ -64,7 +64,7 @@ class ApiModelSpec() extends AlephiumSpec with Generators {
     }
   }
 
-  it should "Output.Ref" in {
+  "Output.Ref" in {
     forAll(outputRefGen) { outputRef =>
       val expected = s"""
      |{
@@ -75,7 +75,7 @@ class ApiModelSpec() extends AlephiumSpec with Generators {
     }
   }
 
-  it should "Output" in {
+  "Output" in {
     forAll(outputGen) { output =>
       val expected = s"""
      |{
@@ -90,7 +90,7 @@ class ApiModelSpec() extends AlephiumSpec with Generators {
     }
   }
 
-  it should "Input" in {
+  "Input" in {
     forAll(inputGen) { input =>
       val expected = s"""
      |{
@@ -104,7 +104,7 @@ class ApiModelSpec() extends AlephiumSpec with Generators {
     }
   }
 
-  it should "UInput" in {
+  "UInput" in {
     forAll(uinputGen) { uinput =>
       val expected = uinput.unlockScript match {
         case None =>
@@ -123,7 +123,7 @@ class ApiModelSpec() extends AlephiumSpec with Generators {
     }
   }
 
-  it should "UnconfirmedTx" in {
+  "UnconfirmedTx" in {
     forAll(utransactionGen) { utx =>
       val expected = s"""
      |{
@@ -140,7 +140,7 @@ class ApiModelSpec() extends AlephiumSpec with Generators {
     }
   }
 
-  it should "ExplorerInfo" in {
+  "ExplorerInfo" in {
     val expected = s"""
      |{
      |  "releaseVersion": "1.2.3",

--- a/app/src/test/scala/org/alephium/explorer/cache/AsyncReloadingCacheSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/cache/AsyncReloadingCacheSpec.scala
@@ -30,7 +30,7 @@ class AsyncReloadingCacheSpec extends AlephiumSpec with ScalaFutures with Eventu
 
   implicit val executionContext: ExecutionContext = ExecutionContext.global
 
-  it should "reload cache after expiration while returning existing value even during reloading" in {
+  "reload cache after expiration while returning existing value even during reloading" in {
     val reloadCount = new AtomicInteger() //number of times reload was executed
 
     //a cache with initial value as 1 and reload set to 1.second
@@ -55,7 +55,7 @@ class AsyncReloadingCacheSpec extends AlephiumSpec with ScalaFutures with Eventu
     reloadCount.get() is 3 //third reload
   }
 
-  it should "not allow multiple threads to concurrently execute reload" in {
+  "not allow multiple threads to concurrently execute reload" in {
     val reloadCount = new AtomicInteger() //number of times reload was executed
 
     //a cache with initial value as 1 and reload set to 2.seconds
@@ -81,7 +81,7 @@ class AsyncReloadingCacheSpec extends AlephiumSpec with ScalaFutures with Eventu
     }
   }
 
-  it should "expireAndReload immediately" in {
+  "expireAndReload immediately" in {
     val reloadCount = new AtomicInteger() //number of times reload was executed
 
     //long 1.hour reload timeout to test manual expireAndReload
@@ -115,7 +115,7 @@ class AsyncReloadingCacheSpec extends AlephiumSpec with ScalaFutures with Eventu
     }
   }
 
-  it should "reloadNow: should reload on boot" in {
+  "reloadNow: should reload on boot" in {
     AsyncReloadingCache
       .reloadNow(reloadAfter = 1.hour)(Future(Int.MaxValue))
       .futureValue

--- a/app/src/test/scala/org/alephium/explorer/cache/CaffeineAsyncCacheSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/cache/CaffeineAsyncCacheSpec.scala
@@ -25,7 +25,7 @@ import org.alephium.explorer.AlephiumSpec
 
 class CaffeineAsyncCacheSpec extends AlephiumSpec with ScalaFutures {
 
-  it should "return None for getIfPresent when cache is empty (NullPointerException check)" in {
+  "return None for getIfPresent when cache is empty (NullPointerException check)" in {
     val cache =
       CaffeineAsyncCache {
         Caffeine

--- a/app/src/test/scala/org/alephium/explorer/config/ApplicationConfigSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/config/ApplicationConfigSpec.scala
@@ -19,16 +19,14 @@ package org.alephium.explorer.config
 import scala.compat.java8.DurationConverters.DurationOps
 
 import org.scalatest.TryValues._
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-import org.alephium.explorer.AlephiumSpec.IsOps
+import org.alephium.explorer.AlephiumSpec
 import org.alephium.explorer.config.ApplicationConfig._
 import org.alephium.explorer.config.GenConfig._
 import org.alephium.explorer.error.ExplorerError.{EmptyApplicationConfig, InvalidApplicationConfig}
 
-class ApplicationConfigSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenPropertyChecks {
+class ApplicationConfigSpec extends AlephiumSpec with ScalaCheckDrivenPropertyChecks {
 
   "read valid configuration" in {
     forAll(genRawConfig()) { raw =>

--- a/app/src/test/scala/org/alephium/explorer/config/ExplorerConfigSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/config/ExplorerConfigSpec.scala
@@ -20,17 +20,16 @@ import scala.concurrent.duration._
 
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.TryValues._
-import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 import org.alephium.api.model.ApiKey
-import org.alephium.explorer.AlephiumSpec._
+import org.alephium.explorer.AlephiumSpec
 import org.alephium.explorer.GenCommon._
 import org.alephium.explorer.config.ExplorerConfig._
 import org.alephium.explorer.error.ExplorerError._
 import org.alephium.protocol.model.NetworkId
 
-class ExplorerConfigSpec extends AnyWordSpec with ScalaCheckDrivenPropertyChecks {
+class ExplorerConfigSpec extends AlephiumSpec with ScalaCheckDrivenPropertyChecks {
 
   "validateGroupNum" should {
     "fail validation" when {

--- a/app/src/test/scala/org/alephium/explorer/persistence/dao/BlockDaoSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/dao/BlockDaoSpec.scala
@@ -24,12 +24,10 @@ import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.time.{Minutes, Span}
-import org.scalatest.wordspec.AnyWordSpec
 import slick.jdbc.PostgresProfile.api._
 
 import org.alephium.api.{model, ApiModelCodec}
-import org.alephium.explorer.{Generators, GroupSetting}
-import org.alephium.explorer.AlephiumSpec._
+import org.alephium.explorer.{AlephiumSpec, Generators, GroupSetting}
 import org.alephium.explorer.GenModel._
 import org.alephium.explorer.api.model.{BlockEntry, GroupIndex, Pagination}
 import org.alephium.explorer.cache.BlockCache
@@ -44,7 +42,7 @@ import org.alephium.protocol.model.ChainIndex
 import org.alephium.util.{Duration, TimeStamp}
 
 class BlockDaoSpec
-    extends AnyWordSpec
+    extends AlephiumSpec
     with DatabaseFixtureForEach
     with DBRunner
     with ScalaFutures

--- a/app/src/test/scala/org/alephium/explorer/persistence/dao/UnconfirmedTxDaoSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/dao/UnconfirmedTxDaoSpec.scala
@@ -39,7 +39,7 @@ class UnconfirmedTxDaoSpec
   implicit val executionContext: ExecutionContext = ExecutionContext.global
   override implicit val patienceConfig            = PatienceConfig(timeout = Span(1, Minutes))
 
-  it should "insertMany" in {
+  "insertMany" in {
     forAll(Gen.listOfN(5, utransactionGen)) { txs =>
       UnconfirmedTxDao.insertMany(txs).futureValue
 
@@ -65,7 +65,7 @@ class UnconfirmedTxDaoSpec
     }
   }
 
-  it should "get" in {
+  "get" in {
     forAll(utransactionGen) { utx =>
       UnconfirmedTxDao.insertMany(Seq(utx)).futureValue
 
@@ -73,7 +73,7 @@ class UnconfirmedTxDaoSpec
     }
   }
 
-  it should "removeMany" in {
+  "removeMany" in {
     forAll(Gen.listOfN(5, utransactionGen)) { txs =>
       UnconfirmedTxDao.insertMany(txs).futureValue
       UnconfirmedTxDao.removeMany(txs.map(_.hash)).futureValue
@@ -84,7 +84,7 @@ class UnconfirmedTxDaoSpec
     }
   }
 
-  it should "listHashes" in {
+  "listHashes" in {
     var hashes = Set.empty[Transaction.Hash]
     forAll(Gen.listOfN(5, utransactionGen)) { txs =>
       UnconfirmedTxDao.insertMany(txs).futureValue

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockDepQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockDepQueriesSpec.scala
@@ -38,7 +38,7 @@ class BlockDepQueriesSpec
   implicit val executionContext: ExecutionContext = ExecutionContext.global
   override implicit val patienceConfig            = PatienceConfig(timeout = Span(1, Minutes))
 
-  it should "insert and ignore block_deps" in {
+  "insert and ignore block_deps" in {
 
     forAll(Gen.listOf(blockDepUpdatedGen)) { deps =>
       //clean existing rows

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockQueriesSpec.scala
@@ -37,7 +37,7 @@ class BlockQueriesSpec
   implicit val executionContext: ExecutionContext = ExecutionContext.global
   override implicit val patienceConfig            = PatienceConfig(timeout = Span(1000, Minutes))
 
-  it should "insert and ignore block_headers" in {
+  "insert and ignore block_headers" in {
 
     forAll(Gen.listOf(updatedBlockHeaderGen())) { existingAndUpdates =>
       //fresh table
@@ -58,7 +58,7 @@ class BlockQueriesSpec
     }
   }
 
-  it should "insert deps, transactions, inputs, outputs, block_headers" in {
+  "insert deps, transactions, inputs, outputs, block_headers" in {
 
     forAll(Gen.listOf(genBlockEntityWithOptionalParent().map(_._1))) {
       case entities =>

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/InputQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/InputQueriesSpec.scala
@@ -39,7 +39,7 @@ class InputQueriesSpec
   implicit val executionContext: ExecutionContext = ExecutionContext.global
   override implicit val patienceConfig            = PatienceConfig(timeout = Span(1, Minutes))
 
-  it should "insert and ignore inputs" in {
+  "insert and ignore inputs" in {
 
     def runTest(existingAndUpdated: Seq[(InputEntity, InputEntity)]) = {
       //fresh table

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/OutputQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/OutputQueriesSpec.scala
@@ -38,7 +38,7 @@ class OutputQueriesSpec
   implicit val executionContext: ExecutionContext = ExecutionContext.global
   override implicit val patienceConfig            = PatienceConfig(timeout = Span(1, Minutes))
 
-  it should "insert and ignore outputs" in {
+  "insert and ignore outputs" in {
 
     forAll(Gen.listOf(updatedOutputEntityGen())) { existingAndUpdates =>
       //fresh table

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/QuerySplitterSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/QuerySplitterSpec.scala
@@ -63,7 +63,7 @@ class QuerySplitterSpec extends AlephiumSpec {
       result :+ Query(rows, placeHolders)
     }
 
-  it should "empty split when parameters are empty" in {
+  "empty split when parameters are empty" in {
 
     forAll(Gen.posNum[Short]) { queryMaxParams =>
       val queries =
@@ -78,7 +78,7 @@ class QuerySplitterSpec extends AlephiumSpec {
     }
   }
 
-  it should "split queries evenly when queryColumns & queryMaxParams are even" in {
+  "split queries evenly when queryColumns & queryMaxParams are even" in {
     val queries =
       getQueriesLimitByMaxParams(
         rows           = Seq(Row(1, 1), Row(2, 2), Row(3, 3), Row(4, 4), Row(5, 5), Row(6, 6)),
@@ -97,7 +97,7 @@ class QuerySplitterSpec extends AlephiumSpec {
     queries is expectedQueries
   }
 
-  it should "split queries when queryColumns & queryMaxParams are odd" in {
+  "split queries when queryColumns & queryMaxParams are odd" in {
     val queries =
       getQueriesLimitByMaxParams(
         //7 parameters
@@ -118,7 +118,7 @@ class QuerySplitterSpec extends AlephiumSpec {
     queries is expectedQueries
   }
 
-  it should "split when queryColumns == queryMaxParams" in {
+  "split when queryColumns == queryMaxParams" in {
     val queries =
       getQueriesLimitByMaxParams(
         rows           = Seq(Row(1, 1), Row(2, 2), Row(3, 3), Row(4, 4), Row(5, 5), Row(6, 6), Row(7, 7)),
@@ -141,7 +141,7 @@ class QuerySplitterSpec extends AlephiumSpec {
     queries is expectedQueries
   }
 
-  it should "split should generate a single query when all parameter can fit in a single query" in {
+  "split should generate a single query when all parameter can fit in a single query" in {
     val queries =
       getQueriesLimitByMaxParams(
         rows           = Seq(Row(1, 1), Row(2, 2), Row(3, 3), Row(4, 4), Row(5, 5), Row(6, 6), Row(7, 7)),
@@ -159,7 +159,7 @@ class QuerySplitterSpec extends AlephiumSpec {
     queries should contain only expectedQuery
   }
 
-  it should "Test following PR review comment in #162: See link below" in {
+  "Test following PR review comment in #162: See link below" in {
 
     /**
       * Test following <a href="https://github.com/alephium/explorer-backend/pull/162#discussion_r826874299">comment</a>.
@@ -225,7 +225,7 @@ class QuerySplitterSpec extends AlephiumSpec {
     querySplits.flatMap(_.rows) is rows
   }
 
-  it should "not exceed Short.MaxValue parameter per query limit allowed by Postgres" in {
+  "not exceed Short.MaxValue parameter per query limit allowed by Postgres" in {
 
     /** In reality this test-case is not expected to occur but for the sake of totality it is tested */
     //A row. This test doesn't check for actual column values so a Row object is enough.

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/TransactionQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/TransactionQueriesSpec.scala
@@ -45,7 +45,7 @@ class TransactionQueriesSpec
 
   implicit val executionContext: ExecutionContext = ExecutionContext.global
 
-  it should "compute locked balance when empty" in new Fixture {
+  "compute locked balance when empty" in new Fixture {
     val balanceOption = run(TransactionQueries.getBalanceActionOption(address)).futureValue
     balanceOption is ((None, None))
 
@@ -53,7 +53,7 @@ class TransactionQueriesSpec
     balance is ((U256.Zero, U256.Zero))
   }
 
-  it should "compute locked balance" in new Fixture {
+  "compute locked balance" in new Fixture {
 
     val output1 = output(address, ALPH.alph(1), None)
     val output2 =
@@ -70,7 +70,7 @@ class TransactionQueriesSpec
 
   }
 
-  it should "get balance should only return unpent outputs" in new Fixture {
+  "get balance should only return unpent outputs" in new Fixture {
 
     val output1 = output(address, ALPH.alph(1), None)
     val output2 = output(address, ALPH.alph(2), None)
@@ -92,7 +92,7 @@ class TransactionQueriesSpec
     totalFinalized is ALPH.alph(1)
   }
 
-  it should "get balance should only take main chain outputs" in new Fixture {
+  "get balance should only take main chain outputs" in new Fixture {
 
     val output1 = output(address, ALPH.alph(1), None)
     val output2 = output(address, ALPH.alph(2), None).copy(mainChain = false)
@@ -106,7 +106,7 @@ class TransactionQueriesSpec
     total is ALPH.alph(1)
   }
 
-  it should "txs count" in new Fixture {
+  "txs count" in new Fixture {
     val output1 = output(address, ALPH.alph(1), None)
     val output2 = output(address, ALPH.alph(2), None)
     val output3 = output(address, ALPH.alph(3), None).copy(mainChain = false)
@@ -128,7 +128,7 @@ class TransactionQueriesSpec
     totalSQLNoJoin is 3
   }
 
-  it should "return inputs to update if corresponding output is not inserted" in new Fixture {
+  "return inputs to update if corresponding output is not inserted" in new Fixture {
 
     val output1 = output(address, ALPH.alph(1), None)
     val output2 = output(address, ALPH.alph(2), None)
@@ -154,7 +154,7 @@ class TransactionQueriesSpec
     run(TransactionQueries.countAddressTransactionsSQLNoJoin(address)).futureValue.head is 3
   }
 
-  it should "get tx hashes by address" in new Fixture {
+  "get tx hashes by address" in new Fixture {
 
     val output1 = output(address, ALPH.alph(1), None)
     val output2 = output(address, ALPH.alph(2), None)
@@ -182,7 +182,7 @@ class TransactionQueriesSpec
     hashesSQLNoJoin is expected.toVector
   }
 
-  it should "outpus for txs" in new Fixture {
+  "outpus for txs" in new Fixture {
 
     val output1 = output(address, ALPH.alph(1), None)
     val output2 = output(address, ALPH.alph(2), None)
@@ -219,7 +219,7 @@ class TransactionQueriesSpec
     run(outputsFromTxsSQL(txHashes)).futureValue.sortBy(_._1.toString) is expected.toVector
   }
 
-  it should "inputs for txs" in new Fixture {
+  "inputs for txs" in new Fixture {
 
     val output1 = output(address, ALPH.alph(1), None)
     val output2 = output(address, ALPH.alph(2), None)
@@ -251,7 +251,7 @@ class TransactionQueriesSpec
     run(inputsFromTxsSQL(txHashes)).futureValue is expected.toVector
   }
 
-  it should "get tx by address" in new Fixture {
+  "get tx by address" in new Fixture {
     val output1 = output(address, ALPH.alph(1), None)
     val output2 = output(address, ALPH.alph(2), None)
     val output3 = output(address, ALPH.alph(3), None).copy(mainChain = false)
@@ -292,7 +292,7 @@ class TransactionQueriesSpec
     txsSQL is expected
   }
 
-  it should "output's spent info should only take the input from the main chain " in new Fixture {
+  "output's spent info should only take the input from the main chain " in new Fixture {
 
     val tx1 = transactionGen.sample.get
     val tx2 = transactionGen.sample.get
@@ -323,7 +323,7 @@ class TransactionQueriesSpec
     tx.outputs.size is 1 // was 2 in v1.4.1
   }
 
-  it should "insert and ignore transactions" in new Fixture {
+  "insert and ignore transactions" in new Fixture {
 
     forAll(Gen.listOf(updatedTransactionEntityGen())) { transactions =>
       run(TransactionSchema.table.delete).futureValue
@@ -342,11 +342,11 @@ class TransactionQueriesSpec
   }
 
   //https://github.com/alephium/explorer-backend/issues/174
-  it should "return an empty list when not transactions are found - Isssue 174" in new Fixture {
+  "return an empty list when not transactions are found - Isssue 174" in new Fixture {
     run(TransactionQueries.getTransactionsByAddressSQL(address, Pagination.unsafe(0, 10))).futureValue is Seq.empty
   }
 
-  it should "get total number of main transactions" in new Fixture {
+  "get total number of main transactions" in new Fixture {
 
     val tx1 = transactionEntityGen().sample.get.copy(mainChain = true)
     val tx2 = transactionEntityGen().sample.get.copy(mainChain = true)

--- a/app/src/test/scala/org/alephium/explorer/persistence/schema/CustomJdbcTypesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/schema/CustomJdbcTypesSpec.scala
@@ -40,7 +40,7 @@ class CustomJdbcTypesSpec
   implicit val executionContext: ExecutionContext = ExecutionContext.global
   override implicit val patienceConfig            = PatienceConfig(timeout = Span(1, Minutes))
 
-  it should "convert TimeStamp" in new Fixture {
+  "convert TimeStamp" in new Fixture {
 
     run(sqlu"DROP TABLE IF EXISTS timestamps;").futureValue
     run(timestampTable.schema.create).futureValue

--- a/app/src/test/scala/org/alephium/explorer/service/BlockFlowSyncServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/BlockFlowSyncServiceSpec.scala
@@ -45,7 +45,7 @@ class BlockFlowSyncServiceSpec
     with Eventually {
   override implicit val patienceConfig = PatienceConfig(timeout = Span(50, Seconds))
 
-  it should "build timestamp range" in new Fixture {
+  "build timestamp range" in new Fixture {
 
     BlockFlowSyncService.buildTimestampRange(t(0), t(5), s(1)) is
       Seq(r(0, 1), r(2, 3), r(4, 5))
@@ -69,7 +69,7 @@ class BlockFlowSyncServiceSpec
       Seq.empty
   }
 
-  it should "fetch and build timestamp range" in new Fixture {
+  "fetch and build timestamp range" in new Fixture {
 
     def th(ts: TimeStamp, height: Int) = Future.successful(Option((ts, height)))
 
@@ -86,7 +86,7 @@ class BlockFlowSyncServiceSpec
       .futureValue is ((Seq.empty, 0))
   }
 
-  it should "start/sync/stop" in new Fixture {
+  "start/sync/stop" in new Fixture {
     using(Scheduler("")) { implicit scheduler =>
       checkBlocks(Seq.empty)
       BlockFlowSyncService.start(Seq(""), 1.second)

--- a/app/src/test/scala/org/alephium/explorer/service/FinalizerServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/FinalizerServiceSpec.scala
@@ -36,11 +36,11 @@ class FinalizerServiceSpec
     with DBRunner
     with ScalaFutures {
   implicit val executionContext: ExecutionContext = ExecutionContext.global
-  it should "getStartEndTime - return nothing if there's no input" in new Fixture {
+  "getStartEndTime - return nothing if there's no input" in new Fixture {
     run(FinalizerService.getStartEndTime()).futureValue is None
   }
 
-  it should "getStartEndTime - return nothing if there's only 1 input" in new Fixture {
+  "getStartEndTime - return nothing if there's only 1 input" in new Fixture {
 
     val input1 = input(TimeStamp.now())
     run(InputQueries.insertInputs(Seq(input1))).futureValue
@@ -48,7 +48,7 @@ class FinalizerServiceSpec
     run(FinalizerService.getStartEndTime()).futureValue is None
   }
 
-  it should "getStartEndTime - return nothing if all inputs are after finalization time" in new Fixture {
+  "getStartEndTime - return nothing if all inputs are after finalization time" in new Fixture {
 
     val input1 = input(
       firstFinalizationTime.plusHoursUnsafe(1)
@@ -61,7 +61,7 @@ class FinalizerServiceSpec
     run(FinalizerService.getStartEndTime()).futureValue is None
   }
 
-  it should "getStartEndTime - return correct finalization time" in new Fixture {
+  "getStartEndTime - return correct finalization time" in new Fixture {
 
     val input1 = input(
       firstFinalizationTime.minusUnsafe(Duration.ofHoursUnsafe(10))

--- a/app/src/test/scala/org/alephium/explorer/service/HashrateServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/HashrateServiceSpec.scala
@@ -41,7 +41,7 @@ class HashrateServiceSpec
   implicit val executionContext: ExecutionContext = ExecutionContext.global
   override implicit val patienceConfig            = PatienceConfig(timeout = Span(1, Minutes))
 
-  it should "hourly hashrates" in new Fixture {
+  "hourly hashrates" in new Fixture {
 
     val blocks = Seq(
       b("2022-01-07T23:00:00.001Z", 2),
@@ -65,7 +65,7 @@ class HashrateServiceSpec
     )
   }
 
-  it should "daily hashrates" in new Fixture {
+  "daily hashrates" in new Fixture {
 
     val blocks = Seq(
       b("2022-01-07T00:00:00.001Z", 2),
@@ -95,7 +95,7 @@ class HashrateServiceSpec
       )
   }
 
-  it should "sync, update and return correct hashrates" in new Fixture {
+  "sync, update and return correct hashrates" in new Fixture {
 
     val blocks = Seq(
       b("2022-01-06T23:45:35.300Z", 1),
@@ -149,7 +149,7 @@ class HashrateServiceSpec
     )
   }
 
-  it should "correctly step back" in new Fixture {
+  "correctly step back" in new Fixture {
     {
       val timestamp = ts("2022-01-08T12:21:34.321Z")
 

--- a/app/src/test/scala/org/alephium/explorer/service/MempoolSyncServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/MempoolSyncServiceSpec.scala
@@ -43,7 +43,7 @@ class MempoolSyncServiceSpec
     with Eventually {
   override implicit val patienceConfig = PatienceConfig(timeout = Span(1, Minutes))
 
-  it should "start/sync/stop" in new Fixture {
+  "start/sync/stop" in new Fixture {
     using(Scheduler("test")) { implicit scheduler =>
       MempoolSyncService.start(Seq(""), 100.milliseconds)
 

--- a/app/src/test/scala/org/alephium/explorer/service/TokenSupplyServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TokenSupplyServiceSpec.scala
@@ -46,7 +46,7 @@ class TokenSupplyServiceSpec
   implicit val executionContext: ExecutionContext = ExecutionContext.global
   override implicit val patienceConfig            = PatienceConfig(timeout = Span(50, Seconds))
 
-  it should "Build days range" in {
+  "Build days range" in {
     val launchTime = ALPH.LaunchTimestamp //2021-11-08T11:20:06+00:00
     def ts(str: String): TimeStamp = {
       TimeStamp.unsafe(Instant.parse(str).toEpochMilli)
@@ -93,7 +93,7 @@ class TokenSupplyServiceSpec
       )
   }
 
-  it should "Token supply - only genesis - no lock" in new Fixture {
+  "Token supply - only genesis - no lock" in new Fixture {
     override val genesisLocked = false
 
     test(genesisBlock) {
@@ -101,7 +101,7 @@ class TokenSupplyServiceSpec
     }
   }
 
-  it should "Token supply - only genesis - locked" in new Fixture {
+  "Token supply - only genesis - locked" in new Fixture {
     override val genesisLocked = true
 
     test(genesisBlock) {
@@ -109,7 +109,7 @@ class TokenSupplyServiceSpec
     }
   }
 
-  it should "Token supply - block 1 not locked" in new Fixture {
+  "Token supply - block 1 not locked" in new Fixture {
     override val genesisLocked = false
 
     test(genesisBlock, block1, block2) {
@@ -120,7 +120,7 @@ class TokenSupplyServiceSpec
     }
   }
 
-  it should "Token supply - block 1 locked" in new Fixture {
+  "Token supply - block 1 locked" in new Fixture {
     override val genesisLocked = false
     override val block1Locked  = true
 
@@ -129,7 +129,7 @@ class TokenSupplyServiceSpec
     }
   }
 
-  it should "Token supply - some output spent" in new Fixture {
+  "Token supply - some output spent" in new Fixture {
     override val genesisLocked = false
 
     test(genesisBlock, block1, block2, block3) {
@@ -137,7 +137,7 @@ class TokenSupplyServiceSpec
     }
   }
 
-  it should "Token supply - genesis locked - some output spent" in new Fixture {
+  "Token supply - genesis locked - some output spent" in new Fixture {
     override val genesisLocked = true
 
     test(genesisBlock, block1, block2, block3) {
@@ -145,7 +145,7 @@ class TokenSupplyServiceSpec
     }
   }
 
-  it should "Token supply - Not count excluded addresses" in new Fixture {
+  "Token supply - Not count excluded addresses" in new Fixture {
     override val genesisLocked = true
 
     test(genesisBlock, block1, block2, block3, block4) {

--- a/app/src/test/scala/org/alephium/explorer/service/TransactionHistoryServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TransactionHistoryServiceSpec.scala
@@ -22,11 +22,9 @@ import scala.concurrent.ExecutionContext
 
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.time.{Minutes, Span}
-import org.scalatest.wordspec.AnyWordSpec
 import slick.jdbc.PostgresProfile.api._
 
-import org.alephium.explorer.{Generators, GroupSetting}
-import org.alephium.explorer.AlephiumSpec._
+import org.alephium.explorer.{AlephiumSpec, Generators, GroupSetting}
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.persistence.{DatabaseFixtureForEach, DBRunner}
 import org.alephium.explorer.persistence.model.TransactionEntity
@@ -34,7 +32,7 @@ import org.alephium.explorer.persistence.schema.TransactionSchema
 import org.alephium.util._
 
 class TransactionHistoryServiceSpec
-    extends AnyWordSpec
+    extends AlephiumSpec
     with DatabaseFixtureForEach
     with DBRunner
     with Generators

--- a/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
@@ -47,7 +47,7 @@ class TransactionServiceSpec
   implicit val executionContext: ExecutionContext = ExecutionContext.global
   override implicit val patienceConfig            = PatienceConfig(timeout = Span(1, Minutes))
 
-  it should "limit the number of transactions in address details" in new Fixture {
+  "limit the number of transactions in address details" in new Fixture {
 
     val address = addressGen.sample.get
 
@@ -77,7 +77,7 @@ class TransactionServiceSpec
       .size is txLimit
   }
 
-  it should "handle huge alph number" in new Fixture {
+  "handle huge alph number" in new Fixture {
 
     val amount = ALPH.MaxALPHValue.mulUnsafe(ALPH.MaxALPHValue)
 
@@ -100,7 +100,7 @@ class TransactionServiceSpec
     fetchedAmout is amount
   }
 
-  it should "get all transactions for an address even when outputs don't contain that address" in new Fixture {
+  "get all transactions for an address even when outputs don't contain that address" in new Fixture {
 
     val address0 = addressGen.sample.get
     val address1 = addressGen.sample.get
@@ -223,7 +223,7 @@ class TransactionServiceSpec
     res2 is Seq(t1, t0)
   }
 
-  it should "get only main chain transaction for an address in case of tx in two blocks (in case of reorg)" in new Fixture {
+  "get only main chain transaction for an address in case of tx in two blocks (in case of reorg)" in new Fixture {
 
     forAll(blockEntryHashGen, blockEntryHashGen) {
       case (blockHash0, blockHash1) =>
@@ -296,7 +296,7 @@ class TransactionServiceSpec
     }
   }
 
-  it should "fall back on unconfirmed tx" in new Fixture {
+  "fall back on unconfirmed tx" in new Fixture {
     val utx = utransactionGen.sample.get
 
     TransactionService.getTransaction(utx.hash).futureValue is None
@@ -304,7 +304,7 @@ class TransactionServiceSpec
     TransactionService.getTransaction(utx.hash).futureValue is Some(utx)
   }
 
-  it should "preserve outputs order" in new Fixture {
+  "preserve outputs order" in new Fixture {
 
     val address = addressGen.sample.get
 
@@ -349,7 +349,7 @@ class TransactionServiceSpec
       }
   }
 
-  it should "preserve inputs order" in new Fixture {
+  "preserve inputs order" in new Fixture {
     //TODO Test this please
     //We need to generate a coherent blockflow, otherwise the queries can't match the inputs with outputs
 

--- a/app/src/test/scala/org/alephium/explorer/util/SchedulerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/util/SchedulerSpec.scala
@@ -27,14 +27,13 @@ import org.scalacheck.Gen
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-import org.alephium.explorer.AlephiumSpec._
+import org.alephium.explorer.AlephiumSpec
 import org.alephium.explorer.util.TestUtils._
 
 class SchedulerSpec
-    extends AnyWordSpec
+    extends AlephiumSpec
     with ScalaCheckDrivenPropertyChecks
     with Matchers
     with Eventually

--- a/app/src/test/scala/org/alephium/explorer/util/TimeUtilSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/util/TimeUtilSpec.scala
@@ -19,13 +19,12 @@ package org.alephium.explorer.util
 import java.time._
 
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
 
-import org.alephium.explorer.AlephiumSpec._
+import org.alephium.explorer.AlephiumSpec
 import org.alephium.explorer.util.TimeUtil._
 import org.alephium.util.TimeStamp
 
-class TimeUtilSpec extends AnyWordSpec with Matchers {
+class TimeUtilSpec extends AlephiumSpec with Matchers {
 
   "toZonedDateTime" should {
     "convert OffsetTime to ZonedDateTime with today's date" in {

--- a/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
@@ -46,7 +46,7 @@ class AddressServerSpec()
 
   override def api: Api = Json
 
-  it should "validate and forward `txLimit` query param " in new Fixture {
+  "validate and forward `txLimit` query param " in new Fixture {
     var testLimit = 0
     override val transactionService = new EmptyTransactionService {
       override def getTransactionsByAddressSQL(address: Address, pagination: Pagination)(
@@ -80,7 +80,7 @@ class AddressServerSpec()
     }
   }
 
-  it should "get total transactions" in new Fixture {
+  "get total transactions" in new Fixture {
     forAll(addressGen) {
       case (address) =>
         Get(s"/addresses/${address}/total-transactions") ~> server.route ~> check {
@@ -89,7 +89,7 @@ class AddressServerSpec()
     }
   }
 
-  it should "get balance" in new Fixture {
+  "get balance" in new Fixture {
     forAll(addressGen) {
       case (address) =>
         Get(s"/addresses/${address}/balance") ~> server.route ~> check {
@@ -98,7 +98,7 @@ class AddressServerSpec()
     }
   }
 
-  it should "get address info" in new Fixture {
+  "get address info" in new Fixture {
     forAll(addressGen) {
       case (address) =>
         Get(s"/addresses/${address}") ~> server.route ~> check {

--- a/app/src/test/scala/org/alephium/explorer/web/ChartsServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/ChartsServerSpec.scala
@@ -39,7 +39,7 @@ class ChartsServerSpec()
 
   override def api: Api = Json
 
-  it should "validate hourly/daily time range " in new Fixture {
+  "validate hourly/daily time range " in new Fixture {
     val now     = TimeStamp.now().millis
     val days30  = Duration.ofDaysUnsafe(30)
     val millis1 = Duration.ofMillisUnsafe(1).millis

--- a/app/src/test/scala/org/alephium/explorer/web/InfosServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/InfosServerSpec.scala
@@ -45,7 +45,7 @@ class InfosServerSpec()
 
   override def api: Api = Json
 
-  it should "return the explorer infos" in new Fixture {
+  "return the explorer infos" in new Fixture {
     Get(s"/infos") ~> server.route ~> check {
       responseAs[ExplorerInfo] is ExplorerInfo(
         BuildInfo.releaseVersion,
@@ -54,19 +54,19 @@ class InfosServerSpec()
     }
   }
 
-  it should "return chains heights" in new Fixture {
+  "return chains heights" in new Fixture {
     Get(s"/infos/heights") ~> server.route ~> check {
       responseAs[Seq[PerChainHeight]] is Seq(chainHeight)
     }
   }
 
-  it should "return the token supply list" in new Fixture {
+  "return the token supply list" in new Fixture {
     Get(s"/infos/supply") ~> server.route ~> check {
       responseAs[Seq[TokenSupply]] is Seq(tokenSupply)
     }
   }
 
-  it should "return the token current supply" in new Fixture {
+  "return the token current supply" in new Fixture {
     Get(s"/infos/supply/circulating-alph") ~> server.route ~> check {
       val circulating = response.entity
         .toStrict(Duration.ofSecondsUnsafe(5).asScala)
@@ -77,7 +77,7 @@ class InfosServerSpec()
     }
   }
 
-  it should "return the total token supply" in new Fixture {
+  "return the total token supply" in new Fixture {
     Get(s"/infos/supply/total-alph") ~> server.route ~> check {
       val total = response.entity
         .toStrict(Duration.ofSecondsUnsafe(5).asScala)
@@ -88,7 +88,7 @@ class InfosServerSpec()
     }
   }
 
-  it should "return the reserved token supply" in new Fixture {
+  "return the reserved token supply" in new Fixture {
     Get(s"/infos/supply/reserved-alph") ~> server.route ~> check {
       val reserved = response.entity
         .toStrict(Duration.ofSecondsUnsafe(5).asScala)
@@ -99,7 +99,7 @@ class InfosServerSpec()
     }
   }
 
-  it should "return the locked token supply" in new Fixture {
+  "return the locked token supply" in new Fixture {
     Get(s"/infos/supply/locked-alph") ~> server.route ~> check {
       val locked = response.entity
         .toStrict(Duration.ofSecondsUnsafe(5).asScala)
@@ -110,7 +110,7 @@ class InfosServerSpec()
     }
   }
 
-  it should "return the total transactions number" in new Fixture {
+  "return the total transactions number" in new Fixture {
     Get(s"/infos/total-transactions") ~> server.route ~> check {
       val total = response.entity
         .toStrict(Duration.ofSecondsUnsafe(5).asScala)
@@ -121,7 +121,7 @@ class InfosServerSpec()
     }
   }
 
-  it should "return the average block times" in new Fixture {
+  "return the average block times" in new Fixture {
     Get(s"/infos/average-block-times") ~> server.route ~> check {
       responseAs[Seq[PerChainDuration]] is Seq(blockTime)
     }

--- a/app/src/test/scala/org/alephium/explorer/web/UtilsServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/UtilsServerSpec.scala
@@ -43,7 +43,7 @@ class UtilsServerSpec()
 
   override def api: Api = Json
 
-  it should "update global loglevel" in new Fixture {
+  "update global loglevel" in new Fixture {
     List("TRACE", "DEBUG", "INFO", "WARN", "ERROR").foreach { level =>
       val entity = HttpEntity(ContentTypes.`text/plain(UTF-8)`, level)
       Put(s"/utils/update-global-loglevel", entity) ~> server.route ~> check {
@@ -59,7 +59,7 @@ class UtilsServerSpec()
     }
   }
 
-  it should "update logback values" in new Fixture {
+  "update logback values" in new Fixture {
 
     val logbackValues: Seq[LogbackValue] = Seq(
       LogbackValue("org.test", LogbackValue.Level.Debug),

--- a/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/ReadBenchmarkStateSpec.scala
+++ b/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/ReadBenchmarkStateSpec.scala
@@ -36,7 +36,7 @@ class ReadBenchmarkStateSpec extends AlephiumSpec with ScalaFutures {
   //total number of rows to generate
   val testDataCount = 10
 
-  it should "beforeAll - generate & cache test data" in {
+  "beforeAll - generate & cache test data" in {
     def doTest[D, S <: ReadBenchmarkState[D]](state: => S, getRows: S => Seq[D]): Unit =
       using(state) { state =>
         //create test data
@@ -68,7 +68,7 @@ class ReadBenchmarkStateSpec extends AlephiumSpec with ScalaFutures {
     )
   }
 
-  it should "beforeEach - fetch next data incrementally" in {
+  "beforeEach - fetch next data incrementally" in {
     def doTest(state: => ReadBenchmarkState[_]): Unit =
       using(state) { state =>
         //create test data
@@ -90,7 +90,7 @@ class ReadBenchmarkStateSpec extends AlephiumSpec with ScalaFutures {
     doTest(new VarcharReadState(testDataCount, DBExecutor.forTest()))
   }
 
-  it should "afterAll - terminate connection" in {
+  "afterAll - terminate connection" in {
     def doTest(state: => ReadBenchmarkState[_]): Unit =
       using(state) { state =>
         //call beforeAll some data and establish connection

--- a/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/WriteBenchmarkStateSpec.scala
+++ b/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/WriteBenchmarkStateSpec.scala
@@ -32,7 +32,7 @@ class WriteBenchmarkStateSpec extends AlephiumSpec {
   //total number of rows to generate
   val testDataCount = 10
 
-  it should "beforeAll - generate a new empty table" in {
+  "beforeAll - generate a new empty table" in {
     def doTest[S <: WriteBenchmarkState[_]](state: => S, getRowCount: S => Int): Unit =
       using(state) { state =>
         state.beforeAll()
@@ -58,7 +58,7 @@ class WriteBenchmarkStateSpec extends AlephiumSpec {
     )
   }
 
-  it should "beforeEach - generate data incrementally" in {
+  "beforeEach - generate data incrementally" in {
     using(new VarcharWriteState(DBExecutor.forTest())) { state =>
       //invoking next before setNext should return null
       //Option is not used here to avoid the cost of unnecessary


### PR DESCRIPTION
Discussed this with Thomas a while back but never got around to it.

We've been using `AnyWordSpec` for new test-cases and its getting a bit repetitive to extend `AnyWordSpec` for every new test-case individually. This PR switches `AlephiumSpec` to use `AnyWordSpec`.

`AnyWordSpec` helps writing more descriptive test-cases and grouping multiple cases for a single test which helps a fair bit because our test-cases are growing in number. 

Eg: 
```scala
"myFunction" should {
  "do something" when {
    "empty" in { //CASE 1
      ???
    }

    "nonempty" in { //CASE 2
      ???
    }
  }
}
```

We lose the keyword `it should` which is kinda redundant anyway because it's required for all tests. 

Replaced existing `AnyFlatSpec` style test-cases 
```scala
it should "do something" in {
  ???
}
```

With

```scala
"do something" in {
  ???
}
```

Thank you Regex!