### PR TITLE
Add a super fast endpoint to check if an address is active (at least 1 tx)

### DIFF
--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -1295,29 +1295,35 @@
         }
       }
     },
-    "/addresses/{address}/active": {
-      "get": {
+    "/addresses-active": {
+      "post": {
         "tags": [
           "Addresses"
         ],
-        "description": "Is the address active (at least 1 tx)",
-        "operationId": "getAddressesAddressActive",
-        "parameters": [
-          {
-            "name": "address",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
+        "description": "Are the addresses active (at least 1 transaction)",
+        "operationId": "postAddresses-active",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
             }
-          }
-        ],
+          },
+          "required": false
+        },
         "responses": {
           "200": {
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "boolean"
+                  "type": "array",
+                  "items": {
+                    "type": "boolean"
+                  }
                 }
               }
             }

--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -1310,7 +1310,7 @@
                 "items": {
                   "type": "string"
                 },
-                "maxItems": 200
+                "maxItems": 80
               }
             }
           },

--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -1295,6 +1295,102 @@
         }
       }
     },
+    "/addresses/{address}/active": {
+      "get": {
+        "tags": [
+          "Addresses"
+        ],
+        "description": "Is the address active (at least 1 tx)",
+        "operationId": "getAddressesAddressActive",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequest"
+                },
+                "example": {
+                  "detail": "Something bad in the request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unauthorized"
+                },
+                "example": {
+                  "detail": "You shall not pass"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFound"
+                },
+                "example": {
+                  "resource": "wallet-name",
+                  "detail": "wallet-name not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                },
+                "example": {
+                  "detail": "Ouch"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailable"
+                },
+                "example": {
+                  "detail": "Self clique unsynced"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/infos": {
       "get": {
         "tags": [

--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -1309,7 +1309,8 @@
                 "type": "array",
                 "items": {
                   "type": "string"
-                }
+                },
+                "maxItems": 200
               }
             }
           },

--- a/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
@@ -96,10 +96,12 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
       .out(jsonBody[Seq[Transaction]])
       .description("List address tokens")
 
-  val isAddressActive: BaseEndpoint[Address, Boolean] =
-    addressesEndpoint.get
-      .in(path[Address]("address")(Codecs.addressTapirCodec))
-      .in("active")
-      .out(jsonBody[Boolean])
-      .description("Is the address active (at least 1 tx)")
+  val areAddressesActive: BaseEndpoint[Seq[Address], Seq[Boolean]] =
+    baseEndpoint
+      .tag("Addresses")
+      .in("addresses-active")
+      .post
+      .in(jsonBody[Seq[Address]])
+      .out(jsonBody[Seq[Boolean]])
+      .description("Are the addresses active (at least 1 transaction)")
 }

--- a/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
@@ -95,4 +95,11 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
       .in(pagination)
       .out(jsonBody[Seq[Transaction]])
       .description("List address tokens")
+
+  val isAddressActive: BaseEndpoint[Address, Boolean] =
+    addressesEndpoint.get
+      .in(path[Address]("address")(Codecs.addressTapirCodec))
+      .in("active")
+      .out(jsonBody[Boolean])
+      .description("Is the address active (at least 1 tx)")
 }

