### PR TITLE
fixes #293: Typed `AppStateSchema`

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/persistence/Migrations.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/Migrations.scala
@@ -25,9 +25,8 @@ import slick.dbio.DBIOAction
 import slick.jdbc.PostgresProfile
 import slick.jdbc.PostgresProfile.api._
 
-import org.alephium.explorer.persistence._
-import org.alephium.explorer.persistence.model.AppState
-import org.alephium.explorer.persistence.schema.AppStateSchema
+import org.alephium.explorer.persistence.model.AppState.MigrationVersion
+import org.alephium.explorer.persistence.queries.AppStateQueries
 import org.alephium.explorer.persistence.schema.CustomGetResult._
 import org.alephium.serde._
 
@@ -69,8 +68,8 @@ object Migrations extends StrictLogging {
     versionOpt match {
       case None => DBIOAction.successful(())
       case Some(version) =>
-        AppStateSchema.table
-          .insertOrUpdate(AppState("migrations_version", serialize(version)))
+        AppStateQueries
+          .insertOrUpdate(MigrationVersion(version))
           .map(_ => ())
     }
   }

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/AppState.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/AppState.scala
@@ -18,7 +18,57 @@ package org.alephium.explorer.persistence.model
 
 import akka.util.ByteString
 
-final case class AppState(
-    key: String,
-    value: ByteString
-)
+import org.alephium.serde._
+import org.alephium.util.TimeStamp
+
+/** Values of AppState */
+sealed trait AppState
+
+/** Keys for AppState */
+sealed trait AppStateKey {
+  def key: String
+
+  def apply(bytes: ByteString): Either[SerdeError, AppState]
+}
+
+object AppState {
+
+  /** Fetch value for the key and serialised value, or-else, throw error */
+  def applyOrThrow(key: AppStateKey, bytes: ByteString): AppState =
+    key(bytes) match {
+      case Left(error)     => throw error
+      case Right(appState) => appState
+    }
+
+  def unapplyOpt(result: AppState): Option[(AppStateKey, ByteString)] =
+    Some(unapply(result))
+
+  def unapply(result: AppState): (AppStateKey, ByteString) =
+    result match {
+      case LastFinalizedInputTime(value) => (LastFinalizedInputTime, serialize(value))
+      case MigrationVersion(value)       => (MigrationVersion, serialize(value))
+    }
+
+  object LastFinalizedInputTime extends AppStateKey {
+    val key = "last_finalized_input_time"
+
+    def apply(bytes: ByteString): Either[SerdeError, LastFinalizedInputTime] =
+      deserialize[TimeStamp](bytes).map(LastFinalizedInputTime(_))
+  }
+
+  final case class LastFinalizedInputTime(time: TimeStamp) extends AppState
+
+  object MigrationVersion extends AppStateKey {
+    val key = "migrations_version"
+
+    def apply(bytes: ByteString): Either[SerdeError, MigrationVersion] =
+      deserialize[Int](bytes).map(MigrationVersion(_))
+  }
+
+  final case class MigrationVersion(version: Int) extends AppState
+
+  /** All the keys */
+  def keys(): Array[AppStateKey] =
+    Array(LastFinalizedInputTime, MigrationVersion)
+
+}

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/AppStateQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/AppStateQueries.scala
@@ -14,24 +14,24 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the library. If not, see <http://www.gnu.org/licenses/>.
 
-package org.alephium.explorer.persistence.schema
+package org.alephium.explorer.persistence.queries
 
-import akka.util.ByteString
 import slick.jdbc.PostgresProfile.api._
-import slick.lifted.ProvenShape
 
+import org.alephium.explorer.persistence.{DBActionR, DBActionW}
 import org.alephium.explorer.persistence.model.{AppState, AppStateKey}
+import org.alephium.explorer.persistence.schema.AppStateSchema
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 
-object AppStateSchema extends Schema[AppState]("app_state") {
+/** Queries for table [[org.alephium.explorer.persistence.schema.AppStateSchema.table]] */
+object AppStateQueries {
 
-  class AppStates(tag: Tag) extends Table[AppState](tag, name) {
-    def key: Rep[AppStateKey]  = column[AppStateKey]("key", O.PrimaryKey)
-    def value: Rep[ByteString] = column[ByteString]("value")
+  @inline def insert(appState: AppState): DBActionW[Int] =
+    AppStateSchema.table += appState
 
-    def * : ProvenShape[AppState] =
-      (key, value).<>((AppState.applyOrThrow _).tupled, AppState.unapplyOpt)
-  }
+  @inline def insertOrUpdate(appState: AppState): DBActionW[Int] =
+    AppStateSchema.table insertOrUpdate appState
 
-  val table: TableQuery[AppStates] = TableQuery[AppStates]
+  @inline def get(appState: AppStateKey): DBActionR[Option[AppState]] =
+    AppStateSchema.table.filter(_.key === appState).result.headOption
 }

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomJdbcTypes.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomJdbcTypes.scala
@@ -27,7 +27,7 @@ import slick.jdbc.PostgresProfile.api._
 
 import org.alephium.explorer._
 import org.alephium.explorer.api.model._
-import org.alephium.explorer.persistence.model.OutputEntity
+import org.alephium.explorer.persistence.model.{AppState, AppStateKey, OutputEntity}
 import org.alephium.serde._
 import org.alephium.util.{AVector, TimeStamp, U256}
 
@@ -121,5 +121,15 @@ object CustomJdbcTypes {
     MappedJdbcType.base[OutputEntity.OutputType, Int](
       _.value,
       OutputEntity.OutputType.unsafe
+    )
+
+  implicit val appStateKey: JdbcType[AppStateKey] =
+    MappedJdbcType.base[AppStateKey, String](
+      state => state.key,
+      key =>
+        AppState
+          .keys()
+          .find(_.key == key)
+          .getOrElse(throw new Exception(s"Invalid ${classOf[AppStateKey].getSimpleName}: $key"))
     )
 }

--- a/app/src/main/scala/org/alephium/explorer/service/FinalizerService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/FinalizerService.scala
@@ -29,8 +29,8 @@ import slick.jdbc.PostgresProfile.api._
 import org.alephium.explorer.foldFutures
 import org.alephium.explorer.persistence._
 import org.alephium.explorer.persistence.DBRunner._
-import org.alephium.explorer.persistence.model.AppState
-import org.alephium.explorer.persistence.schema.AppStateSchema
+import org.alephium.explorer.persistence.model.AppState.LastFinalizedInputTime
+import org.alephium.explorer.persistence.queries.AppStateQueries
 import org.alephium.explorer.persistence.schema.CustomGetResult._
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.explorer.util.{Scheduler, TimeUtil}
@@ -163,5 +163,5 @@ case object FinalizerService extends StrictLogging {
       })
 
   private def updateLastFinalizedInputTime(time: TimeStamp) =
