### PR TITLE
Reset migration

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/persistence/Migrations.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/Migrations.scala
@@ -18,82 +18,52 @@ package org.alephium.explorer.persistence
 
 import scala.concurrent.{ExecutionContext, Future}
 
-import akka.util.ByteString
 import com.typesafe.scalalogging.StrictLogging
 import slick.basic.DatabaseConfig
 import slick.dbio.DBIOAction
 import slick.jdbc.PostgresProfile
-import slick.jdbc.PostgresProfile.api._
 
 import org.alephium.explorer.persistence.model.AppState.MigrationVersion
 import org.alephium.explorer.persistence.queries.AppStateQueries
-import org.alephium.explorer.persistence.schema.CustomGetResult._
-import org.alephium.serde._
 
 object Migrations extends StrictLogging {
 
-  private val addUOutputOrderColumn: DBActionW[Int] = sqlu"""
-    ALTER TABLE uoutputs
-    ADD COLUMN IF NOT EXISTS "uoutput_order" INTEGER DEFAULT 0;
-  """
-
-  private val updateUOutputPK =
-    sqlu"""
-      ALTER TABLE uoutputs
-      DROP CONSTRAINT IF EXISTS uoutputs_pk CASCADE,
-      ADD CONSTRAINT uoutputs_pk PRIMARY KEY(tx_hash, address, uoutput_order)
-    """
-
-  private val addUTransactionLastSeenColumn: DBActionW[Int] = sqlu"""
-    ALTER TABLE utransactions
-    ADD COLUMN IF NOT EXISTS "last_seen" BIGINT DEFAULT 0;
-  """
-
-  def migrations(version: Int)(implicit ec: ExecutionContext): DBActionWT[Option[Int]] = {
-    logger.debug(s"Current migration version: $version")
-    if (version == 0) {
-      for {
-        _ <- addUOutputOrderColumn
-        _ <- updateUOutputPK
-        _ <- addUTransactionLastSeenColumn
-      } yield Some(1)
-    } else {
-      DBIOAction.successful(None)
+  def migrations(versionOpt: Option[MigrationVersion]): DBActionWT[Option[MigrationVersion]] = {
+    logger.info(s"Current migration version: $versionOpt")
+    versionOpt match {
+      case Some(MigrationVersion(0)) => DBIOAction.successful(None)
+      case _                         => DBIOAction.successful(Some(MigrationVersion(0)))
     }
   }
 
   def migrate(databaseConfig: DatabaseConfig[PostgresProfile])(
-      implicit ec: ExecutionContext): Future[Option[Int]] = {
+      implicit ec: ExecutionContext): Future[Unit] = {
     logger.info("Migrating")
     DBRunner
       .run(databaseConfig)(for {
         version       <- getVersion()
         newVersionOpt <- migrations(version)
         _             <- updateVersion(newVersionOpt)
-      } yield newVersionOpt)
+      } yield ())
   }
 
-  def getVersion()(implicit ec: ExecutionContext): DBActionR[Int] = {
-    sql"""
-      SELECT value FROM app_state where key = 'migrations_version'
-    """.as[ByteString].headOption.map {
-      case None => 0
-      case Some(bytes) =>
-        deserialize[Int](bytes) match {
-          case Left(error) =>
-            logger.error(s"Invalid migration version, closing app. $error")
-            sys.exit(1)
-          case Right(version) => version
-        }
+  def getVersion()(implicit ec: ExecutionContext): DBActionR[Option[MigrationVersion]] = {
+    AppStateQueries.get(MigrationVersion).map {
+      case None                            => None
+      case Some(MigrationVersion(version)) => Some(MigrationVersion(version))
+      case _ =>
+        logger.error(s"Invalid migration version, closing app.")
+        sys.exit(1)
     }
   }
 
-  def updateVersion(versionOpt: Option[Int])(implicit ec: ExecutionContext): DBActionW[Unit] = {
+  def updateVersion(versionOpt: Option[MigrationVersion])(
+      implicit ec: ExecutionContext): DBActionW[Unit] = {
     versionOpt match {
       case None => DBIOAction.successful(())
       case Some(version) =>
         AppStateQueries
-          .insertOrUpdate(MigrationVersion(version))
+          .insertOrUpdate(version)
           .map(_ => ())
     }
   }


### PR DESCRIPTION
Next release `v1.8.0` requires to drop the database and restart from
scratch.

We can thus reset the migrations.