--- a/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
@@ -28,7 +28,12 @@ import org.alephium.protocol.Hash
 // scalastyle:off magic.number
 trait AddressesEndpoints extends BaseEndpoint with QueryParams {
 
-  private val activeAddressesMaxSize: Int = 200
+  def groupNum: Int
+
+  //As defined in https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#address-gap-limit
+  private val gapLimit = 20
+
+  private lazy val activeAddressesMaxSize: Int = groupNum * gapLimit
 
   private val addressesEndpoint =
     baseEndpoint
@@ -98,7 +103,7 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
       .out(jsonBody[Seq[Transaction]])
       .description("List address tokens")
 
-  val areAddressesActive: BaseEndpoint[Seq[Address], Seq[Boolean]] =
+  lazy val areAddressesActive: BaseEndpoint[Seq[Address], Seq[Boolean]] =
     baseEndpoint
       .tag("Addresses")
       .in("addresses-active")

--- a/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
@@ -28,6 +28,8 @@ import org.alephium.protocol.Hash
 // scalastyle:off magic.number
 trait AddressesEndpoints extends BaseEndpoint with QueryParams {
 
+  private val activeAddressesMaxSize: Int = 200
+
   private val addressesEndpoint =
     baseEndpoint
       .tag("Addresses")
@@ -101,7 +103,7 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
       .tag("Addresses")
       .in("addresses-active")
       .post
-      .in(jsonBody[Seq[Address]])
+      .in(jsonBody[Seq[Address]].validate(Validator.maxSize(activeAddressesMaxSize)))
       .out(jsonBody[Seq[Boolean]])
       .description("Are the addresses active (at least 1 transaction)")
 }

--- a/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
+++ b/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
@@ -30,7 +30,7 @@ trait Documentation
     with TokensEndpoints
     with UtilsEndpoints
     with OpenAPIDocsInterpreter {
-  val docs: OpenAPI = toOpenAPI(
+  lazy val docs: OpenAPI = toOpenAPI(
     List(
       listBlocks,
       getBlockByHash,

--- a/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
+++ b/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
@@ -44,6 +44,7 @@ trait Documentation
       listAddressTokens,
       listAddressTokenTransactions,
       getAddressTokenBalance,
+      isAddressActive,
       getInfos,
       getHeights,
       listTokens,

--- a/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
+++ b/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
@@ -44,7 +44,7 @@ trait Documentation
       listAddressTokens,
       listAddressTokenTransactions,
       getAddressTokenBalance,
-      isAddressActive,
+      areAddressesActive,
       getInfos,
       getHeights,
       listTokens,

--- a/app/src/main/scala/org/alephium/explorer/persistence/dao/TransactionDao.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/dao/TransactionDao.scala
@@ -64,9 +64,10 @@ object TransactionDao {
       dc: DatabaseConfig[PostgresProfile]): Future[(U256, U256)] =
     run(getTokenBalanceAction(address, token))
 
-  def isAddressActive(address: Address)(implicit ec: ExecutionContext,
-                                        dc: DatabaseConfig[PostgresProfile]): Future[Boolean] =
-    run(isAddressActiveAction(address))
+  def areAddressesActive(addresses: Seq[Address])(
+      implicit ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile]): Future[Seq[Boolean]] =
+    run(areAddressesActiveAction(addresses))
 
   def listTokens(pagination: Pagination)(implicit ec: ExecutionContext,
                                          dc: DatabaseConfig[PostgresProfile]): Future[Seq[Hash]] =

--- a/app/src/main/scala/org/alephium/explorer/persistence/dao/TransactionDao.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/dao/TransactionDao.scala
@@ -64,6 +64,10 @@ object TransactionDao {
       dc: DatabaseConfig[PostgresProfile]): Future[(U256, U256)] =
     run(getTokenBalanceAction(address, token))
 
+  def isAddressActive(address: Address)(implicit ec: ExecutionContext,
+                                        dc: DatabaseConfig[PostgresProfile]): Future[Boolean] =
+    run(isAddressActiveAction(address))
+
   def listTokens(pagination: Pagination)(implicit ec: ExecutionContext,
                                          dc: DatabaseConfig[PostgresProfile]): Future[Seq[Hash]] =
     run(listTokensAction(pagination))

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
@@ -356,10 +356,13 @@ object TransactionQueries extends StrictLogging {
                   gasPrice)
     }
 
-  def isAddressActiveAction(address: Address)(implicit ec: ExecutionContext): DBActionR[Boolean] = {
-    sql"""
-       SELECT EXISTS (SELECT 1 FROM transaction_per_addresses WHERE address = $address)
-         """.as[Boolean].exactlyOne
+  def areAddressesActiveAction(addresses: Seq[Address])(
+      implicit ec: ExecutionContext): DBActionR[Seq[Boolean]] = {
+    DBIOAction.sequence(addresses.map { address =>
+      sql"""
+         SELECT EXISTS (SELECT 1 FROM transaction_per_addresses WHERE address = $address)
+           """.as[Boolean].exactlyOne
+    })
   }
 
   def getBalanceAction(address: Address)(implicit ec: ExecutionContext): DBActionR[(U256, U256)] =

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
@@ -356,6 +356,12 @@ object TransactionQueries extends StrictLogging {
                   gasPrice)
     }
 
+  def isAddressActiveAction(address: Address)(implicit ec: ExecutionContext): DBActionR[Boolean] = {
+    sql"""
+       SELECT EXISTS (SELECT 1 FROM transaction_per_addresses WHERE address = $address)
+         """.as[Boolean].exactlyOne
+  }
+
   def getBalanceAction(address: Address)(implicit ec: ExecutionContext): DBActionR[(U256, U256)] =
     getBalanceUntilLockTime(
       address  = address,

--- a/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
@@ -57,6 +57,9 @@ trait TransactionService {
 
   def getTotalNumber()(implicit cache: TransactionCache): Int
 
+  def isAddressActive(address: Address)(implicit ec: ExecutionContext,
+                                        dc: DatabaseConfig[PostgresProfile]): Future[Boolean]
+
   def listTokens(pagination: Pagination)(implicit ec: ExecutionContext,
                                          dc: DatabaseConfig[PostgresProfile]): Future[Seq[Hash]]
 
@@ -141,6 +144,10 @@ object TransactionService extends TransactionService {
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[Seq[Transaction]] =
     TransactionDao.listAddressTokenTransactions(address, token, pagination)
+
+  def isAddressActive(address: Address)(implicit ec: ExecutionContext,
+                                        dc: DatabaseConfig[PostgresProfile]): Future[Boolean] =
+    TransactionDao.isAddressActive(address)
 
   def getTotalNumber()(implicit cache: TransactionCache): Int =
     cache.getMainChainTxnCount()

--- a/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
@@ -57,8 +57,9 @@ trait TransactionService {
 
   def getTotalNumber()(implicit cache: TransactionCache): Int
 
-  def isAddressActive(address: Address)(implicit ec: ExecutionContext,
-                                        dc: DatabaseConfig[PostgresProfile]): Future[Boolean]
+  def areAddressesActive(addresses: Seq[Address])(
+      implicit ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile]): Future[Seq[Boolean]]
 
   def listTokens(pagination: Pagination)(implicit ec: ExecutionContext,
                                          dc: DatabaseConfig[PostgresProfile]): Future[Seq[Hash]]
@@ -145,9 +146,10 @@ object TransactionService extends TransactionService {
       dc: DatabaseConfig[PostgresProfile]): Future[Seq[Transaction]] =
     TransactionDao.listAddressTokenTransactions(address, token, pagination)
 
-  def isAddressActive(address: Address)(implicit ec: ExecutionContext,
-                                        dc: DatabaseConfig[PostgresProfile]): Future[Boolean] =
-    TransactionDao.isAddressActive(address)
+  def areAddressesActive(addresses: Seq[Address])(
+      implicit ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile]): Future[Seq[Boolean]] =
+    TransactionDao.areAddressesActive(addresses)
 
   def getTotalNumber()(implicit cache: TransactionCache): Int =
     cache.getMainChainTxnCount()

--- a/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
@@ -75,8 +75,8 @@ class AddressServer(transactionService: TransactionService)(
             tokens <- transactionService.listAddressTokenTransactions(address, token, pagination)
           } yield tokens
       }) ~
-      toRoute(isAddressActive.serverLogicSuccess[Future] { address =>
-        transactionService.isAddressActive(address)
+      toRoute(areAddressesActive.serverLogicSuccess[Future] { addresses =>
+        transactionService.areAddressesActive(addresses)
       })
 
 }

--- a/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
@@ -23,15 +23,19 @@ import akka.http.scaladsl.server.Route
 import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
 
+import org.alephium.explorer.GroupSetting
 import org.alephium.explorer.api.AddressesEndpoints
 import org.alephium.explorer.api.model.{AddressBalance, AddressInfo}
 import org.alephium.explorer.service.TransactionService
 
 class AddressServer(transactionService: TransactionService)(
     implicit val executionContext: ExecutionContext,
+    groupSetting: GroupSetting,
     dc: DatabaseConfig[PostgresProfile])
     extends Server
     with AddressesEndpoints {
+
+  val groupNum = groupSetting.groupNum
 
   val route: Route =
     toRoute(getTransactionsByAddress.serverLogicSuccess[Future] {

--- a/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
@@ -74,5 +74,9 @@ class AddressServer(transactionService: TransactionService)(
           for {
             tokens <- transactionService.listAddressTokenTransactions(address, token, pagination)
           } yield tokens
+      }) ~
+      toRoute(isAddressActive.serverLogicSuccess[Future] { address =>
+        transactionService.isAddressActive(address)
       })
+
 }

--- a/app/src/main/scala/org/alephium/explorer/web/DocumentationServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/DocumentationServer.scala
@@ -22,11 +22,16 @@ import akka.http.scaladsl.server.Route
 import sttp.tapir.swagger.{SwaggerUI, SwaggerUIOptions}
 
 import org.alephium.api.OpenAPIWriters.openApiJson
+import org.alephium.explorer.GroupSetting
 import org.alephium.explorer.docs.Documentation
 
-class DocumentationServer()(implicit val executionContext: ExecutionContext)
+class DocumentationServer()(implicit val executionContext: ExecutionContext,
+                            groupSetting: GroupSetting)
     extends Server
     with Documentation {
+
+  val groupNum = groupSetting.groupNum
+
   val route: Route = toRoute(
     SwaggerUI[Future](openApiJson(docs, dropAuth             = false),
                       SwaggerUIOptions.default.copy(yamlName = "explorer-backend-openapi.json")))

--- a/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
@@ -415,6 +415,25 @@ class TransactionServiceSpec
     }
   }
 
+  "check active address" in new Fixture {
+
+    val address  = addressGen.sample.get
+    val address2 = addressGen.sample.get
+
+    val block =
+      blockEntityGen(groupIndex, groupIndex, None)
+        .map { block =>
+          block.copy(outputs = block.outputs.map(_.copy(address = address)))
+        }
+        .sample
+        .get
+
+    BlockDao.insertAll(Seq(block)).futureValue
+
+    TransactionService.isAddressActive(address).futureValue is true
+    TransactionService.isAddressActive(address2).futureValue is false
+  }
+
   trait Fixture {
     implicit val groupSettings: GroupSetting = GroupSetting(groupNum)
     implicit val blockCache: BlockCache      = BlockCache()

--- a/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
@@ -430,8 +430,7 @@ class TransactionServiceSpec
 
     BlockDao.insertAll(Seq(block)).futureValue
 
-    TransactionService.isAddressActive(address).futureValue is true
-    TransactionService.isAddressActive(address2).futureValue is false
+    TransactionService.areAddressesActive(Seq(address, address2)).futureValue is Seq(true, false)
   }
 
   trait Fixture {

--- a/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
@@ -117,6 +117,19 @@ class AddressServerSpec()
     }
   }
 
+  "fail if too many active addresses" in new Fixture {
+    forAll(addressGen) {
+      case (address) =>
+        val json   = s"[${Seq.fill(201)(s""""$address"""").mkString(",")}]"
+        val entity = HttpEntity(ContentTypes.`application/json`, json)
+        Post(s"/addresses-active", entity) ~> server.route ~> check {
+          status is StatusCodes.BadRequest
+          responseAs[ApiError.BadRequest] is ApiError.BadRequest(
+            s"Invalid value for: body (expected size of value to be less than or equal to 200, but was 201)")
+        }
+    }
+  }
+
   trait Fixture {
 
     val transactionService = new EmptyTransactionService {}

--- a/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
@@ -18,7 +18,7 @@ package org.alephium.explorer.web
 
 import scala.concurrent.{ExecutionContext, Future}
 
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCodes}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import de.heikoseeberger.akkahttpupickle.UpickleCustomizationSupport
 import org.scalacheck.Gen
@@ -107,6 +107,16 @@ class AddressServerSpec()
     }
   }
 
+  "check if addresses are active" in new Fixture {
+    forAll(addressGen) {
+      case (address) =>
+        val entity = HttpEntity(ContentTypes.`application/json`, s"""["$address"]""")
+        Post(s"/addresses-active", entity) ~> server.route ~> check {
+          responseAs[Seq[Boolean]] is Seq(true)
+        }
+    }
+  }
+
   trait Fixture {
 
     val transactionService = new EmptyTransactionService {}
@@ -165,9 +175,11 @@ class AddressServerSpec()
       def listTokens(pagination: Pagination)(
           implicit ec: ExecutionContext,
           dc: DatabaseConfig[PostgresProfile]): Future[Seq[Hash]] = ???
-      def isAddressActive(address: Address)(implicit ec: ExecutionContext,
-                                            dc: DatabaseConfig[PostgresProfile]): Future[Boolean] =
-        ???
+      def areAddressesActive(addresses: Seq[Address])(
+          implicit ec: ExecutionContext,
+          dc: DatabaseConfig[PostgresProfile]): Future[Seq[Boolean]] = {
+        Future.successful(Seq(true))
+      }
     }
   }
 }

