### PR TITLE
#333: Fetch data required by `BlockFlowSyncService.init()` in single query

### DIFF
--- a/app/src/test/scala/org/alephium/explorer/Generators.scala
+++ b/app/src/test/scala/org/alephium/explorer/Generators.scala
@@ -69,11 +69,16 @@ object Generators {
       )
 
   val blockHeaderGen: Gen[BlockHeader] =
+    blockHeaderGenWithDefaults()
+
+  @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
+  def blockHeaderGenWithDefaults(chainFrom: Gen[GroupIndex] = groupIndexGen,
+                                 chainTo: Gen[GroupIndex]   = groupIndexGen): Gen[BlockHeader] =
     for {
       hash         <- blockEntryHashGen
       timestamp    <- timestampGen
-      chainFrom    <- groupIndexGen
-      chainTo      <- groupIndexGen
+      chainFrom    <- chainFrom
+      chainTo      <- chainTo
       height       <- heightGen
       version      <- Gen.posNum[Byte]
       depStateHash <- hashGen

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockQueriesSpec.scala
@@ -291,8 +291,8 @@ class BlockQueriesSpec
               groupSetting.groupIndexes
                 .map {
                   case (from, to) =>
-                    val blocksInThisChain = BlockHeader.filterBlocksInChain(blocks, from, to)
-                    BlockHeader.maxHeight(blocksInThisChain).map(_.height)
+                    val blocksInThisChain = filterBlocksInChain(blocks, from, to)
+                    maxHeight(blocksInThisChain).map(_.height)
                 }
 
             val actualHeights =


### PR DESCRIPTION
- Resolves #333
- This is PR is stacked on #332 (needed the functions implemented there).

## TODO

[`BlockFlowSyncService.init()`](https://github.com/alephium/explorer-backend/blob/master/app/src/main/scala/org/alephium/explorer/service/BlockFlowSyncService.scala#L151) has no existing unit tests. So can't really compare the function's output against this change.  

Please let me know if you'd like test-cases for `BlockFlowSyncService.init()` implemented.