### PR TITLE
Cache blocks pages

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/cache/BlockCache.scala
+++ b/app/src/main/scala/org/alephium/explorer/cache/BlockCache.scala
@@ -103,7 +103,7 @@ object BlockCache {
     new BlockCache(
       blockTimes   = cachedBlockTimes,
       rowCount     = cacheRowCount,
-      latestBlocks = cachedLatestBlocks
+      latestBlockPerChains = cachedLatestBlocks
     )
   }
 
@@ -115,20 +115,20 @@ object BlockCache {
   * */
 class BlockCache(blockTimes: CaffeineAsyncCache[ChainIndex, Duration],
                  rowCount: AsyncReloadingCache[Int],
-                 latestBlocks: CaffeineAsyncCache[ChainIndex, LatestBlock]) {
+                 latestBlockPerChains: CaffeineAsyncCache[ChainIndex, LatestBlock]) {
 
   /** Operations on `blockTimes` cache */
   def getAllBlockTimes(chainIndexes: Iterable[ChainIndex])(
       implicit ec: ExecutionContext): Future[Seq[(ChainIndex, Duration)]] =
     blockTimes.getAll(chainIndexes)
 
-  /** Operations on `latestBlocks` cache */
+  /** Operations on `latestBlockPerChains` cache */
   def getAllLatestBlocks()(implicit ec: ExecutionContext,
                            groupSetting: GroupSetting): Future[Seq[(ChainIndex, LatestBlock)]] =
-    latestBlocks.getAll(groupSetting.chainIndexes)
+    latestBlockPerChains.getAll(groupSetting.chainIndexes)
 
   def putLatestBlock(chainIndex: ChainIndex, block: LatestBlock): Unit =
-    latestBlocks.put(chainIndex, block)
+    latestBlockPerChains.put(chainIndex, block)
 
   def getMainChainBlockCount(): Int =
     rowCount.get()

--- a/app/src/main/scala/org/alephium/explorer/persistence/dao/BlockDao.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/dao/BlockDao.scala
@@ -71,9 +71,8 @@ object BlockDao {
 
   def listMainChain(pagination: Pagination)(
       implicit ec: ExecutionContext,
-      dc: DatabaseConfig[PostgresProfile],
       cache: BlockCache): Future[(Seq[BlockEntryLite], Int)] = {
-    run(listMainChainHeadersWithTxnNumberSQL(pagination)).map { blockEntries =>
+    cache.listMainChainHeaders(pagination).map { blockEntries =>
       (blockEntries, cache.getMainChainBlockCount())
     }
   }

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
@@ -117,14 +117,13 @@ object BlockQueries extends StrictLogging {
   /**
     * Fetches all main_chain [[org.alephium.explorer.persistence.schema.BlockHeaderSchema.table]] rows
     */
-  def listMainChainHeadersWithTxnNumberSQL(
-      pagination: Pagination): DBActionRWT[Vector[BlockEntryLite]] =
-    listMainChainHeadersWithTxnNumberSQLBuilder(pagination)
+  def listMainChainHeadersSQL(pagination: Pagination): DBActionRWT[Vector[BlockEntryLite]] =
+    listMainChainHeadersSQLBuilder(pagination)
       .as[BlockEntryLite](blockEntryListGetResult)
 
   def explainListMainChainHeadersWithTxnNumber(pagination: Pagination)(
       implicit ec: ExecutionContext): DBActionR[ExplainResult] =
-    listMainChainHeadersWithTxnNumberSQLBuilder(pagination).explainAnalyze() map { explain =>
+    listMainChainHeadersSQLBuilder(pagination).explainAnalyze() map { explain =>
       ExplainResult(
         queryName  = "listMainChainHeadersWithTxnNumber",
         queryInput = pagination.toString,
@@ -134,7 +133,7 @@ object BlockQueries extends StrictLogging {
       )
     }
 
-  def listMainChainHeadersWithTxnNumberSQLBuilder(pagination: Pagination): SQLActionBuilder = {
+  def listMainChainHeadersSQLBuilder(pagination: Pagination): SQLActionBuilder = {
     //order by for inner query
     val orderBy =
       if (pagination.reverse) {

--- a/benchmark/src/main/scala/org/alephium/explorer/benchmark/db/DBBenchmark.scala
+++ b/benchmark/src/main/scala/org/alephium/explorer/benchmark/db/DBBenchmark.scala
@@ -111,9 +111,8 @@ class DBBenchmark {
     */
   @Benchmark
   def listBlocks_Forward_DisabledCP_SQL(state: ListBlocks_Forward_DisabledCP_ReadState): Unit = {
-    implicit val ec: ExecutionContext                = state.config.db.ioExecutionContext
-    implicit val dc: DatabaseConfig[PostgresProfile] = state.config
-    implicit val cache: BlockCache                   = state.blockCache
+    implicit val ec: ExecutionContext = state.config.db.ioExecutionContext
+    implicit val cache: BlockCache    = state.blockCache
 
     val _ =
       Await.result(BlockDao.listMainChain(state.next), requestTimeout)
@@ -121,9 +120,8 @@ class DBBenchmark {
 
   @Benchmark
   def listBlocks_Reverse_DisabledCP_SQL(state: ListBlocks_Reverse_DisabledCP_ReadState): Unit = {
-    implicit val ec: ExecutionContext                = state.config.db.ioExecutionContext
-    implicit val dc: DatabaseConfig[PostgresProfile] = state.config
-    implicit val cache: BlockCache                   = state.blockCache
+    implicit val ec: ExecutionContext = state.config.db.ioExecutionContext
+    implicit val cache: BlockCache    = state.blockCache
 
     val _ =
       Await.result(BlockDao.listMainChain(state.next), requestTimeout)
@@ -137,9 +135,8 @@ class DBBenchmark {
     */
   @Benchmark
   def listBlocks_Forward_HikariCP_SQL_Cached(state: ListBlocks_Forward_HikariCP_ReadState): Unit = {
-    implicit val ec: ExecutionContext                = state.config.db.ioExecutionContext
-    implicit val dc: DatabaseConfig[PostgresProfile] = state.config
-    implicit val cache: BlockCache                   = state.blockCache
+    implicit val ec: ExecutionContext = state.config.db.ioExecutionContext
+    implicit val cache: BlockCache    = state.blockCache
 
     val _ =
       Await.result(BlockDao.listMainChain(state.next), requestTimeout)


### PR DESCRIPTION
Cache blocks based on pagination

The goal is to improve the home page of our explorer.

We trust here the eviction algorithm of Caffeine:

[tinyLFU](https://dl.acm.org/doi/pdf/10.1145/3149371)

As the first page of the explorer is the one that will be called almost
all the time compared to any other pages, it should almost never be
evicted by the cache.

Resolves: #151