--- a/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
@@ -165,6 +165,9 @@ class AddressServerSpec()
       def listTokens(pagination: Pagination)(
           implicit ec: ExecutionContext,
           dc: DatabaseConfig[PostgresProfile]): Future[Seq[Hash]] = ???
+      def isAddressActive(address: Address)(implicit ec: ExecutionContext,
+                                            dc: DatabaseConfig[PostgresProfile]): Future[Boolean] =
+        ???
     }
   }
 }

--- a/app/src/test/scala/org/alephium/explorer/web/InfosServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/InfosServerSpec.scala
@@ -233,6 +233,9 @@ class InfosServerSpec()
       def listTokens(pagination: Pagination)(
           implicit ec: ExecutionContext,
           dc: DatabaseConfig[PostgresProfile]): Future[Seq[Hash]] = ???
+      def isAddressActive(address: Address)(implicit ec: ExecutionContext,
+                                            dc: DatabaseConfig[PostgresProfile]): Future[Boolean] =
+        ???
     }
 
     implicit val groupSettings: GroupSetting        = GroupSetting(groupNum)

--- a/app/src/test/scala/org/alephium/explorer/web/InfosServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/InfosServerSpec.scala
@@ -233,8 +233,9 @@ class InfosServerSpec()
       def listTokens(pagination: Pagination)(
           implicit ec: ExecutionContext,
           dc: DatabaseConfig[PostgresProfile]): Future[Seq[Hash]] = ???
