### PR TITLE
Added `explain` for query `getTxnHashSQL`

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
@@ -52,7 +52,7 @@ object BlockQueries extends StrictLogging {
         queryName  = "mainChainQuery",
         queryInput = "Unit",
         explain    = explain,
-        message    = None,
+        message    = Iterable.empty,
         passed     = explain.mkString contains "block_headers_main_chain_idx"
       )
     }
@@ -129,7 +129,7 @@ object BlockQueries extends StrictLogging {
         queryName  = "listMainChainHeadersWithTxnNumber",
         queryInput = pagination.toString,
         explain    = explain,
-        message    = None,
+        message    = Iterable.empty,
         passed     = explain.mkString contains "block_headers_full_index"
       )
     }

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
@@ -52,6 +52,7 @@ object BlockQueries extends StrictLogging {
         queryName  = "mainChainQuery",
         queryInput = "Unit",
         explain    = explain,
+        message    = None,
         passed     = explain.mkString contains "block_headers_main_chain_idx"
       )
     }
@@ -128,6 +129,7 @@ object BlockQueries extends StrictLogging {
         queryName  = "listMainChainHeadersWithTxnNumber",
         queryInput = pagination.toString,
         explain    = explain,
+        message    = None,
         passed     = explain.mkString contains "block_headers_full_index"
       )
     }

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
@@ -52,7 +52,7 @@ object BlockQueries extends StrictLogging {
         queryName  = "mainChainQuery",
         queryInput = "Unit",
         explain    = explain,
-        message    = Iterable.empty,
+        messages   = Iterable.empty,
         passed     = explain.mkString contains "block_headers_main_chain_idx"
       )
     }
