### PR TITLE
Fix/input update

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/persistence/DBInitializer.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/DBInitializer.scala
@@ -96,6 +96,7 @@ object DBInitializer extends StrictLogging {
       _ <- OutputSchema.createMainChainIndex()
       _ <- TransactionPerAddressSchema.createMainChainIndex()
       _ <- OutputSchema.createNonSpentIndex()
+      _ <- InputSchema.createOutputRefAddressNullIndex()
     } yield ())
   }
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/InputUpdateQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/InputUpdateQueries.scala
@@ -39,7 +39,7 @@ object InputUpdateQueries {
         output_ref_tokens = outputs.tokens
       FROM outputs
       WHERE inputs.output_ref_key = outputs.key
-      AND inputs.output_ref_address IS NULL
+      AND inputs.output_ref_amount IS NULL
       RETURNING outputs.address, outputs.tokens, inputs.tx_hash, inputs.block_hash, inputs.block_timestamp, inputs.tx_order, inputs.main_chain
     """
       .as[(Address, Option[Seq[Token]], Transaction.Hash, BlockEntry.Hash, TimeStamp, Int, Boolean)]

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/InputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/InputSchema.scala
@@ -22,6 +22,7 @@ import slick.lifted.{Index, PrimaryKey, ProvenShape}
 
 import org.alephium.explorer.Hash
 import org.alephium.explorer.api.model.{Address, BlockEntry, Token, Transaction}
+import org.alephium.explorer.persistence.DBActionW
 import org.alephium.explorer.persistence.model.InputEntity
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.util.{TimeStamp, U256}
@@ -66,6 +67,11 @@ object InputSchema extends SchemaMainChain[InputEntity]("inputs") {
        outputRefTokens)
         .<>((InputEntity.apply _).tupled, InputEntity.unapply)
   }
+
+  def createOutputRefAddressNullIndex(): DBActionW[Int] =
+    sqlu"""CREATE INDEX IF NOT EXISTS inputs_output_ref_amount_null_idx
+      ON #${name} (output_ref_address, output_ref_amount, output_ref_tokens)
+      WHERE output_ref_amount IS NULL"""
 
   val table: TableQuery[Inputs] = TableQuery[Inputs]
 }

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/InputUpdateQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/InputUpdateQueriesSpec.scala
@@ -59,8 +59,7 @@ class InputUpdateQueriesSpec
             run(InputSchema.table.filter(_.outputRefKey === output.key).result.head).futureValue
 
           updatedInput.outputRefAddress is Some(output.address)
-          //FIXME: it should be: Some(output.amount)
-          updatedInput.outputRefAmount is None
+          updatedInput.outputRefAmount is Some(output.amount)
       }
     }
   }

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/InputUpdateQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/InputUpdateQueriesSpec.scala
@@ -1,0 +1,67 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.persistence.queries
+
+import scala.concurrent.ExecutionContext
+
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Minutes, Span}
+import slick.jdbc.PostgresProfile.api._
+
+import org.alephium.explorer.AlephiumSpec
+import org.alephium.explorer.Generators._
+import org.alephium.explorer.persistence.{DatabaseFixtureForEach, DBRunner}
+import org.alephium.explorer.persistence.schema.{InputSchema, OutputSchema}
+import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
+
+class InputUpdateQueriesSpec
+    extends AlephiumSpec
+    with DatabaseFixtureForEach
+    with DBRunner
+    with ScalaFutures {
+
+  implicit val executionContext: ExecutionContext = ExecutionContext.global
+  override implicit val patienceConfig            = PatienceConfig(timeout = Span(1, Minutes))
+
+  "Input Update" should {
+    "update inputs when address is already set" in {
+      forAll(outputEntityGen, inputEntityGen()) {
+        case (output, input) =>
+          run(for {
+            _ <- OutputSchema.table += output
+            _ <- InputSchema.table +=
+              input.copy(outputRefKey = output.key, outputRefAddress = Some(output.address))
+          } yield ()).futureValue
+
+          val inputBeforeUpdate =
+            run(InputSchema.table.filter(_.outputRefKey === output.key).result.head).futureValue
+
+          inputBeforeUpdate.outputRefAddress is Some(output.address)
+          inputBeforeUpdate.outputRefAmount is None
+
+          run(InputUpdateQueries.updateInputs()).futureValue
+
+          val updatedInput =
+            run(InputSchema.table.filter(_.outputRefKey === output.key).result.head).futureValue
+
+          updatedInput.outputRefAddress is Some(output.address)
+          //FIXME: it should be: Some(output.amount)
+          updatedInput.outputRefAmount is None
+      }
+    }
+  }
+}


### PR DESCRIPTION
In a recent commit, we added directly the `output_ref_address`
to the `Input` when available through the `UnlockScript`.
The `InputUpdateQuery` was then failing as we were searching for
the empty addresses. We are now looking for empty amount, an index is
added and we can see that the query planner is using our new
`inputs_output_ref_amount_null_idx` index

```
EXPLAIN UPDATE inputs
SET
  output_ref_address = outputs.address,
  output_ref_amount = outputs.amount,
  output_ref_tokens = outputs.tokens
FROM outputs
WHERE inputs.output_ref_key = outputs.key
AND inputs.output_ref_amount IS NULL
RETURNING outputs.address, outputs.tokens, inputs.tx_hash, inputs.block_hash, inputs.block_timestamp, inputs.tx_order, inputs.main_chain
                                                 QUERY PLAN
-------------------------------------------------------------------------------------------------------------
 Update on inputs  (cost=0.69..16.73 rows=1 width=100)
   ->  Nested Loop  (cost=0.69..16.73 rows=1 width=100)
         ->  Index Scan using inputs_output_ref_amount_null_idx on inputs  (cost=0.12..8.14 rows=1 width=39)
               Index Cond: (output_ref_amount IS NULL)
         ->  Index Scan using outputs_pk on outputs  (cost=0.56..8.58 rows=1 width=127)
               Index Cond: (key = inputs.output_ref_key)
```