### PR TITLE
#328: Query for `getLocalMaxTimestamp`

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/persistence/model/BlockHeader.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/BlockHeader.scala
@@ -18,8 +18,6 @@ package org.alephium.explorer.persistence.model
 
 import java.math.BigInteger
 
-import scala.math.Ordering.Implicits.infixOrderingOps
-
 import akka.util.ByteString
 
 import org.alephium.explorer.Hash
@@ -67,62 +65,4 @@ object BlockHeader {
       blockEntity.hashrate,
       blockEntity.parent(groupNum)
     )
-
-  /**
-    * Finds a block with maximum height. If two blocks have the same
-    * height, returns the one with maximum timestamp.
-    * */
-  def maxHeight(blocks: Iterable[BlockHeader]): Option[BlockHeader] =
-    blocks.foldLeft(Option.empty[BlockHeader]) {
-      case (currentMax, header) =>
-        currentMax match {
-          case Some(current) =>
-            if (header.height > current.height) {
-              Some(header)
-            } else if (header.height == current.height) {
-              maxTimeStamp(Array(current, header))
-            } else {
-              currentMax
-            }
-
-          case None =>
-            Some(header)
-        }
-    }
-
-  /** Finds a block with maximum timestamp */
-  def maxTimeStamp(blocks: Iterable[BlockHeader]): Option[BlockHeader] =
-    blocks.foldLeft(Option.empty[BlockHeader]) {
-      case (currentMax, header) =>
-        currentMax match {
-          case Some(current) =>
-            if (header.timestamp > current.timestamp) {
-              Some(header)
-            } else {
-              currentMax
-            }
-
-          case None =>
-            Some(header)
-        }
-    }
-
-  /** Filter blocks within the given chain */
-  @inline def filterBlocksInChain(blocks: Iterable[BlockHeader],
-                                  chainFrom: GroupIndex,
-                                  chainTo: GroupIndex): Iterable[BlockHeader] =
-    blocks.filter { header =>
-      header.chainFrom == chainFrom &&
-      header.chainTo == chainTo
-    }
-
-  /** Sum height of all blocks */
-  def sumHeight(blocks: Iterable[BlockHeader]): Option[Height] =
-    blocks.foldLeft(Option.empty[Height]) {
-      case (currentSum, header) =>
-        currentSum match {
-          case Some(sum) => Some(Height.unsafe(sum.value + header.height.value))
-          case None      => Some(header.height)
-        }
-    }
 }

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/BlockHeader.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/BlockHeader.scala
@@ -80,7 +80,7 @@ object BlockHeader {
             if (header.height > current.height) {
               Some(header)
             } else if (header.height == current.height) {
-              maxTimeStamp(currentMax ++ Some(header))
+              maxTimeStamp(Array(current, header))
             } else {
               currentMax
             }
@@ -116,7 +116,7 @@ object BlockHeader {
       header.chainTo == chainTo
     }
 
-  /** Sum height of the given blocks */
+  /** Sum height of all blocks */
   def sumHeight(blocks: Iterable[BlockHeader]): Option[Height] =
     blocks.foldLeft(Option.empty[Height]) {
       case (currentSum, header) =>

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
@@ -343,11 +343,13 @@ object BlockQueries extends StrictLogging {
   def noOfBlocksAndMaxBlockTimestamp()(
       implicit groupSetting: GroupSetting,
       ec: ExecutionContext): DBActionR[Option[(TimeStamp, Height)]] = {
+    //build queries for each chainFrom-chainTo and merge them into a single UNION query
     val unions: String =
       Array
         .fill(groupSetting.groupIndexes.size)(maxBlockTimestampForMaxHeightForChainSQL)
         .mkString("UNION")
 
+    //fetch maximum `block_timestamp` and sum all `heights` for all unions
     val query =
       s"""
         |SELECT max(block_timestamp),

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
@@ -340,7 +340,7 @@ object BlockQueries extends StrictLogging {
     * @param groupSetting Provides the list of chains to run this query on
     * @return Maximum timestamp and sum of all heights i.e. the total number of blocks.
     */
-  def noOfBlocksAndMaxBlockTimestamp()(
+  def numOfBlocksAndMaxBlockTimestamp()(
       implicit groupSetting: GroupSetting,
       ec: ExecutionContext): DBActionR[Option[(TimeStamp, Height)]] = {
     //build queries for each chainFrom-chainTo and merge them into a single UNION query

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomGetResult.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomGetResult.scala
@@ -64,6 +64,16 @@ object CustomGetResult {
   implicit val heightGetResult: GetResult[Height] =
     (result: PositionedResult) => Height.unsafe(result.nextInt())
 
+  implicit val heightOptionGetResult: GetResult[Option[Height]] =
+    (result: PositionedResult) => result.nextIntOption().map(Height.unsafe)
+
+  implicit val timeStampHeightOptionGetResult: GetResult[Option[(TimeStamp, Height)]] =
+    (result: PositionedResult) =>
+      for {
+        timestamp <- optionTimestampGetResult(result)
+        height    <- heightOptionGetResult(result)
+      } yield (timestamp, height)
+
   implicit val bigIntegerGetResult: GetResult[BigInteger] =
     (result: PositionedResult) => result.nextBigDecimal().toBigInt.bigInteger
 

--- a/app/src/main/scala/org/alephium/explorer/service/BlockFlowSyncService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/BlockFlowSyncService.scala
@@ -179,13 +179,13 @@ case object BlockFlowSyncService extends StrictLogging {
     fetchAndBuildTimeStampRange(step, backStep, getLocalMaxTimestamp(), getRemoteMaxTimestamp())
   }
 
-  /** @see [[org.alephium.explorer.persistence.queries.BlockQueries.noOfBlocksAndMaxBlockTimestamp]] */
+  /** @see [[org.alephium.explorer.persistence.queries.BlockQueries.numOfBlocksAndMaxBlockTimestamp]] */
   def getLocalMaxTimestamp()(implicit ec: ExecutionContext,
                              dc: DatabaseConfig[PostgresProfile],
                              groupSetting: GroupSetting): Future[Option[(TimeStamp, Int)]] = {
     //Convert query result to return `Height` as `Int` value.
     val queryResultToIntHeight =
-      BlockQueries.noOfBlocksAndMaxBlockTimestamp() map { optionResult =>
+      BlockQueries.numOfBlocksAndMaxBlockTimestamp() map { optionResult =>
         optionResult map {
           case (timestamp, height) =>
             (timestamp, height.value)

--- a/app/src/main/scala/org/alephium/explorer/util/SlickUtil.scala
+++ b/app/src/main/scala/org/alephium/explorer/util/SlickUtil.scala
@@ -49,6 +49,7 @@ object SlickUtil {
       * return only one row or none. If the more than one rows are return then there
       * is a problem in the query itself.
       * */
+    @SuppressWarnings(Array("org.wartremover.warts.IterableOps"))
     def oneOrNone(implicit ec: ExecutionContext): DBActionR[Option[A]] =
       action.flatMap { rows =>
         rows.size match {

--- a/app/src/main/scala/org/alephium/explorer/util/SlickUtil.scala
+++ b/app/src/main/scala/org/alephium/explorer/util/SlickUtil.scala
@@ -40,6 +40,25 @@ object SlickUtil {
       }
   }
 
+  implicit class OptionResultEnrichment[A](val action: DBActionSR[Option[A]]) extends AnyVal {
+
+    /**
+      * Expects query to return less than or equal to 1. Fails is the result is greater than 1.
+      *
+      * This is used to ensure queries selecting on SQL functions like `sum` and `max`
+      * return only one row or none. If the more than one rows are return then there
+      * is a problem in the query itself.
+      * */
+    def oneOrNone(implicit ec: ExecutionContext): DBActionR[Option[A]] =
+      action.flatMap { rows =>
+        rows.size match {
+          case 0 => DBIO.successful(None)
+          case 1 => DBIO.successful(rows.head)
+          case n => DBIO.failed(new RuntimeException(s"Expected 1 result, actual $n"))
+        }
+      }
+  }
+
   def paramPlaceholderTuple2(rows: Int, columns: Int): String =
     paramPlaceholder(rows, columns, "(?, ?)")
 

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockQueriesSpec.scala
@@ -256,22 +256,6 @@ class BlockQueriesSpec
 
           actualTimeStampAndNumberOfBlocks.map(_._1) is expectedMaxTimeStamp
           actualTimeStampAndNumberOfBlocks.map(_._2) is expectedNumberOfBlocks
-
-          /**
-            * Checks that replacement query returns the same result as
-            * original code.
-            *
-            * TODO: Remove this and deprecated code before merge.
-            */
-          locally {
-            val replacementResult =
-              BlockFlowSyncService.getLocalMaxTimestamp().futureValue
-
-            val deprecatedResult =
-              BlockFlowSyncService.getLocalMaxTimestampDEPRECATED().futureValue
-
-            replacementResult is deprecatedResult
-          }
         }
       }
     }

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockQueriesSpec.scala
@@ -205,14 +205,11 @@ class BlockQueriesSpec
             * TODO: Remove this and deprecated code before merge.
             */
           locally {
+            val replacementResult =
+              BlockFlowSyncService.getLocalMaxTimestamp().futureValue
+
             val deprecatedResult =
               BlockFlowSyncService.getLocalMaxTimestampDEPRECATED().futureValue
-
-            val replacementResult =
-              actualTimeStampAndNumberOfBlocks map {
-                case (timestamp, height) =>
-                  (timestamp, height.value)
-              }
 
             replacementResult is deprecatedResult
           }

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockQueriesSpec.scala
@@ -17,6 +17,7 @@
 package org.alephium.explorer.persistence.queries
 
 import scala.concurrent.ExecutionContext
+import scala.math.Ordering.Implicits.infixOrderingOps
 
 import org.scalacheck.Gen
 import org.scalatest.concurrent.ScalaFutures
@@ -26,7 +27,7 @@ import slick.jdbc.PostgresProfile.api._
 import org.alephium.explorer.{AlephiumSpec, GroupSetting}
 import org.alephium.explorer.GenApiModel.blockEntryHashGen
 import org.alephium.explorer.Generators._
-import org.alephium.explorer.api.model.GroupIndex
+import org.alephium.explorer.api.model.{GroupIndex, Height}
 import org.alephium.explorer.persistence.{DatabaseFixtureForEach, DBRunner}
 import org.alephium.explorer.persistence.model.BlockHeader
 import org.alephium.explorer.persistence.schema._
@@ -40,6 +41,64 @@ class BlockQueriesSpec
 
   implicit val executionContext: ExecutionContext = ExecutionContext.global
   override implicit val patienceConfig            = PatienceConfig(timeout = Span(1000, Minutes))
+
+  /**
+    * Finds a block with maximum height. If two blocks have the same
+    * height, returns the one with maximum timestamp.
+    * */
+  def maxHeight(blocks: Iterable[BlockHeader]): Option[BlockHeader] =
+    blocks.foldLeft(Option.empty[BlockHeader]) {
+      case (currentMax, header) =>
+        currentMax match {
+          case Some(current) =>
+            if (header.height > current.height) {
+              Some(header)
+            } else if (header.height == current.height) {
+              maxTimeStamp(Array(current, header))
+            } else {
+              currentMax
+            }
+
+          case None =>
+            Some(header)
+        }
+    }
+
+  /** Finds a block with maximum timestamp */
+  def maxTimeStamp(blocks: Iterable[BlockHeader]): Option[BlockHeader] =
+    blocks.foldLeft(Option.empty[BlockHeader]) {
+      case (currentMax, header) =>
+        currentMax match {
+          case Some(current) =>
+            if (header.timestamp > current.timestamp) {
+              Some(header)
+            } else {
+              currentMax
+            }
+
+          case None =>
+            Some(header)
+        }
+    }
+
+  /** Filter blocks within the given chain */
+  @inline def filterBlocksInChain(blocks: Iterable[BlockHeader],
+                                  chainFrom: GroupIndex,
+                                  chainTo: GroupIndex): Iterable[BlockHeader] =
+    blocks.filter { header =>
+      header.chainFrom == chainFrom &&
+      header.chainTo == chainTo
+    }
+
+  /** Sum height of all blocks */
+  def sumHeight(blocks: Iterable[BlockHeader]): Option[Height] =
+    blocks.foldLeft(Option.empty[Height]) {
+      case (currentSum, header) =>
+        currentSum match {
+          case Some(sum) => Some(Height.unsafe(sum.value + header.height.value))
+          case None      => Some(header.height)
+        }
+    }
 
   "insert and ignore block_headers" in {
 
@@ -179,17 +238,17 @@ class BlockQueriesSpec
             groupSetting.groupIndexes
               .flatMap {
                 case (from, to) =>
-                  val blocksInThisChain = BlockHeader.filterBlocksInChain(blocks, from, to)
-                  BlockHeader.maxHeight(blocksInThisChain)
+                  val blocksInThisChain = filterBlocksInChain(blocks, from, to)
+                  maxHeight(blocksInThisChain)
               }
 
           //expected total number of blocks
           val expectedNumberOfBlocks =
-            BlockHeader.sumHeight(maxHeightBlocks)
+            sumHeight(maxHeightBlocks)
 
           //expected maximum timestamp
           val expectedMaxTimeStamp =
-            BlockHeader.maxTimeStamp(maxHeightBlocks).map(_.timestamp)
+            maxTimeStamp(maxHeightBlocks).map(_.timestamp)
 
           //Queried result Option[(TimeStamp, Height)]
           val actualTimeStampAndNumberOfBlocks =

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockQueriesSpec.scala
@@ -31,7 +31,6 @@ import org.alephium.explorer.api.model.{GroupIndex, Height}
 import org.alephium.explorer.persistence.{DatabaseFixtureForEach, DBRunner}
 import org.alephium.explorer.persistence.model.BlockHeader
 import org.alephium.explorer.persistence.schema._
-import org.alephium.explorer.service.BlockFlowSyncService
 
 class BlockQueriesSpec
     extends AlephiumSpec
@@ -82,9 +81,9 @@ class BlockQueriesSpec
     }
 
   /** Filter blocks within the given chain */
-  @inline def filterBlocksInChain(blocks: Iterable[BlockHeader],
-                                  chainFrom: GroupIndex,
-                                  chainTo: GroupIndex): Iterable[BlockHeader] =
+  def filterBlocksInChain(blocks: Iterable[BlockHeader],
+                          chainFrom: GroupIndex,
+                          chainTo: GroupIndex): Iterable[BlockHeader] =
     blocks.filter { header =>
       header.chainFrom == chainFrom &&
       header.chainTo == chainTo
@@ -199,7 +198,7 @@ class BlockQueriesSpec
     "return None" when {
       "there is no data" in {
         forAll(groupSettingGen) { implicit groupSetting =>
-          run(BlockQueries.noOfBlocksAndMaxBlockTimestamp()).futureValue is None
+          run(BlockQueries.numOfBlocksAndMaxBlockTimestamp()).futureValue is None
         }
       }
 
@@ -220,7 +219,7 @@ class BlockQueriesSpec
 
             implicit val implicitGroupSetting: GroupSetting = groupSetting
             //No blocks exists for the groupSetting so result is None
-            run(BlockQueries.noOfBlocksAndMaxBlockTimestamp()).futureValue is None
+            run(BlockQueries.numOfBlocksAndMaxBlockTimestamp()).futureValue is None
 
         }
       }
@@ -252,7 +251,7 @@ class BlockQueriesSpec
 
           //Queried result Option[(TimeStamp, Height)]
           val actualTimeStampAndNumberOfBlocks =
-            run(BlockQueries.noOfBlocksAndMaxBlockTimestamp()).futureValue
+            run(BlockQueries.numOfBlocksAndMaxBlockTimestamp()).futureValue
 
           actualTimeStampAndNumberOfBlocks.map(_._1) is expectedMaxTimeStamp
           actualTimeStampAndNumberOfBlocks.map(_._2) is expectedNumberOfBlocks


### PR DESCRIPTION
- Resolves #328. 
- Ran the test-case in this PR over 100s of iterations. The test also checks for same output as existing code. So it should cover all existing cases. 

Started off with typed query [here](https://github.com/alephium/explorer-backend/blob/328_getLocalMaxTimestamp_2/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala#L342) hoping to reuse existing queries to speed things up. But the generated `UNION` queries looked like following so switched to SQL. 

## TODO
- Remove deprecated code. See TODO in code. 
- Benchmarks. Please let me if you'd like this done.


## Generated query
<details>
  <summary>Generated query</summary>

  ```sql
(select x2.x3 as x4, x2.x5 as x6
 from ((select x7.x8 as x3, x7.x9 as x5
        from ((select x10.x11 as x8, x10.x12 as x9
               from ((select x13.x14 as x11, x13.x15 as x12
                      from ((select x16.x17 as x14, x16.x18 as x15
                             from ((select x19.x20 as x17, x19.x21 as x18
                                    from ((select x22.x23 as x20, x22.x24 as x21
                                           from ((select "height" as x23, max("block_timestamp") as x24
                                                  from "block_headers"
                                                  where (("height" = (select max("height")
                                                                      from "block_headers"
                                                                      where ("chain_from" = 0)
                                                                        and ("chain_to" = 0))) and ("chain_from" = 0))
                                                    and ("chain_to" = 0)
                                                  group by "height")
                                                 union all
                                                 (select "height" as x23, max("block_timestamp") as x24
                                                  from "block_headers"
                                                  where (("height" = (select max("height")
                                                                      from "block_headers"
                                                                      where ("chain_from" = 0)
                                                                        and ("chain_to" = 1))) and ("chain_from" = 0))
                                                    and ("chain_to" = 1)
                                                  group by "height")) x22)
                                          union all
                                          (select "height" as x20, max("block_timestamp") as x21
                                           from "block_headers"
                                           where (("height" = (select max("height")
                                                               from "block_headers"
                                                               where ("chain_from" = 0) and ("chain_to" = 2))) and
                                                  ("chain_from" = 0))
                                             and ("chain_to" = 2)
                                           group by "height")) x19)
                                   union all
                                   (select "height" as x17, max("block_timestamp") as x18
                                    from "block_headers"
                                    where (("height" = (select max("height")
                                                        from "block_headers"
                                                        where ("chain_from" = 1) and ("chain_to" = 0))) and
                                           ("chain_from" = 1))
                                      and ("chain_to" = 0)
                                    group by "height")) x16)
                            union all
                            (select "height" as x14, max("block_timestamp") as x15
                             from "block_headers"
                             where (("height" = (select max("height")
                                                 from "block_headers"
                                                 where ("chain_from" = 1) and ("chain_to" = 1))) and ("chain_from" = 1))
                               and ("chain_to" = 1)
                             group by "height")) x13)
                     union all
                     (select "height" as x11, max("block_timestamp") as x12
                      from "block_headers"
                      where (("height" = (select max("height")
                                          from "block_headers"
                                          where ("chain_from" = 1) and ("chain_to" = 2))) and ("chain_from" = 1))
                        and ("chain_to" = 2)
                      group by "height")) x10)
              union all
              (select "height" as x8, max("block_timestamp") as x9
               from "block_headers"
               where (("height" =
                       (select max("height") from "block_headers" where ("chain_from" = 2) and ("chain_to" = 0))) and
                      ("chain_from" = 2))
                 and ("chain_to" = 0)
               group by "height")) x7)
       union all
       (select "height" as x3, max("block_timestamp") as x5
        from "block_headers"
        where (("height" =
                (select max("height") from "block_headers" where ("chain_from" = 2) and ("chain_to" = 1))) and
               ("chain_from" = 2))
          and ("chain_to" = 1)
        group by "height")) x2)
union all
(select "height" as x4, max("block_timestamp") as x6
 from "block_headers"
 where (("height" = (select max("height") from "block_headers" where ("chain_from" = 2) and ("chain_to" = 2))) and
        ("chain_from" = 2))
   and ("chain_to" = 2)
 group by "height");
  ```
</details>
