### PR TITLE
Added `SlickTestUtil.explain()`: For testing Postgres's `EXPLAIN ANALYSE` output

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
@@ -106,8 +106,11 @@ object BlockQueries extends StrictLogging {
     * Fetches all main_chain [[org.alephium.explorer.persistence.schema.BlockHeaderSchema.table]] rows
     */
   def listMainChainHeadersWithTxnNumberSQL(
-      pagination: Pagination): DBActionRWT[Vector[BlockEntryLite]] = {
+      pagination: Pagination): DBActionRWT[Vector[BlockEntryLite]] =
+    listMainChainHeadersWithTxnNumberSQLBuilder(pagination)
+      .as[BlockEntryLite](blockEntryListGetResult)
 
+  def listMainChainHeadersWithTxnNumberSQLBuilder(pagination: Pagination): SQLActionBuilder = {
     //order by for inner query
     val orderBy =
       if (pagination.reverse) {
@@ -117,20 +120,19 @@ object BlockQueries extends StrictLogging {
       }
 
     sql"""
-           |select hash,
-           |       block_timestamp,
-           |       chain_from,
-           |       chain_to,
-           |       height,
-           |       main_chain,
-           |       hashrate,
-           |       txs_count
-           |from #$block_headers
-           |where main_chain = true
-           |#$orderBy
-           |limit ${pagination.limit} offset ${pagination.limit * pagination.offset}
-           |""".stripMargin
-      .as[BlockEntryLite](blockEntryListGetResult)
+         |select hash,
+         |       block_timestamp,
+         |       chain_from,
+         |       chain_to,
+         |       height,
+         |       main_chain,
+         |       hashrate,
+         |       txs_count
+         |from #$block_headers
+         |where main_chain = true
+         |#$orderBy
+         |limit ${pagination.limit} offset ${pagination.limit * pagination.offset}
+         |""".stripMargin
   }
 
   def updateMainChainStatusAction(hash: BlockEntry.Hash, isMainChain: Boolean)(

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockQueriesSpec.scala
@@ -134,24 +134,25 @@ class BlockQueriesSpec
 
   "listMainChainHeadersWithTxnNumberSQLBuilder" should {
     "use block_headers_full_index" in {
-      //test-data
-      val headers = Array.fill(100)(blockHeaderGen.sample).flatten
-      //persist test-data
-      run(BlockHeaderSchema.table ++= headers).futureValue
+      forAll(Gen.listOf(blockHeaderGen)) { headers =>
+        //persist test-data
+        run(BlockHeaderSchema.table.delete).futureValue
+        run(BlockHeaderSchema.table ++= headers).futureValue
 
-      //build explain query
-      val explain =
-        BlockQueries
-          .listMainChainHeadersWithTxnNumberSQLBuilder(Pagination.unsafe(1, 10))
-          .explain() //flatten so we get single String instead of Vector[String]
+        //build explain query
+        val explain =
+          BlockQueries
+            .listMainChainHeadersWithTxnNumberSQLBuilder(Pagination.unsafe(1, 10))
+            .explain() //flatten so we get single String instead of Vector[String]
 
-      //run explain query
-      val explainResult =
-        run(explain).futureValue
+        //run explain query
+        val explainResult =
+          run(explain).futureValue
 
-      //check the query is using the index named `block_headers_full_index` in `block_headers` table
-      explainResult.mkString should
-        include("Index Scan using block_headers_full_index on block_headers")
+        //check the query is using the index named `block_headers_full_index` in `block_headers` table
+        explainResult.mkString should
+          include("Index Scan using block_headers_full_index on block_headers")
+      }
     }
   }
 }

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockQueriesSpec.scala
@@ -24,8 +24,10 @@ import org.scalatest.time.{Minutes, Span}
 import slick.jdbc.PostgresProfile.api._
 
 import org.alephium.explorer.{AlephiumSpec, Generators}
+import org.alephium.explorer.api.model.Pagination
 import org.alephium.explorer.persistence.{DatabaseFixtureForEach, DBRunner}
 import org.alephium.explorer.persistence.schema._
+import org.alephium.explorer.util.SlickTestUtil._
 
 class BlockQueriesSpec
     extends AlephiumSpec
@@ -127,6 +129,29 @@ class BlockQueriesSpec
           run(BlockQueries.getBlockHeaderAction(hash)).futureValue is None
         }
       }
+    }
+  }
+
+  "listMainChainHeadersWithTxnNumberSQLBuilder" should {
+    "use block_headers_full_index" in {
+      //test-data
+      val headers = Array.fill(100)(blockHeaderGen.sample).flatten
+      //persist test-data
+      run(BlockHeaderSchema.table ++= headers).futureValue
+
+      //build explain query
+      val explain =
+        BlockQueries
+          .listMainChainHeadersWithTxnNumberSQLBuilder(Pagination.unsafe(1, 10))
+          .explain() //flatten so we get single String instead of Vector[String]
+
+      //run explain query
+      val explainResult =
+        run(explain).futureValue
+
+      //check the query is using the index named `block_headers_full_index` in `block_headers` table
+      explainResult.mkString should
+        include("Index Scan using block_headers_full_index on block_headers")
     }
   }
 }

--- a/app/src/test/scala/org/alephium/explorer/util/SlickTestUtil.scala
+++ b/app/src/test/scala/org/alephium/explorer/util/SlickTestUtil.scala
@@ -1,0 +1,32 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+package org.alephium.explorer.util
+
+import slick.dbio.Effect
+import slick.jdbc.SQLActionBuilder
+import slick.sql.SqlStreamingAction
+
+object SlickTestUtil {
+
+  implicit class SlickTestImplicits(sql: SQLActionBuilder) {
+
+    /** Adds EXPLAIN ANALYZE to the head of the query */
+    def explain(): SqlStreamingAction[Vector[String], String, Effect.Read] =
+      sql
+        .copy(queryParts = sql.queryParts.updated(0, s"EXPLAIN ANALYZE ${sql.queryParts.head}"))
+        .as[String]
+  }
+}

--- a/app/src/test/scala/org/alephium/explorer/util/SlickTestUtil.scala
+++ b/app/src/test/scala/org/alephium/explorer/util/SlickTestUtil.scala
@@ -23,10 +23,18 @@ object SlickTestUtil {
 
   implicit class SlickTestImplicits(sql: SQLActionBuilder) {
 
-    /** Adds EXPLAIN ANALYZE to the head of the query */
-    def explain(): SqlStreamingAction[Vector[String], String, Effect.Read] =
+    private def alterHeadQuery(
+        prefix: String): SqlStreamingAction[Vector[String], String, Effect.Read] =
       sql
-        .copy(queryParts = sql.queryParts.updated(0, s"EXPLAIN ANALYZE ${sql.queryParts.head}"))
+        .copy(queryParts = sql.queryParts.updated(0, s"$prefix ${sql.queryParts.head}"))
         .as[String]
+
+    /** Adds `EXPLAIN ANALYZE` to head query */
+    def explainAnalyze(): SqlStreamingAction[Vector[String], String, Effect.Read] =
+      alterHeadQuery("EXPLAIN ANALYZE")
+
+    /** Adds `EXPLAIN` to head query */
+    def explain(): SqlStreamingAction[Vector[String], String, Effect.Read] =
+      alterHeadQuery("EXPLAIN")
   }
 }


### PR DESCRIPTION
For issues #208, #123, [comment](https://github.com/alephium/explorer-backend/issues/283#issuecomment-1173800115) and other 'double check' tasks we can write test-cases using `explain()` to assert output of `EXPLAIN ANALYSE` for Slick queries. 

For example:
```scala
val explainQuery = BlockQueries.someQuery(params).explain()

run(explainQuery) should include("Some text from `EXPLAIN ANALYSE` output")
```
I've added an example test for a query in `BlockQueriesSpec` to assert the query uses this `main_chain` index

```sql
index block_headers_full_index
    on block_headers (main_chain asc, block_timestamp desc, hash asc, chain_from asc, chain_to asc, height asc);
 ```

We ok writing such test-cases?