### PR TITLE
Fix/issue 142

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/persistence/dao/UnconfirmedTxDao.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/dao/UnconfirmedTxDao.scala
@@ -60,7 +60,7 @@ object UnconfirmedTxDao extends UnconfirmedTxDao {
     run(for {
       maybeTx <- UnconfirmedTxSchema.table.filter(_.hash === hash).result.headOption
       inputs  <- UInputSchema.table.filter(_.txHash === hash).result
-      outputs <- UOutputSchema.table.filter(_.txHash === hash).result
+      outputs <- UOutputSchema.table.filter(_.txHash === hash).sortBy(_.uoutputOrder).result
     } yield {
       maybeTx.map { tx =>
         UnconfirmedTransaction(

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/UOutputEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/UOutputEntity.scala
@@ -23,7 +23,8 @@ final case class UOutputEntity(
     txHash: Transaction.Hash,
     amount: U256,
     address: Address,
-    lockTime: Option[TimeStamp]
+    lockTime: Option[TimeStamp],
+    uoutputOrder: Int
 ) {
   val toApi: UOutput =
     UOutput(

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/UnconfirmedTxEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/UnconfirmedTxEntity.scala
@@ -45,13 +45,15 @@ object UnconfirmedTxEntity {
          input.unlockScript
        )
      },
-     utx.outputs.map { output =>
-       UOutputEntity(
-         utx.hash,
-         output.amount,
-         output.address,
-         output.lockTime
-       )
+     utx.outputs.zipWithIndex.map {
+       case (output, order) =>
+         UOutputEntity(
+           utx.hash,
+           output.amount,
+           output.address,
+           output.lockTime,
+           order
+         )
      })
   }
 }

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/UOutputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/UOutputSchema.scala
@@ -32,13 +32,14 @@ object UOutputSchema extends Schema[UOutputEntity]("uoutputs") {
       column[U256]("amount", O.SqlType("DECIMAL(80,0)")) //U256.MaxValue has 78 digits
     def address: Rep[Address]            = column[Address]("address")
     def lockTime: Rep[Option[TimeStamp]] = column[Option[TimeStamp]]("lock_time")
+    def uoutputOrder: Rep[Int]           = column[Int]("uoutput_order")
 
-    def pk: PrimaryKey = primaryKey("uoutputs_pk", (txHash, address))
+    def pk: PrimaryKey = primaryKey("uoutputs_pk", (txHash, address, uoutputOrder))
 
     def txHashIdx: Index = index("uoutputs_tx_hash_idx", txHash)
 
     def * : ProvenShape[UOutputEntity] =
-      (txHash, amount, address, lockTime)
+      (txHash, amount, address, lockTime, uoutputOrder)
         .<>((UOutputEntity.apply _).tupled, UOutputEntity.unapply)
   }
 

--- a/app/src/test/scala/org/alephium/explorer/persistence/dao/UnconfirmedTxDaoSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/dao/UnconfirmedTxDaoSpec.scala
@@ -24,7 +24,8 @@ import org.scalatest.time.{Minutes, Span}
 import slick.jdbc.PostgresProfile.api._
 
 import org.alephium.explorer.AlephiumSpec
-import org.alephium.explorer.GenApiModel.utransactionGen
+import org.alephium.explorer.GenApiModel.{uoutputGen, utransactionGen}
+import org.alephium.explorer.GenCoreUtil.timestampGen
 import org.alephium.explorer.api.model.Transaction
 import org.alephium.explorer.persistence.{DatabaseFixtureForEach, DBRunner}
 import org.alephium.explorer.persistence.schema._
@@ -70,6 +71,19 @@ class UnconfirmedTxDaoSpec
       UnconfirmedTxDao.insertMany(Seq(utx)).futureValue
 
       UnconfirmedTxDao.get(utx.hash).futureValue is Some(utx)
+    }
+  }
+
+  "get utx with multiple outputs with same address but different lock time. Issue #142 " in {
+    forAll(Gen.choose(2, 6), uoutputGen, utransactionGen) {
+      case (outputSize, out, utx) =>
+        //outputs with same address but different lockTime
+        val outputs = Seq.fill(outputSize)(out.copy(lockTime = Some(timestampGen.sample.get)))
+
+        UnconfirmedTxDao.insertMany(Seq(utx.copy(outputs = outputs))).futureValue
+
+        //TODO Fix me, this is wrong, should be `outputSize`
+        UnconfirmedTxDao.get(utx.hash).futureValue.get.outputs.size is 1
     }
   }
 

--- a/app/src/test/scala/org/alephium/explorer/persistence/dao/UnconfirmedTxDaoSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/dao/UnconfirmedTxDaoSpec.scala
@@ -82,8 +82,7 @@ class UnconfirmedTxDaoSpec
 
         UnconfirmedTxDao.insertMany(Seq(utx.copy(outputs = outputs))).futureValue
 
-        //TODO Fix me, this is wrong, should be `outputSize`
-        UnconfirmedTxDao.get(utx.hash).futureValue.get.outputs.size is 1
+        UnconfirmedTxDao.get(utx.hash).futureValue.get.outputs.size is outputSize
     }
   }
 


### PR DESCRIPTION
Basically we were not using the correct primary key and when we were
inserting multiple uoutput with the same address but a different lock
time, we were overriding the previous one.