-    AppStateSchema.table.insertOrUpdate(AppState("last_finalized_input_time", serialize(time)))
+    AppStateQueries.insertOrUpdate(LastFinalizedInputTime(time))
 }

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/AppStateQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/AppStateQueriesSpec.scala
@@ -1,0 +1,69 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.persistence.queries
+
+import scala.concurrent.ExecutionContext
+
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Minutes, Span}
+import slick.jdbc.PostgresProfile.api._
+
+import org.alephium.explorer.AlephiumSpec
+import org.alephium.explorer.GenCoreUtil._
+import org.alephium.explorer.persistence.{DatabaseFixtureForEach, DBRunner}
+import org.alephium.explorer.persistence.model.AppState
+import org.alephium.explorer.persistence.schema.AppStateSchema
+
+class AppStateQueriesSpec
+    extends AlephiumSpec
+    with DatabaseFixtureForEach
+    with DBRunner
+    with ScalaFutures {
+
+  implicit val executionContext: ExecutionContext = ExecutionContext.global
+  override implicit val patienceConfig            = PatienceConfig(timeout = Span(1, Minutes))
+
+  "insert" should {
+    "write LastFinalizedInputTime key-value" in {
+      forAll(timestampGen) { timestamp =>
+        run(AppStateSchema.table.delete).futureValue
+        val insertValue = AppState.LastFinalizedInputTime(timestamp)
+        run(AppStateQueries.insert(insertValue)).futureValue is 1
+        run(AppStateQueries.get(AppState.LastFinalizedInputTime)).futureValue is Some(insertValue)
+      }
+    }
+
+    "write MigrationVersion key-value" in {
+      forAll { int: Int =>
+        run(AppStateSchema.table.delete).futureValue
+        val insertValue = AppState.MigrationVersion(int)
+        run(AppStateQueries.insert(insertValue)).futureValue is 1
+        run(AppStateQueries.get(AppState.MigrationVersion)).futureValue is Some(insertValue)
+      }
+    }
+  }
+
+  "insertOrUpdate" should {
+    "overwrite key-values" in {
+      forAll { int: Int =>
+        val insertValue = AppState.MigrationVersion(int)
+        run(AppStateQueries.insertOrUpdate(insertValue)).futureValue is 1
+        run(AppStateQueries.get(AppState.MigrationVersion)).futureValue is Some(insertValue)
+      }
+    }
+  }
+}

--- a/app/src/test/scala/org/alephium/explorer/service/FinalizerServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/FinalizerServiceSpec.scala
@@ -19,15 +19,13 @@ package org.alephium.explorer.service
 import scala.concurrent.ExecutionContext
 
 import org.scalatest.concurrent.ScalaFutures
-import slick.jdbc.PostgresProfile.api._
 
 import org.alephium.explorer.AlephiumSpec
 import org.alephium.explorer.Generators._
 import org.alephium.explorer.persistence.{DatabaseFixtureForEach, DBRunner}
-import org.alephium.explorer.persistence.model.{AppState, InputEntity}
-import org.alephium.explorer.persistence.queries.InputQueries
-import org.alephium.explorer.persistence.schema.AppStateSchema
-import org.alephium.serde._
+import org.alephium.explorer.persistence.model.AppState.LastFinalizedInputTime
+import org.alephium.explorer.persistence.model.InputEntity
+import org.alephium.explorer.persistence.queries.{AppStateQueries, InputQueries}
 import org.alephium.util.{Duration, TimeStamp}
 
 class FinalizerServiceSpec
@@ -86,9 +84,7 @@ class FinalizerServiceSpec
     firstFinalizationTime.isBefore(end2)
     end2.isBefore(FinalizerService.finalizationTime)
 
-    run(
-      AppStateSchema.table.insertOrUpdate(
-        AppState("last_finalized_input_time", serialize(input2.timestamp)))).futureValue
+    run(AppStateQueries.insertOrUpdate(LastFinalizedInputTime(input2.timestamp))).futureValue
 
     val Some((start3, _)) = run(FinalizerService.getStartEndTime()).futureValue
 


### PR DESCRIPTION
- fixes #293
- added `AppStateQueries` and moved calls directly to the table to use `AppStateQueries`.