@@ -129,7 +129,7 @@ object BlockQueries extends StrictLogging {
         queryName  = "listMainChainHeadersWithTxnNumber",
         queryInput = pagination.toString,
         explain    = explain,
-        message    = Iterable.empty,
+        messages   = Iterable.empty,
         passed     = explain.mkString contains "block_headers_full_index"
       )
     }

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
@@ -35,7 +35,7 @@ import org.alephium.explorer.persistence.schema._
 import org.alephium.explorer.persistence.schema.CustomGetResult._
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
-import org.alephium.explorer.util.SlickTestUtil._
+import org.alephium.explorer.util.SlickExplainUtil._
 import org.alephium.util.TimeStamp
 
 object BlockQueries extends StrictLogging {

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/ExplainResult.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/ExplainResult.scala
@@ -25,5 +25,5 @@ object ExplainResult {
 final case class ExplainResult(queryName: String,
                                queryInput: String,
                                explain: Vector[String],
-                               message: Iterable[String],
+                               messages: Iterable[String],
                                passed: Boolean)

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/ExplainResult.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/ExplainResult.scala
@@ -25,4 +25,5 @@ object ExplainResult {
 final case class ExplainResult(queryName: String,
                                queryInput: String,
                                explain: Vector[String],
+                               message: Iterable[String],
                                passed: Boolean)

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/OutputQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/OutputQueries.scala
@@ -401,7 +401,7 @@ object OutputQueries {
       val message =
         Seq(
           s"Used outputs_main_chain_idx = $outputs_main_chain_idx_used",
-          s"Used outputs_pk_used        = $outputs_pk_used"
+          s"Used outputs_pk             = $outputs_pk_used"
         )
 
       ExplainResult(

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/OutputQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/OutputQueries.scala
@@ -408,7 +408,7 @@ object OutputQueries {
         queryName  = "getTxnHashSQL",
         queryInput = key.toString(),
         explain    = explain,
-        message    = message,
+        messages   = message,
         passed     = passed
       )
     }

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/OutputQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/OutputQueries.scala
@@ -28,7 +28,9 @@ import org.alephium.explorer.persistence._
 import org.alephium.explorer.persistence.model._
 import org.alephium.explorer.persistence.queries.result.{OutputsFromTxQR, OutputsQR}
 import org.alephium.explorer.persistence.schema.CustomGetResult._
+import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
+import org.alephium.explorer.persistence.schema.OutputSchema
 import org.alephium.explorer.util.SlickUtil._
 import org.alephium.util.{TimeStamp, U256}
 
@@ -375,6 +377,18 @@ object OutputQueries {
           AND block_hash = $blockHash
         ORDER BY output_order
       """.as[OutputsQR]
+
+  /** Get main chain [[OutputEntity]]s ordered by timestamp */
+  def getMainChainOutputs(
+      ascendingOrder: Boolean): Query[OutputSchema.Outputs, OutputEntity, Seq] = {
+    val mainChain = OutputSchema.table.filter(_.mainChain === true)
+
+    if (ascendingOrder) {
+      mainChain.sortBy(_.timestamp.asc)
+    } else {
+      mainChain.sortBy(_.timestamp.desc)
+    }
+  }
 
   def getTxnHash(key: Hash): DBActionR[Vector[Transaction.Hash]] =
     getTxnHashSQL(key).as[Transaction.Hash]

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/OutputQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/OutputQueries.scala
@@ -31,7 +31,7 @@ import org.alephium.explorer.persistence.schema.CustomGetResult._
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.explorer.persistence.schema.OutputSchema
-import org.alephium.explorer.util.SlickTestUtil._
+import org.alephium.explorer.util.SlickExplainUtil._
 import org.alephium.explorer.util.SlickUtil._
 import org.alephium.util.{TimeStamp, U256}
 

--- a/app/src/main/scala/org/alephium/explorer/util/SlickExplainUtil.scala
+++ b/app/src/main/scala/org/alephium/explorer/util/SlickExplainUtil.scala
@@ -24,7 +24,7 @@ import slick.sql.{FixedSqlStreamingAction, SqlStreamingAction}
 
 import org.alephium.explorer.persistence.DBActionR
 
-object SlickTestUtil {
+object SlickExplainUtil {
 
   /** For SQL queries */
   implicit class SQLActionBuilderImplicits(sql: SQLActionBuilder) {

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/InputQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/InputQueriesSpec.scala
@@ -30,7 +30,7 @@ import org.alephium.explorer.persistence.queries.InputQueries._
 import org.alephium.explorer.persistence.queries.result.{InputsFromTxQR, InputsQR}
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.explorer.persistence.schema.InputSchema
-import org.alephium.explorer.util.SlickTestUtil._
+import org.alephium.explorer.util.SlickExplainUtil._
 
 class InputQueriesSpec
     extends AlephiumSpec

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/OutputQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/OutputQueriesSpec.scala
@@ -185,32 +185,6 @@ class OutputQueriesSpec
     }
   }
 
-  "getTxnHash" should {
-    "fetch tx_hash and use outputs_pk index" when {
-      "main_chain = true" in {
-        forAll(Gen.listOf(outputEntityGen)) { outputs =>
-          //no-need to clear the table for each iteration.
-          run(OutputSchema.table ++= outputs).futureValue
-
-          //run query for each output.
-          outputs foreach { output =>
-            val actual =
-              run(getTxnHash(output.txHash.value)).futureValue
-
-            run(getTxnHashSQL(output.txHash.value).explain()).futureValue
-              .mkString("\n") should include("outputs_pk")
-
-            if (output.mainChain) { //when main_chain = true expect hash to be fetched
-              actual.toList contains only(output.txHash.value)
-            } else { //else expect empty
-              actual.size is 0
-            }
-          }
-        }
-      }
-    }
-  }
-
   "getBalanceActionOption" should {
     "return None" when {
       "address does not exist" in {

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/OutputQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/OutputQueriesSpec.scala
@@ -159,6 +159,32 @@ class OutputQueriesSpec
     }
   }
 
+  "getMainChainOutputs" should {
+    "all OutputEntities" when {
+      "order is ascending" in {
+        forAll(Gen.listOf(outputEntityGen)) { outputs =>
+          run(OutputSchema.table.delete).futureValue
+          run(OutputSchema.table ++= outputs).futureValue
+
+          val expected = outputs.filter(_.mainChain).sortBy(_.timestamp)
+
+          //Ascending order
+          locally {
+            val actual = run(OutputQueries.getMainChainOutputs(true).result).futureValue
+            actual should contain inOrderElementsOf expected
+          }
+
+          //Descending order
+          locally {
+            val expectedReversed = expected.reverse
+            val actual           = run(OutputQueries.getMainChainOutputs(false).result).futureValue
+            actual should contain inOrderElementsOf expectedReversed
+          }
+        }
+      }
+    }
+  }
+
   "getTxnHash" should {
     "fetch tx_hash and use outputs_pk index" when {
       "main_chain = true" in {

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/OutputQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/OutputQueriesSpec.scala
@@ -29,7 +29,7 @@ import org.alephium.explorer.persistence.queries.OutputQueries._
 import org.alephium.explorer.persistence.queries.result.{OutputsFromTxQR, OutputsQR}
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.explorer.persistence.schema.OutputSchema
-import org.alephium.explorer.util.SlickTestUtil._
+import org.alephium.explorer.util.SlickExplainUtil._
 
 class OutputQueriesSpec
     extends AlephiumSpec

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/OutputQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/OutputQueriesSpec.scala
@@ -217,28 +217,4 @@ class OutputQueriesSpec
       }
     }
   }
-
-  "index 'outputs_pk'" should {
-    "get used" when {
-      "accessing column output_ref_key" ignore {
-        forAll(Gen.listOf(outputEntityGen)) { outputs =>
-          run(OutputSchema.table.delete).futureValue
-          run(OutputSchema.table ++= outputs).futureValue
-
-          outputs foreach { output =>
-            val query =
-              sql"""
-                   |SELECT *
-                   |FROM outputs
-                   |where key = ${output.key}
-                   |""".stripMargin
-
-            val explain = run(query.explain()).futureValue.mkString("\n")
-
-            explain should include("outputs_pk")
-          }
-        }
-      }
-    }
-  }
 }

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/TransactionQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/TransactionQueriesSpec.scala
@@ -35,7 +35,7 @@ import org.alephium.explorer.persistence.queries.result._
 import org.alephium.explorer.persistence.schema._
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.explorer.service.FinalizerService
-import org.alephium.explorer.util.SlickTestUtil._
+import org.alephium.explorer.util.SlickExplainUtil._
 import org.alephium.protocol.ALPH
 import org.alephium.util.{Duration, TimeStamp, U256}
 


### PR DESCRIPTION
## Overview
- For #283, #191
- Added check for query `getTxnHash` to `IndexChecker`
- Added field `message` to `ExplainResult` for showing more info. For example: The following image shows the output for all indexes used by the query. 

## JSON
- First is for an `output` with oldest `timestamp`.
- First is for an `output` with latest `timestamp`. 
- Real data used by running sync partially. `173651` rows in `outputs` table, all with `main_chain = true`.

![image](https://user-images.githubusercontent.com/1773953/182075056-28fa65fe-6277-4981-8bae-2604ede0852e.png)