-      def isAddressActive(address: Address)(implicit ec: ExecutionContext,
-                                            dc: DatabaseConfig[PostgresProfile]): Future[Boolean] =
+      def areAddressesActive(addresses: Seq[Address])(
+          implicit ec: ExecutionContext,
+          dc: DatabaseConfig[PostgresProfile]): Future[Seq[Boolean]] =
         ???
     }
 

--- a/tools/src/main/scala/org/alephium/tools/OpenApiUpdate.scala
+++ b/tools/src/main/scala/org/alephium/tools/OpenApiUpdate.scala
@@ -24,6 +24,9 @@ object OpenApiUpdate {
   def main(args: Array[String]): Unit = {
     sideEffect {
       new Documentation {
+
+        val groupNum = 4
+
         private val json = openApiJson(docs, dropAuth = false)
 
         import java.io.PrintWriter


### PR DESCRIPTION
based on [this discussion](https://github.com/alephium/desktop-wallet/issues/136#issuecomment-1176264853)

This is a feature needed for address discovery in the desktop-wallet

here is the curl time in second: 
![maim-1657120048](https://user-images.githubusercontent.com/2979182/177583147-294f15d8-14cd-4098-bc33-4658f1b6afce.png)


The query is: 
```
SELECT EXISTS (SELECT 1 FROM transaction_per_addresses WHERE address = $address)
```
it's the fastest thing I could find and the one that pop up the more often in all my searches