### PR TITLE
Update common to `1.8.5-rc8`

### DIFF
--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -464,7 +464,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ConfirmedTransaction"
+                  "$ref": "#/components/schemas/Transaction"
                 }
               }
             }
@@ -883,7 +883,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/UnconfirmedTransaction"
+                    "$ref": "#/components/schemas/TransactionLike"
                   }
                 }
               }
@@ -1717,7 +1717,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/UnconfirmedTransaction"
+                    "$ref": "#/components/schemas/TransactionLike"
                   }
                 }
               }
@@ -3983,7 +3983,7 @@
           "outputs": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/AssetOutput"
+              "$ref": "#/components/schemas/Output"
             }
           },
           "gasAmount": {

--- a/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
@@ -25,7 +25,7 @@ import org.alephium.api.{alphJsonBody => jsonBody}
 import org.alephium.explorer.api.BaseEndpoint
 import org.alephium.explorer.api.Codecs
 import org.alephium.explorer.api.model._
-import org.alephium.protocol.Hash
+import org.alephium.protocol.model.TokenId
 
 // scalastyle:off magic.number
 trait AddressesEndpoints extends BaseEndpoint with QueryParams {
@@ -46,19 +46,19 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
     baseEndpoint
       .tag("Addresses")
       .in("addresses")
-      .in(path[Address]("address")(Codecs.addressTapirCodec))
+      .in(path[Address]("address")(Codecs.explorerAddressTapirCodec))
       .in("tokens")
 
   val getAddressInfo: BaseEndpoint[Address, AddressInfo] =
     addressesEndpoint.get
-      .in(path[Address]("address")(Codecs.addressTapirCodec))
+      .in(path[Address]("address")(Codecs.explorerAddressTapirCodec))
       .out(jsonBody[AddressInfo])
       .description("Get address information")
 
   val getTransactionsByAddressDEPRECATED
     : BaseEndpoint[(Address, Pagination), ArraySeq[Transaction]] =
     addressesEndpoint.get
-      .in(path[Address]("address")(Codecs.addressTapirCodec))
+      .in(path[Address]("address")(Codecs.explorerAddressTapirCodec))
       .in("transactions-DEPRECATED")
       .in(pagination)
       .out(jsonBody[ArraySeq[Transaction]])
@@ -66,7 +66,7 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
 
   val getTransactionsByAddress: BaseEndpoint[(Address, Pagination), ArraySeq[Transaction]] =
     addressesEndpoint.get
-      .in(path[Address]("address")(Codecs.addressTapirCodec))
+      .in(path[Address]("address")(Codecs.explorerAddressTapirCodec))
       .in("transactions")
       .in(pagination)
       .out(jsonBody[ArraySeq[Transaction]])
@@ -74,41 +74,41 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
 
   val getTotalTransactionsByAddress: BaseEndpoint[Address, Int] =
     addressesEndpoint.get
-      .in(path[Address]("address")(Codecs.addressTapirCodec))
+      .in(path[Address]("address")(Codecs.explorerAddressTapirCodec))
       .in("total-transactions")
       .out(jsonBody[Int])
       .description("Get total transactions of a given address")
 
   val addressUnconfirmedTransactions: BaseEndpoint[Address, ArraySeq[UnconfirmedTransaction]] =
     addressesEndpoint.get
-      .in(path[Address]("address")(Codecs.addressTapirCodec))
+      .in(path[Address]("address")(Codecs.explorerAddressTapirCodec))
       .in("unconfirmed-transactions")
       .out(jsonBody[ArraySeq[UnconfirmedTransaction]])
       .description("List unconfirmed transactions of a given address")
 
   val getAddressBalance: BaseEndpoint[Address, AddressBalance] =
     addressesEndpoint.get
-      .in(path[Address]("address")(Codecs.addressTapirCodec))
+      .in(path[Address]("address")(Codecs.explorerAddressTapirCodec))
       .in("balance")
       .out(jsonBody[AddressBalance])
       .description("Get address balance")
 
-  val listAddressTokens: BaseEndpoint[Address, ArraySeq[Hash]] =
+  val listAddressTokens: BaseEndpoint[Address, ArraySeq[TokenId]] =
     addressesTokensEndpoint.get
-      .out(jsonBody[ArraySeq[Hash]])
+      .out(jsonBody[ArraySeq[TokenId]])
       .description("List address tokens")
 
-  val getAddressTokenBalance: BaseEndpoint[(Address, Hash), AddressBalance] =
+  val getAddressTokenBalance: BaseEndpoint[(Address, TokenId), AddressBalance] =
     addressesTokensEndpoint.get
-      .in(path[Hash]("token-id"))
+      .in(path[TokenId]("token-id"))
       .in("balance")
       .out(jsonBody[AddressBalance])
       .description("Get address balance of given token")
 
   val listAddressTokenTransactions
-    : BaseEndpoint[(Address, Hash, Pagination), ArraySeq[Transaction]] =
+    : BaseEndpoint[(Address, TokenId, Pagination), ArraySeq[Transaction]] =
     addressesTokensEndpoint.get
-      .in(path[Hash]("token-id"))
+      .in(path[TokenId]("token-id"))
       .in("transactions")
       .in(pagination)
       .out(jsonBody[ArraySeq[Transaction]])

--- a/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
@@ -79,11 +79,11 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
       .out(jsonBody[Int])
       .description("Get total transactions of a given address")
 
-  val addressUnconfirmedTransactions: BaseEndpoint[Address, ArraySeq[UnconfirmedTransaction]] =
+  val addressUnconfirmedTransactions: BaseEndpoint[Address, ArraySeq[TransactionLike]] =
     addressesEndpoint.get
       .in(path[Address]("address")(Codecs.explorerAddressTapirCodec))
       .in("unconfirmed-transactions")
-      .out(jsonBody[ArraySeq[UnconfirmedTransaction]])
+      .out(jsonBody[ArraySeq[TransactionLike]])
       .description("List unconfirmed transactions of a given address")
 
   val getAddressBalance: BaseEndpoint[Address, AddressBalance] =

--- a/app/src/main/scala/org/alephium/explorer/api/BlockEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/BlockEndpoints.scala
@@ -23,8 +23,8 @@ import sttp.tapir.generic.auto._
 
 import org.alephium.api.{alphJsonBody => jsonBody}
 import org.alephium.explorer.api.BaseEndpoint
-import org.alephium.explorer.api.Codecs.blockEntryHashTapirCodec
 import org.alephium.explorer.api.model._
+import org.alephium.protocol.model.BlockHash
 
 trait BlockEndpoints extends BaseEndpoint with QueryParams {
 
@@ -33,15 +33,15 @@ trait BlockEndpoints extends BaseEndpoint with QueryParams {
       .tag("Blocks")
       .in("blocks")
 
-  val getBlockByHash: BaseEndpoint[BlockEntry.Hash, BlockEntryLite] =
+  val getBlockByHash: BaseEndpoint[BlockHash, BlockEntryLite] =
     blocksEndpoint.get
-      .in(path[BlockEntry.Hash]("block-hash"))
+      .in(path[BlockHash]("block-hash"))
       .out(jsonBody[BlockEntryLite])
       .description("Get a block with hash")
 
-  val getBlockTransactions: BaseEndpoint[(BlockEntry.Hash, Pagination), ArraySeq[Transaction]] =
+  val getBlockTransactions: BaseEndpoint[(BlockHash, Pagination), ArraySeq[Transaction]] =
     blocksEndpoint.get
-      .in(path[BlockEntry.Hash]("block-hash"))
+      .in(path[BlockHash]("block-hash"))
       .in("transactions")
       .in(pagination)
       .out(jsonBody[ArraySeq[Transaction]])

--- a/app/src/main/scala/org/alephium/explorer/api/Codecs.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/Codecs.scala
@@ -21,31 +21,18 @@ import scala.util.{Failure, Success, Try}
 import sttp.tapir.{Codec, DecodeResult}
 import sttp.tapir.CodecFormat.TextPlain
 
-import org.alephium.explorer.{BlockHash, Hash}
-import org.alephium.explorer.api.Json._
-import org.alephium.explorer.api.model.{Address, BlockEntry, IntervalType, Transaction}
+import org.alephium.api.TapirCodecs
+import org.alephium.explorer.api.model.{Address, IntervalType}
 import org.alephium.json.Json._
 
-object Codecs {
-  private val hashTapirCodec: Codec[String, Hash, TextPlain] =
-    fromJson[Hash]
-
-  private val blockHashTapirCodec: Codec[String, BlockHash, TextPlain] =
-    fromJson[BlockHash]
-
-  implicit val addressTapirCodec: Codec[String, Address, TextPlain] =
+object Codecs extends TapirCodecs {
+  implicit val explorerAddressTapirCodec: Codec[String, Address, TextPlain] =
     fromJson[Address]
-
-  implicit val blockEntryHashTapirCodec: Codec[String, BlockEntry.Hash, TextPlain] =
-    blockHashTapirCodec.map(new BlockEntry.Hash(_))(_.value)
-
-  implicit val transactionHashTapirCodec: Codec[String, Transaction.Hash, TextPlain] =
-    hashTapirCodec.map(new Transaction.Hash(_))(_.value)
 
   implicit val timeIntervalCodec: Codec[String, IntervalType, TextPlain] =
     fromJson[IntervalType]
 
-  def fromJson[A: ReadWriter]: Codec[String, A, TextPlain] =
+  def explorerFromJson[A: ReadWriter]: Codec[String, A, TextPlain] =
     Codec.string.mapDecode[A] { raw =>
       Try(read[A](ujson.Str(raw))) match {
         case Success(a) => DecodeResult.Value(a)

--- a/app/src/main/scala/org/alephium/explorer/api/Json.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/Json.scala
@@ -16,35 +16,11 @@
 
 package org.alephium.explorer.api
 
-import upickle.core.Abort
-
-import org.alephium.api.UtilJson._
-import org.alephium.explorer.{BlockHash, Hash}
+import org.alephium.api.ApiModelCodec
 import org.alephium.json.Json._
 import org.alephium.util.U256
 
 @SuppressWarnings(Array("org.wartremover.warts.Throw"))
-object Json {
-  implicit val hashWriter: Writer[Hash] = StringWriter.comap[Hash](
-    _.toHexString
-  )
-  implicit val hashReader: Reader[Hash] =
-    byteStringReader.map(Hash.from(_).getOrElse(throw new Abort("cannot decode hash")))
-  implicit val hashReadWriter: ReadWriter[Hash] = ReadWriter.join(hashReader, hashWriter)
-
-  implicit val blockHashWriter: Writer[BlockHash] = StringWriter.comap[BlockHash](
-    _.toHexString
-  )
-  implicit val blockHashReader: Reader[BlockHash] =
-    byteStringReader.map(BlockHash.from(_).getOrElse(throw new Abort("cannot decode block hash")))
-
-  implicit val blockHashReadWriter: ReadWriter[BlockHash] =
-    ReadWriter.join(blockHashReader, blockHashWriter)
-
-  implicit val u256Writer: Writer[U256] = javaBigIntegerWriter.comap[U256](_.toBigInt)
-  implicit val u256Reader: Reader[U256] = javaBigIntegerReader.map { u256 =>
-    U256.from(u256).getOrElse(throw new Abort(s"Invalid U256: $u256"))
-  }
-
+object Json extends ApiModelCodec {
   implicit val u256ReadWriter: ReadWriter[U256] = ReadWriter.join(u256Reader, u256Writer)
 }

--- a/app/src/main/scala/org/alephium/explorer/api/QueryParams.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/QueryParams.scala
@@ -17,14 +17,19 @@
 package org.alephium.explorer.api
 
 import sttp.tapir._
+import sttp.tapir.CodecFormat.TextPlain
 
 import org.alephium.api.TapirCodecs
 import org.alephium.api.model.TimeInterval
 import org.alephium.explorer.api.Codecs._
 import org.alephium.explorer.api.model.{IntervalType, Pagination}
+import org.alephium.protocol.model.TokenId
 import org.alephium.util.TimeStamp
 
 trait QueryParams extends TapirCodecs {
+
+  implicit val tokenIdTapirCodec: Codec[String, TokenId, TextPlain] =
+    fromJson[TokenId]
 
   val pagination: EndpointInput[Pagination] =
     query[Option[Int]]("page")

--- a/app/src/main/scala/org/alephium/explorer/api/TokensEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/TokensEndpoints.scala
@@ -24,7 +24,7 @@ import sttp.tapir.generic.auto._
 import org.alephium.api.{alphJsonBody => jsonBody}
 import org.alephium.explorer.api.BaseEndpoint
 import org.alephium.explorer.api.model._
-import org.alephium.protocol.Hash
+import org.alephium.protocol.model.TokenId
 
 // scalastyle:off magic.number
 trait TokensEndpoints extends BaseEndpoint with QueryParams {
@@ -34,23 +34,23 @@ trait TokensEndpoints extends BaseEndpoint with QueryParams {
       .tag("Tokens")
       .in("tokens")
 
-  val listTokens: BaseEndpoint[Pagination, ArraySeq[Hash]] =
+  val listTokens: BaseEndpoint[Pagination, ArraySeq[TokenId]] =
     tokensEndpoint.get
       .in(pagination)
-      .out(jsonBody[ArraySeq[Hash]])
+      .out(jsonBody[ArraySeq[TokenId]])
       .description("List tokens")
 
-  val listTokenTransactions: BaseEndpoint[(Hash, Pagination), ArraySeq[Transaction]] =
+  val listTokenTransactions: BaseEndpoint[(TokenId, Pagination), ArraySeq[Transaction]] =
     tokensEndpoint.get
-      .in(path[Hash]("token-id"))
+      .in(path[TokenId]("token-id"))
       .in("transactions")
       .in(pagination)
       .out(jsonBody[ArraySeq[Transaction]])
       .description("List token transactions")
 
-  val listTokenAddresses: BaseEndpoint[(Hash, Pagination), ArraySeq[Address]] =
+  val listTokenAddresses: BaseEndpoint[(TokenId, Pagination), ArraySeq[Address]] =
     tokensEndpoint.get
-      .in(path[Hash]("token-id"))
+      .in(path[TokenId]("token-id"))
       .in("addresses")
       .in(pagination)
       .out(jsonBody[ArraySeq[Address]])

--- a/app/src/main/scala/org/alephium/explorer/api/TransactionEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/TransactionEndpoints.scala
@@ -22,8 +22,8 @@ import sttp.tapir.generic.auto._
 import org.alephium.api.{alphJsonBody => jsonBody}
 import org.alephium.explorer.Hash
 import org.alephium.explorer.api.BaseEndpoint
-import org.alephium.explorer.api.Codecs.transactionHashTapirCodec
-import org.alephium.explorer.api.model.{ConfirmedTransaction, Transaction, TransactionLike}
+import org.alephium.explorer.api.model.{ConfirmedTransaction, TransactionLike}
+import org.alephium.protocol.model.TransactionId
 
 trait TransactionEndpoints extends BaseEndpoint {
 
@@ -32,9 +32,9 @@ trait TransactionEndpoints extends BaseEndpoint {
       .tag("Transactions")
       .in("transactions")
 
-  val getTransactionById: BaseEndpoint[Transaction.Hash, TransactionLike] =
+  val getTransactionById: BaseEndpoint[TransactionId, TransactionLike] =
     transactionsEndpoint.get
-      .in(path[Transaction.Hash]("transaction-hash"))
+      .in(path[TransactionId]("transaction-hash"))
       .out(jsonBody[TransactionLike])
       .description("Get a transaction with hash")
 

--- a/app/src/main/scala/org/alephium/explorer/api/TransactionEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/TransactionEndpoints.scala
@@ -22,7 +22,7 @@ import sttp.tapir.generic.auto._
 import org.alephium.api.{alphJsonBody => jsonBody}
 import org.alephium.explorer.Hash
 import org.alephium.explorer.api.BaseEndpoint
-import org.alephium.explorer.api.model.{ConfirmedTransaction, TransactionLike}
+import org.alephium.explorer.api.model.{Transaction, TransactionLike}
 import org.alephium.protocol.model.TransactionId
 
 trait TransactionEndpoints extends BaseEndpoint {
@@ -38,12 +38,12 @@ trait TransactionEndpoints extends BaseEndpoint {
       .out(jsonBody[TransactionLike])
       .description("Get a transaction with hash")
 
-  val getOutputRefTransaction: BaseEndpoint[Hash, ConfirmedTransaction] =
+  val getOutputRefTransaction: BaseEndpoint[Hash, Transaction] =
     baseEndpoint
       .tag("Transactions")
       .in("transaction-by-output-ref-key")
       .get
       .in(path[Hash]("output-ref-key"))
-      .out(jsonBody[ConfirmedTransaction])
+      .out(jsonBody[Transaction])
       .description("Get a transaction from a output reference key")
 }

--- a/app/src/main/scala/org/alephium/explorer/api/UnconfirmedTransactionEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/UnconfirmedTransactionEndpoints.scala
@@ -23,7 +23,7 @@ import sttp.tapir.generic.auto._
 
 import org.alephium.api.{alphJsonBody => jsonBody}
 import org.alephium.explorer.api.BaseEndpoint
-import org.alephium.explorer.api.model.{Pagination, UnconfirmedTransaction}
+import org.alephium.explorer.api.model.{Pagination, TransactionLike}
 
 trait UnconfirmedTransactionEndpoints extends BaseEndpoint with QueryParams {
 
@@ -32,9 +32,9 @@ trait UnconfirmedTransactionEndpoints extends BaseEndpoint with QueryParams {
       .tag("Unconfirmed Transactions")
       .in("unconfirmed-transactions")
 
-  val listUnconfirmedTransactions: BaseEndpoint[Pagination, ArraySeq[UnconfirmedTransaction]] =
+  val listUnconfirmedTransactions: BaseEndpoint[Pagination, ArraySeq[TransactionLike]] =
     unconfirmedTransactionsEndpoint.get
       .in(pagination)
-      .out(jsonBody[ArraySeq[UnconfirmedTransaction]])
+      .out(jsonBody[ArraySeq[TransactionLike]])
       .description("list unconfirmed transactions")
 }

--- a/app/src/main/scala/org/alephium/explorer/api/model/AddressBalance.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/AddressBalance.scala
@@ -16,7 +16,7 @@
 
 package org.alephium.explorer.api.model
 
-import org.alephium.explorer.api.Json.u256ReadWriter
+import org.alephium.explorer.api.Json._
 import org.alephium.json.Json._
 import org.alephium.util.U256
 

--- a/app/src/main/scala/org/alephium/explorer/api/model/BlockEntry.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/BlockEntry.scala
@@ -21,37 +21,30 @@ import java.math.BigInteger
 import scala.collection.immutable.ArraySeq
 
 import org.alephium.api.UtilJson._
-import org.alephium.explorer.BlockHash
-import org.alephium.explorer.HashCompanion
-import org.alephium.explorer.api.Json.blockHashReadWriter
+import org.alephium.explorer.api.Codecs._
 import org.alephium.explorer.service.FlowEntity
 import org.alephium.json.Json._
+import org.alephium.protocol.model.BlockHash
 import org.alephium.util.TimeStamp
 
 final case class BlockEntry(
-    hash: BlockEntry.Hash,
+    hash: BlockHash,
     timestamp: TimeStamp,
     chainFrom: GroupIndex,
     chainTo: GroupIndex,
     height: Height,
-    deps: ArraySeq[BlockEntry.Hash],
+    deps: ArraySeq[BlockHash],
     transactions: ArraySeq[Transaction],
     mainChain: Boolean,
     hashRate: BigInteger
 ) extends FlowEntity
 
 object BlockEntry {
-
-  final class Hash(val value: BlockHash) extends AnyVal {
-    override def toString(): String = value.toHexString
-  }
-  object Hash extends HashCompanion[BlockHash, Hash](new Hash(_), _.value)
-
   implicit val codec: ReadWriter[BlockEntry] = macroRW
 }
 
 final case class BlockEntryLite(
-    hash: BlockEntry.Hash,
+    hash: BlockHash,
     timestamp: TimeStamp,
     chainFrom: GroupIndex,
     chainTo: GroupIndex,

--- a/app/src/main/scala/org/alephium/explorer/api/model/Input.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/Input.scala
@@ -21,7 +21,7 @@ import scala.collection.immutable.ArraySeq
 import akka.util.ByteString
 
 import org.alephium.api.UtilJson._
-import org.alephium.explorer.api.Json.u256ReadWriter
+import org.alephium.explorer.api.Json._
 import org.alephium.json.Json._
 import org.alephium.util.U256
 

--- a/app/src/main/scala/org/alephium/explorer/api/model/Output.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/Output.scala
@@ -22,8 +22,9 @@ import akka.util.ByteString
 
 import org.alephium.api.UtilJson._
 import org.alephium.explorer.Hash
-import org.alephium.explorer.api.Json.{hashReadWriter, u256ReadWriter}
+import org.alephium.explorer.api.Json._
 import org.alephium.json.Json._
+import org.alephium.protocol.model.TransactionId
 import org.alephium.util.{TimeStamp, U256}
 
 sealed trait Output {
@@ -32,7 +33,7 @@ sealed trait Output {
   def attoAlphAmount: U256
   def address: Address
   def tokens: Option[ArraySeq[Token]]
-  def spent: Option[Transaction.Hash]
+  def spent: Option[TransactionId]
 }
 
 @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
@@ -45,7 +46,8 @@ final case class AssetOutput(
     tokens: Option[ArraySeq[Token]] = None,
     lockTime: Option[TimeStamp]     = None,
     message: Option[ByteString]     = None,
-    spent: Option[Transaction.Hash] = None
+    spent: Option[TransactionId]    = None,
+    `type`: String                  = "AssetOutput"
 ) extends Output
 
 @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
@@ -56,7 +58,8 @@ final case class ContractOutput(
     attoAlphAmount: U256,
     address: Address,
     tokens: Option[ArraySeq[Token]] = None,
-    spent: Option[Transaction.Hash] = None
+    spent: Option[TransactionId]    = None,
+    `type`: String                  = "ContractOutput"
 ) extends Output
 
 object Output {

--- a/app/src/main/scala/org/alephium/explorer/api/model/Output.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/Output.scala
@@ -46,8 +46,7 @@ final case class AssetOutput(
     tokens: Option[ArraySeq[Token]] = None,
     lockTime: Option[TimeStamp]     = None,
     message: Option[ByteString]     = None,
-    spent: Option[TransactionId]    = None,
-    `type`: String                  = "AssetOutput"
+    spent: Option[TransactionId]    = None
 ) extends Output
 
 @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
@@ -58,8 +57,7 @@ final case class ContractOutput(
     attoAlphAmount: U256,
     address: Address,
     tokens: Option[ArraySeq[Token]] = None,
-    spent: Option[TransactionId]    = None,
-    `type`: String                  = "ContractOutput"
+    spent: Option[TransactionId]    = None
 ) extends Output
 
 object Output {

--- a/app/src/main/scala/org/alephium/explorer/api/model/OutputRef.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/OutputRef.scala
@@ -17,7 +17,7 @@
 package org.alephium.explorer.api.model
 
 import org.alephium.explorer.Hash
-import org.alephium.explorer.api.Json.hashReadWriter
+import org.alephium.explorer.api.Json._
 import org.alephium.json.Json._
 
 final case class OutputRef(hint: Int, key: Hash)

--- a/app/src/main/scala/org/alephium/explorer/api/model/Token.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/Token.scala
@@ -16,13 +16,13 @@
 
 package org.alephium.explorer.api.model
 
-import org.alephium.explorer.api.Json.{hashReadWriter, u256ReadWriter}
+import org.alephium.explorer.api.Json._
 import org.alephium.json.Json._
-import org.alephium.protocol.Hash
+import org.alephium.protocol.model.TokenId
 import org.alephium.serde._
 import org.alephium.util.U256
 
-final case class Token(id: Hash, amount: U256)
+final case class Token(id: TokenId, amount: U256)
 
 object Token {
   implicit val readWriter: ReadWriter[Token] = macroRW

--- a/app/src/main/scala/org/alephium/explorer/api/model/Transaction.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/Transaction.scala
@@ -58,8 +58,7 @@ final case class ConfirmedTransaction(
     inputs: ArraySeq[Input],
     outputs: ArraySeq[Output],
     gasAmount: Int,
-    gasPrice: U256,
-    `type`: String = "Confirmed"
+    gasPrice: U256
 ) extends TransactionLike
 
 object ConfirmedTransaction {
@@ -82,11 +81,10 @@ final case class UnconfirmedTransaction(
     chainFrom: GroupIndex,
     chainTo: GroupIndex,
     inputs: ArraySeq[Input],
-    outputs: ArraySeq[AssetOutput],
+    outputs: ArraySeq[Output],
     gasAmount: Int,
     gasPrice: U256,
-    lastSeen: TimeStamp,
-    `type`: String = "Unconfirmed"
+    lastSeen: TimeStamp
 ) extends TransactionLike
 
 object UnconfirmedTransaction {

--- a/app/src/main/scala/org/alephium/explorer/api/model/Transaction.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/Transaction.scala
@@ -19,15 +19,14 @@ package org.alephium.explorer.api.model
 import scala.collection.immutable.ArraySeq
 
 import org.alephium.api.UtilJson.{timestampReader, timestampWriter}
-import org.alephium.explorer
-import org.alephium.explorer.HashCompanion
-import org.alephium.explorer.api.Json.{hashReadWriter, u256ReadWriter}
+import org.alephium.explorer.api.Json._
 import org.alephium.json.Json._
+import org.alephium.protocol.model.{BlockHash, TransactionId}
 import org.alephium.util.{TimeStamp, U256}
 
 final case class Transaction(
-    hash: Transaction.Hash,
-    blockHash: BlockEntry.Hash,
+    hash: TransactionId,
+    blockHash: BlockHash,
     timestamp: TimeStamp,
     inputs: ArraySeq[Input],
     outputs: ArraySeq[Output],
@@ -36,16 +35,11 @@ final case class Transaction(
 )
 
 object Transaction {
-  final class Hash(val value: explorer.Hash) extends AnyVal {
-    override def toString(): String = value.toHexString
-  }
-  object Hash extends HashCompanion[explorer.Hash, Hash](new Hash(_), _.value)
-
   implicit val txRW: ReadWriter[Transaction] = macroRW
 }
 
 sealed trait TransactionLike {
-  def hash: Transaction.Hash
+  def hash: TransactionId
   def gasAmount: Int
   def gasPrice: U256
 }
@@ -55,15 +49,17 @@ object TransactionLike {
     ReadWriter.merge(ConfirmedTransaction.txRW, UnconfirmedTransaction.utxRW)
 }
 
+@SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
 @upickle.implicits.key("Confirmed")
 final case class ConfirmedTransaction(
-    hash: Transaction.Hash,
-    blockHash: BlockEntry.Hash,
+    hash: TransactionId,
+    blockHash: BlockHash,
     timestamp: TimeStamp,
     inputs: ArraySeq[Input],
     outputs: ArraySeq[Output],
     gasAmount: Int,
-    gasPrice: U256
+    gasPrice: U256,
+    `type`: String = "Confirmed"
 ) extends TransactionLike
 
 object ConfirmedTransaction {
@@ -79,16 +75,18 @@ object ConfirmedTransaction {
   )
 }
 
+@SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
 @upickle.implicits.key("Unconfirmed")
 final case class UnconfirmedTransaction(
-    hash: Transaction.Hash,
+    hash: TransactionId,
     chainFrom: GroupIndex,
     chainTo: GroupIndex,
     inputs: ArraySeq[Input],
     outputs: ArraySeq[AssetOutput],
     gasAmount: Int,
     gasPrice: U256,
-    lastSeen: TimeStamp
+    lastSeen: TimeStamp,
+    `type`: String = "Unconfirmed"
 ) extends TransactionLike
 
 object UnconfirmedTransaction {

--- a/app/src/main/scala/org/alephium/explorer/package.scala
+++ b/app/src/main/scala/org/alephium/explorer/package.scala
@@ -20,7 +20,7 @@ import scala.collection.immutable.ArraySeq
 import scala.concurrent.{ExecutionContext, Future}
 import scala.reflect.ClassTag
 
-import org.alephium.crypto.{Blake2b, Blake3}
+import org.alephium.crypto.Blake2b
 
 package object explorer {
   @inline @specialized def sideEffect[E](effect: E): Unit = {
@@ -35,9 +35,6 @@ package object explorer {
 
   type Hash = Blake2b
   val Hash: Blake2b.type = Blake2b
-
-  type BlockHash = Blake3
-  val BlockHash: Blake3.type = Blake3
 
   def foldFutures[A, B: ClassTag](seqA: ArraySeq[A])(f: A => Future[B])(
       implicit executionContext: ExecutionContext): Future[ArraySeq[B]] =

--- a/app/src/main/scala/org/alephium/explorer/persistence/dao/BlockDao.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/dao/BlockDao.scala
@@ -37,23 +37,23 @@ import org.alephium.explorer.persistence.schema.CustomGetResult._
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.explorer.util.SlickUtil._
-import org.alephium.protocol.model.ChainIndex
+import org.alephium.protocol.model.{BlockHash, ChainIndex}
 import org.alephium.util.{Duration, TimeStamp}
 
 object BlockDao {
 
-  def getLite(hash: BlockEntry.Hash)(
+  def getLite(hash: BlockHash)(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[Option[BlockEntryLite]] =
     run(getBlockEntryLiteAction(hash))
 
-  def getTransactions(hash: BlockEntry.Hash, pagination: Pagination)(
+  def getTransactions(hash: BlockHash, pagination: Pagination)(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]] =
     run(getTransactionsByBlockHashWithPagination(hash, pagination))
 
-  def get(hash: BlockEntry.Hash)(implicit ec: ExecutionContext,
-                                 dc: DatabaseConfig[PostgresProfile]): Future[Option[BlockEntry]] =
+  def get(hash: BlockHash)(implicit ec: ExecutionContext,
+                           dc: DatabaseConfig[PostgresProfile]): Future[Option[BlockEntry]] =
     run(getBlockEntryAction(hash))
 
   def getAtHeight(fromGroup: GroupIndex, toGroup: GroupIndex, height: Height)(
@@ -107,12 +107,12 @@ object BlockDao {
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
-  private def updateMainChainAction(hash: BlockEntry.Hash,
+  private def updateMainChainAction(hash: BlockHash,
                                     chainFrom: GroupIndex,
                                     chainTo: GroupIndex,
                                     groupNum: Int)(
       implicit ec: ExecutionContext,
-      dc: DatabaseConfig[PostgresProfile]): DBActionRWT[Option[BlockEntry.Hash]] =
+      dc: DatabaseConfig[PostgresProfile]): DBActionRWT[Option[BlockHash]] =
     getBlockHeaderAction(hash)
       .flatMap {
         case Some(block) if !block.mainChain =>
@@ -137,15 +137,12 @@ object BlockDao {
         case None                => DBIOAction.successful(None)
       }
 
-  def updateMainChain(hash: BlockEntry.Hash,
-                      chainFrom: GroupIndex,
-                      chainTo: GroupIndex,
-                      groupNum: Int)(
+  def updateMainChain(hash: BlockHash, chainFrom: GroupIndex, chainTo: GroupIndex, groupNum: Int)(
       implicit ec: ExecutionContext,
-      dc: DatabaseConfig[PostgresProfile]): Future[Option[BlockEntry.Hash]] =
+      dc: DatabaseConfig[PostgresProfile]): Future[Option[BlockHash]] =
     run(updateMainChainAction(hash, chainFrom, chainTo, groupNum))
 
-  def updateMainChainStatus(hash: BlockEntry.Hash, isMainChain: Boolean)(
+  def updateMainChainStatus(hash: BlockHash, isMainChain: Boolean)(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[Unit] =
     run(updateMainChainStatusAction(hash, isMainChain))

--- a/app/src/main/scala/org/alephium/explorer/persistence/dao/TransactionDao.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/dao/TransactionDao.scala
@@ -27,13 +27,13 @@ import org.alephium.explorer.persistence.DBRunner._
 import org.alephium.explorer.persistence.queries.TokenQueries._
 import org.alephium.explorer.persistence.queries.TransactionQueries._
 import org.alephium.protocol.Hash
+import org.alephium.protocol.model.{TokenId, TransactionId}
 import org.alephium.util.U256
 
 object TransactionDao {
 
-  def get(hash: Transaction.Hash)(
-      implicit ec: ExecutionContext,
-      dc: DatabaseConfig[PostgresProfile]): Future[Option[Transaction]] =
+  def get(hash: TransactionId)(implicit ec: ExecutionContext,
+                               dc: DatabaseConfig[PostgresProfile]): Future[Option[Transaction]] =
     run(getTransactionAction(hash))
 
   def getOutputRefTransaction(key: Hash)(
@@ -60,7 +60,7 @@ object TransactionDao {
                                    dc: DatabaseConfig[PostgresProfile]): Future[(U256, U256)] =
     run(getBalanceAction(address))
 
-  def getTokenBalance(address: Address, token: Hash)(
+  def getTokenBalance(address: Address, token: TokenId)(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[(U256, U256)] =
     run(getTokenBalanceAction(address, token))
@@ -71,23 +71,23 @@ object TransactionDao {
     run(areAddressesActiveAction(addresses))
 
   def listTokens(pagination: Pagination)(
-      implicit dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Hash]] =
+      implicit dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[TokenId]] =
     run(listTokensAction(pagination))
 
-  def listTokenTransactions(token: Hash, pagination: Pagination)(
+  def listTokenTransactions(token: TokenId, pagination: Pagination)(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]] =
     run(getTransactionsByToken(token, pagination))
 
-  def listTokenAddresses(token: Hash, pagination: Pagination)(
+  def listTokenAddresses(token: TokenId, pagination: Pagination)(
       implicit dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Address]] =
     run(getAddressesByToken(token, pagination))
 
   def listAddressTokens(address: Address)(
-      implicit dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Hash]] =
+      implicit dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[TokenId]] =
     run(listAddressTokensAction(address))
 
-  def listAddressTokenTransactions(address: Address, token: Hash, pagination: Pagination)(
+  def listAddressTokenTransactions(address: Address, token: TokenId, pagination: Pagination)(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]] =
     run(getTokenTransactionsByAddress(address, token, pagination))

--- a/app/src/main/scala/org/alephium/explorer/persistence/dao/UnconfirmedTxDao.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/dao/UnconfirmedTxDao.scala
@@ -31,10 +31,11 @@ import org.alephium.explorer.persistence.model._
 import org.alephium.explorer.persistence.queries.UnconfirmedTransactionQueries._
 import org.alephium.explorer.persistence.schema._
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
+import org.alephium.protocol.model.TransactionId
 
 trait UnconfirmedTxDao {
 
-  def get(hash: Transaction.Hash)(
+  def get(hash: TransactionId)(
       implicit executionContext: ExecutionContext,
       databaseConfig: DatabaseConfig[PostgresProfile]): Future[Option[UnconfirmedTransaction]]
 
@@ -50,15 +51,14 @@ trait UnconfirmedTxDao {
       implicit executionContext: ExecutionContext,
       databaseConfig: DatabaseConfig[PostgresProfile]): Future[Unit]
 
-  def listHashes()(
-      implicit executionContext: ExecutionContext,
-      databaseConfig: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction.Hash]]
+  def listHashes()(implicit executionContext: ExecutionContext,
+                   databaseConfig: DatabaseConfig[PostgresProfile]): Future[ArraySeq[TransactionId]]
 
-  def removeMany(txs: ArraySeq[Transaction.Hash])(
+  def removeMany(txs: ArraySeq[TransactionId])(
       implicit executionContext: ExecutionContext,
       databaseConfig: DatabaseConfig[PostgresProfile]): Future[Unit]
 
-  def removeAndInsertMany(toRemove: ArraySeq[Transaction.Hash],
+  def removeAndInsertMany(toRemove: ArraySeq[TransactionId],
                           toInsert: ArraySeq[UnconfirmedTransaction])(
       implicit executionContext: ExecutionContext,
       databaseConfig: DatabaseConfig[PostgresProfile]): Future[Unit]
@@ -66,7 +66,7 @@ trait UnconfirmedTxDao {
 
 object UnconfirmedTxDao extends UnconfirmedTxDao {
 
-  def get(hash: Transaction.Hash)(
+  def get(hash: TransactionId)(
       implicit executionContext: ExecutionContext,
       databaseConfig: DatabaseConfig[PostgresProfile]): Future[Option[UnconfirmedTransaction]] = {
     run(for {
@@ -157,11 +157,11 @@ object UnconfirmedTxDao extends UnconfirmedTxDao {
 
   def listHashes()(
       implicit executionContext: ExecutionContext,
-      databaseConfig: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction.Hash]] = {
+      databaseConfig: DatabaseConfig[PostgresProfile]): Future[ArraySeq[TransactionId]] = {
     run(listHashesQuery)
   }
 
-  private def removeManyAction(txs: ArraySeq[Transaction.Hash])(
+  private def removeManyAction(txs: ArraySeq[TransactionId])(
       implicit executionContext: ExecutionContext): DBActionW[Unit] = {
     for {
       _ <- UnconfirmedTxSchema.table.filter(_.hash inSet txs).delete
@@ -170,13 +170,13 @@ object UnconfirmedTxDao extends UnconfirmedTxDao {
     } yield ()
   }
 
-  def removeMany(txs: ArraySeq[Transaction.Hash])(
+  def removeMany(txs: ArraySeq[TransactionId])(
       implicit executionContext: ExecutionContext,
       databaseConfig: DatabaseConfig[PostgresProfile]): Future[Unit] = {
     run(removeManyAction(txs))
   }
 
-  def removeAndInsertMany(toRemove: ArraySeq[Transaction.Hash],
+  def removeAndInsertMany(toRemove: ArraySeq[TransactionId],
                           toInsert: ArraySeq[UnconfirmedTransaction])(
       implicit executionContext: ExecutionContext,
       databaseConfig: DatabaseConfig[PostgresProfile]): Future[Unit] = {

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/BlockDepEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/BlockDepEntity.scala
@@ -16,9 +16,9 @@
 
 package org.alephium.explorer.persistence.model
 
-import org.alephium.explorer.api.model.BlockEntry
+import org.alephium.protocol.model.BlockHash
 
 /**
   * Class for defining rows in table [[org.alephium.explorer.persistence.schema.BlockDepsSchema]]
   */
-final case class BlockDepEntity(hash: BlockEntry.Hash, dep: BlockEntry.Hash, order: Int)
+final case class BlockDepEntity(hash: BlockHash, dep: BlockHash, order: Int)

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/BlockEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/BlockEntity.scala
@@ -23,17 +23,18 @@ import scala.collection.immutable.ArraySeq
 import akka.util.ByteString
 
 import org.alephium.explorer.Hash
-import org.alephium.explorer.api.model.{BlockEntry, GroupIndex, Height}
+import org.alephium.explorer.api.model.{GroupIndex, Height}
 import org.alephium.explorer.service.FlowEntity
+import org.alephium.protocol.model.BlockHash
 import org.alephium.util.TimeStamp
 
 final case class BlockEntity(
-    hash: BlockEntry.Hash,
+    hash: BlockHash,
     timestamp: TimeStamp,
     chainFrom: GroupIndex,
     chainTo: GroupIndex,
     height: Height,
-    deps: ArraySeq[BlockEntry.Hash],
+    deps: ArraySeq[BlockHash],
     transactions: ArraySeq[TransactionEntity],
     inputs: ArraySeq[InputEntity],
     outputs: ArraySeq[OutputEntity],

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/BlockHeader.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/BlockHeader.scala
@@ -24,10 +24,11 @@ import akka.util.ByteString
 
 import org.alephium.explorer.Hash
 import org.alephium.explorer.api.model._
+import org.alephium.protocol.model.BlockHash
 import org.alephium.util.TimeStamp
 
 final case class BlockHeader(
-    hash: BlockEntry.Hash,
+    hash: BlockHash,
     timestamp: TimeStamp,
     chainFrom: GroupIndex,
     chainTo: GroupIndex,
@@ -40,9 +41,9 @@ final case class BlockHeader(
     txsCount: Int,
     target: ByteString,
     hashrate: BigInteger,
-    parent: Option[BlockEntry.Hash]
+    parent: Option[BlockHash]
 ) {
-  def toApi(deps: ArraySeq[BlockEntry.Hash], transactions: ArraySeq[Transaction]): BlockEntry =
+  def toApi(deps: ArraySeq[BlockHash], transactions: ArraySeq[Transaction]): BlockEntry =
     BlockEntry(hash, timestamp, chainFrom, chainTo, height, deps, transactions, mainChain, hashrate)
 
   val toLiteApi: BlockEntryLite =

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/InputEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/InputEntity.scala
@@ -22,11 +22,12 @@ import akka.util.ByteString
 
 import org.alephium.explorer.Hash
 import org.alephium.explorer.api.model._
+import org.alephium.protocol.model.{BlockHash, TransactionId}
 import org.alephium.util.{TimeStamp, U256}
 
 final case class InputEntity(
-    blockHash: BlockEntry.Hash,
-    txHash: Transaction.Hash,
+    blockHash: BlockHash,
+    txHash: TransactionId,
     timestamp: TimeStamp,
     hint: Int,
     outputRefKey: Hash,
@@ -48,6 +49,6 @@ final case class InputEntity(
     )
 
   /** @return All hash types associated with this [[InputEntity]] */
-  def hashes(): (Transaction.Hash, BlockEntry.Hash) =
+  def hashes(): (TransactionId, BlockHash) =
     (txHash, blockHash)
 }

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/LatestBlock.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/LatestBlock.scala
@@ -20,11 +20,12 @@ import java.math.BigInteger
 
 import akka.util.ByteString
 
-import org.alephium.explorer.api.model.{BlockEntry, GroupIndex, Height}
+import org.alephium.explorer.api.model.{GroupIndex, Height}
+import org.alephium.protocol.model.BlockHash
 import org.alephium.util.TimeStamp
 
 final case class LatestBlock(
-    hash: BlockEntry.Hash,
+    hash: BlockHash,
     timestamp: TimeStamp,
     chainFrom: GroupIndex,
     chainTo: GroupIndex,

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/OutputEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/OutputEntity.scala
@@ -22,11 +22,12 @@ import akka.util.ByteString
 
 import org.alephium.explorer.Hash
 import org.alephium.explorer.api.model._
+import org.alephium.protocol.model.{BlockHash, TransactionId}
 import org.alephium.util.{TimeStamp, U256}
 
 final case class OutputEntity(
-    blockHash: BlockEntry.Hash,
-    txHash: Transaction.Hash,
+    blockHash: BlockHash,
+    txHash: TransactionId,
     timestamp: TimeStamp,
     outputType: OutputEntity.OutputType,
     hint: Int,
@@ -39,10 +40,10 @@ final case class OutputEntity(
     message: Option[ByteString],
     outputOrder: Int,
     txOrder: Int,
-    spentFinalized: Option[Transaction.Hash]
+    spentFinalized: Option[TransactionId]
 ) {
   @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
-  def toApi(spent: Option[Transaction.Hash]): Output = {
+  def toApi(spent: Option[TransactionId]): Output = {
     outputType match {
       case OutputEntity.Asset =>
         AssetOutput(hint, key, amount, address, tokens, lockTime, message, spent)

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/TokenInfoEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/TokenInfoEntity.scala
@@ -16,10 +16,10 @@
 
 package org.alephium.explorer.persistence.model
 
-import org.alephium.explorer.Hash
+import org.alephium.protocol.model.TokenId
 import org.alephium.util.TimeStamp
 
 final case class TokenInfoEntity(
-    token: Hash,
+    token: TokenId,
     lastUsed: TimeStamp
 )

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/TokenOutputEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/TokenOutputEntity.scala
@@ -20,16 +20,17 @@ import akka.util.ByteString
 
 import org.alephium.explorer.Hash
 import org.alephium.explorer.api.model._
+import org.alephium.protocol.model.{BlockHash, TokenId, TransactionId}
 import org.alephium.util.{TimeStamp, U256}
 
 final case class TokenOutputEntity(
-    blockHash: BlockEntry.Hash,
-    txHash: Transaction.Hash,
+    blockHash: BlockHash,
+    txHash: TransactionId,
     timestamp: TimeStamp,
     outputType: Int, //0 Asset, 1 Contract
     hint: Int,
     key: Hash,
-    token: Hash,
+    token: TokenId,
     amount: U256,
     address: Address,
     mainChain: Boolean,
@@ -37,5 +38,5 @@ final case class TokenOutputEntity(
     message: Option[ByteString],
     outputOrder: Int,
     txOrder: Int,
-    spentFinalized: Option[Transaction.Hash]
+    spentFinalized: Option[TransactionId]
 )

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/TokenTxPerAddressEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/TokenTxPerAddressEntity.scala
@@ -16,16 +16,16 @@
 
 package org.alephium.explorer.persistence.model
 
-import org.alephium.explorer.api.model.{Address, BlockEntry, Transaction}
-import org.alephium.protocol.Hash
+import org.alephium.explorer.api.model.Address
+import org.alephium.protocol.model.{BlockHash, TokenId, TransactionId}
 import org.alephium.util.TimeStamp
 
 final case class TokenTxPerAddressEntity(
     address: Address,
-    hash: Transaction.Hash,
-    blockHash: BlockEntry.Hash,
+    hash: TransactionId,
+    blockHash: BlockHash,
     timestamp: TimeStamp,
     txOrder: Int,
     mainChain: Boolean,
-    token: Hash
+    token: TokenId
 )

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/TransactionEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/TransactionEntity.scala
@@ -20,12 +20,13 @@ import scala.collection.immutable.ArraySeq
 
 import akka.util.ByteString
 
-import org.alephium.explorer.api.model.{BlockEntry, GroupIndex, Transaction}
+import org.alephium.explorer.api.model.GroupIndex
+import org.alephium.protocol.model.{BlockHash, TransactionId}
 import org.alephium.util.{TimeStamp, U256}
 
 final case class TransactionEntity(
-    hash: Transaction.Hash,
-    blockHash: BlockEntry.Hash,
+    hash: TransactionId,
+    blockHash: BlockHash,
     timestamp: TimeStamp,
     chainFrom: GroupIndex,
     chainTo: GroupIndex,

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/TransactionPerAddressEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/TransactionPerAddressEntity.scala
@@ -16,13 +16,14 @@
 
 package org.alephium.explorer.persistence.model
 
-import org.alephium.explorer.api.model.{Address, BlockEntry, Transaction}
+import org.alephium.explorer.api.model.Address
+import org.alephium.protocol.model.{BlockHash, TransactionId}
 import org.alephium.util.TimeStamp
 
 final case class TransactionPerAddressEntity(
     address: Address,
-    hash: Transaction.Hash,
-    blockHash: BlockEntry.Hash,
+    hash: TransactionId,
+    blockHash: BlockHash,
     timestamp: TimeStamp,
     txOrder: Int,
     mainChain: Boolean

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/TransactionPerTokenEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/TransactionPerTokenEntity.scala
@@ -16,14 +16,13 @@
 
 package org.alephium.explorer.persistence.model
 
-import org.alephium.explorer.api.model.{BlockEntry, Transaction}
-import org.alephium.protocol.Hash
+import org.alephium.protocol.model.{BlockHash, TokenId, TransactionId}
 import org.alephium.util.TimeStamp
 
 final case class TransactionPerTokenEntity(
-    hash: Transaction.Hash,
-    blockHash: BlockEntry.Hash,
-    token: Hash,
+    hash: TransactionId,
+    blockHash: BlockHash,
+    token: TokenId,
     timestamp: TimeStamp,
     txOrder: Int,
     mainChain: Boolean

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/UInputEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/UInputEntity.scala
@@ -19,10 +19,11 @@ package org.alephium.explorer.persistence.model
 import akka.util.ByteString
 
 import org.alephium.explorer.Hash
-import org.alephium.explorer.api.model.{Address, Input, OutputRef, Transaction}
+import org.alephium.explorer.api.model.{Address, Input, OutputRef}
+import org.alephium.protocol.model.TransactionId
 
 final case class UInputEntity(
-    txHash: Transaction.Hash,
+    txHash: TransactionId,
     hint: Int,
     outputRefKey: Hash,
     unlockScript: Option[ByteString],

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/UOutputEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/UOutputEntity.scala
@@ -21,11 +21,12 @@ import scala.collection.immutable.ArraySeq
 import akka.util.ByteString
 
 import org.alephium.explorer.Hash
-import org.alephium.explorer.api.model.{Address, AssetOutput, Token, Transaction}
+import org.alephium.explorer.api.model.{Address, AssetOutput, Token}
+import org.alephium.protocol.model.TransactionId
 import org.alephium.util.{TimeStamp, U256}
 
 final case class UOutputEntity(
-    txHash: Transaction.Hash,
+    txHash: TransactionId,
     hint: Int,
     key: Hash,
     amount: U256,

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/UnconfirmedTxEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/UnconfirmedTxEntity.scala
@@ -19,10 +19,11 @@ package org.alephium.explorer.persistence.model
 import scala.collection.immutable.ArraySeq
 
 import org.alephium.explorer.api.model._
+import org.alephium.protocol.model.TransactionId
 import org.alephium.util.{TimeStamp, U256}
 
 final case class UnconfirmedTxEntity(
-    hash: Transaction.Hash,
+    hash: TransactionId,
     chainFrom: GroupIndex,
     chainTo: GroupIndex,
     gasAmount: Int,

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/UnconfirmedTxEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/UnconfirmedTxEntity.scala
@@ -55,6 +55,14 @@ object UnconfirmedTxEntity {
      },
      utx.outputs.zipWithIndex.map {
        case (output, order) =>
+         val lockTime = output match {
+           case asset: AssetOutput => asset.lockTime
+           case _: ContractOutput  => None
+         }
+         val message = output match {
+           case asset: AssetOutput => asset.message
+           case _: ContractOutput  => None
+         }
          UOutputEntity(
            utx.hash,
            output.hint,
@@ -62,8 +70,8 @@ object UnconfirmedTxEntity {
            output.attoAlphAmount,
            output.address,
            output.tokens,
-           output.lockTime,
-           output.message,
+           lockTime,
+           message,
            order
          )
      })

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockDepQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockDepQueries.scala
@@ -19,23 +19,23 @@ package org.alephium.explorer.persistence.queries
 import slick.jdbc.{PositionedParameters, SetParameter, SQLActionBuilder}
 import slick.jdbc.PostgresProfile.api._
 
-import org.alephium.explorer.api.model.BlockEntry
 import org.alephium.explorer.persistence.DBActionW
 import org.alephium.explorer.persistence.model.BlockDepEntity
 import org.alephium.explorer.persistence.schema.CustomGetResult._
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.explorer.util.SlickUtil._
+import org.alephium.protocol.model.BlockHash
 
 object BlockDepQueries {
 
   @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
-  def getDepsForBlock(blockHash: BlockEntry.Hash) = {
+  def getDepsForBlock(blockHash: BlockHash) = {
     sql"""
       SELECT dep
       FROM block_deps
       WHERE hash = $blockHash
       ORDER BY dep_order
-    """.asAS[BlockEntry.Hash]
+    """.asAS[BlockHash]
   }
 
   /**

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
@@ -39,6 +39,7 @@ import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.explorer.util.SlickExplainUtil._
 import org.alephium.explorer.util.SlickUtil._
+import org.alephium.protocol.model.BlockHash
 import org.alephium.util.TimeStamp
 
 object BlockQueries extends StrictLogging {
@@ -67,20 +68,20 @@ object BlockQueries extends StrictLogging {
       txs  <- getTransactionsByBlockHash(blockHeader.hash)
     } yield blockHeader.toApi(deps, txs)
 
-  def getBlockEntryLiteAction(hash: BlockEntry.Hash)(
+  def getBlockEntryLiteAction(hash: BlockHash)(
       implicit ec: ExecutionContext): DBActionR[Option[BlockEntryLite]] =
     for {
       header <- BlockHeaderSchema.table.filter(_.hash === hash).result.headOption
     } yield header.map(_.toLiteApi)
 
-  def getBlockEntryAction(hash: BlockEntry.Hash)(
+  def getBlockEntryAction(hash: BlockHash)(
       implicit ec: ExecutionContext): DBActionR[Option[BlockEntry]] =
     for {
       headers <- BlockHeaderSchema.table.filter(_.hash === hash).result
       blocks  <- DBIOAction.sequence(headers.map(buildBlockEntryAction))
     } yield blocks.headOption
 
-  def getBlockHeaderAction(hash: BlockEntry.Hash): DBActionR[Option[BlockHeader]] =
+  def getBlockHeaderAction(hash: BlockHash): DBActionR[Option[BlockHeader]] =
     sql"""
        |SELECT *
        |FROM #$block_headers
@@ -171,7 +172,7 @@ object BlockQueries extends StrictLogging {
          |""".stripMargin
   }
 
-  def updateMainChainStatusAction(hash: BlockEntry.Hash, isMainChain: Boolean)(
+  def updateMainChainStatusAction(hash: BlockHash, isMainChain: Boolean)(
       implicit ec: ExecutionContext): DBActionRWT[Unit] = {
     val query =
       for {
@@ -218,7 +219,7 @@ object BlockQueries extends StrictLogging {
       deps <- getDepsForBlock(blockHeader.hash)
     } yield blockHeader.toApi(deps, ArraySeq.empty)
 
-  def getBlockEntryWithoutTxsAction(hash: BlockEntry.Hash)(
+  def getBlockEntryWithoutTxsAction(hash: BlockHash)(
       implicit ec: ExecutionContext): DBActionR[Option[BlockEntry]] =
     for {
       headers <- BlockHeaderSchema.table.filter(_.hash === hash).result

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/InputUpdateQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/InputUpdateQueries.scala
@@ -27,6 +27,7 @@ import org.alephium.explorer.api.model._
 import org.alephium.explorer.persistence._
 import org.alephium.explorer.persistence.schema.CustomGetResult._
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
+import org.alephium.protocol.model.{BlockHash, TransactionId}
 import org.alephium.util._
 
 object InputUpdateQueries {
@@ -43,20 +44,14 @@ object InputUpdateQueries {
       AND inputs.output_ref_amount IS NULL
       RETURNING outputs.address, outputs.tokens, inputs.tx_hash, inputs.block_hash, inputs.block_timestamp, inputs.tx_order, inputs.main_chain
     """
-      .as[(Address,
-           Option[ArraySeq[Token]],
-           Transaction.Hash,
-           BlockEntry.Hash,
-           TimeStamp,
-           Int,
-           Boolean)]
+      .as[(Address, Option[ArraySeq[Token]], TransactionId, BlockHash, TimeStamp, Int, Boolean)]
       .flatMap(internalUpdates)
       .transactionally
   }
 
   // format: off
   private def internalUpdates(
-      data: Vector[(Address, Option[ArraySeq[Token]], Transaction.Hash, BlockEntry.Hash, TimeStamp, Int, Boolean)])
+      data: Vector[(Address, Option[ArraySeq[Token]], TransactionId, BlockHash, TimeStamp, Int, Boolean)])
     : DBActionWT[Unit] = {
   // format: on
     DBIOAction
@@ -69,7 +64,7 @@ object InputUpdateQueries {
 
   // format: off
   private def updateTransactionPerAddresses(
-      data: Vector[(Address, Option[ArraySeq[Token]], Transaction.Hash, BlockEntry.Hash, TimeStamp, Int, Boolean)])
+      data: Vector[(Address, Option[ArraySeq[Token]], TransactionId, BlockHash, TimeStamp, Int, Boolean)])
     : DBActionWT[Int] = {
   // format: on
     QuerySplitter.splitUpdates(rows = data, columnsPerRow = 6) { (data, placeholder) =>
@@ -101,7 +96,7 @@ object InputUpdateQueries {
 
   // format: off
   private def updateTokenTxPerAddresses(
-      data: Vector[(Address, Option[ArraySeq[Token]], Transaction.Hash, BlockEntry.Hash, TimeStamp, Int, Boolean)])
+      data: Vector[(Address, Option[ArraySeq[Token]], TransactionId, BlockHash, TimeStamp, Int, Boolean)])
     : DBActionWT[Int] = {
   // format: on
     val tokenTxPerAddresses = data.flatMap {

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/OutputQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/OutputQueries.scala
@@ -32,6 +32,7 @@ import org.alephium.explorer.persistence.schema.CustomGetResult._
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.explorer.util.SlickExplainUtil._
 import org.alephium.explorer.util.SlickUtil._
+import org.alephium.protocol.model.{BlockHash, TransactionId}
 import org.alephium.util.{TimeStamp, U256}
 
 object OutputQueries {
@@ -296,10 +297,9 @@ object OutputQueries {
     }
   }
 
-  def outputsFromTxsSQL(
-      txHashes: ArraySeq[Transaction.Hash]): DBActionR[ArraySeq[OutputsFromTxQR]] =
+  def outputsFromTxsSQL(txHashes: ArraySeq[TransactionId]): DBActionR[ArraySeq[OutputsFromTxQR]] =
     if (txHashes.nonEmpty) {
-      val values = txHashes.map(hash => s"'\\x$hash'").mkString(",")
+      val values = txHashes.map(hash => s"'\\x${hash.toHexString}'").mkString(",")
       sql"""
           SELECT outputs.tx_hash,
                  outputs.output_order,
@@ -323,9 +323,9 @@ object OutputQueries {
       DBIOAction.successful(ArraySeq.empty)
     }
 
-  def outputsFromTxsSQLAS(txHashes: ArraySeq[Transaction.Hash]): DBActionSR[OutputsFromTxQR] =
+  def outputsFromTxsSQLAS(txHashes: ArraySeq[TransactionId]): DBActionSR[OutputsFromTxQR] =
     if (txHashes.nonEmpty) {
-      val values = txHashes.map(hash => s"'\\x$hash'").mkString(",")
+      val values = txHashes.map(hash => s"'\\x${hash.toHexString}'").mkString(",")
       sql"""
           SELECT outputs.tx_hash,
                  outputs.output_order,
@@ -350,7 +350,7 @@ object OutputQueries {
     }
 
   def outputsFromTxsNoJoin(
-      hashes: ArraySeq[(Transaction.Hash, BlockEntry.Hash)]): DBActionR[ArraySeq[OutputsFromTxQR]] =
+      hashes: ArraySeq[(TransactionId, BlockHash)]): DBActionR[ArraySeq[OutputsFromTxQR]] =
     if (hashes.nonEmpty) {
       val params = paramPlaceholderTuple2(1, hashes.size)
 
@@ -387,7 +387,7 @@ object OutputQueries {
       DBIOAction.successful(ArraySeq.empty)
     }
 
-  def getOutputsQuery(txHash: Transaction.Hash, blockHash: BlockEntry.Hash): DBActionSR[OutputsQR] =
+  def getOutputsQuery(txHash: TransactionId, blockHash: BlockHash): DBActionSR[OutputsQR] =
     sql"""
         SELECT output_type,
                hint,
@@ -461,8 +461,8 @@ object OutputQueries {
     }
   }
 
-  def getTxnHash(key: Hash): DBActionSR[Transaction.Hash] =
-    getTxnHashSQL(key).asAS[Transaction.Hash]
+  def getTxnHash(key: Hash): DBActionSR[TransactionId] =
+    getTxnHashSQL(key).asAS[TransactionId]
 
   /** Fetch `tx_hash` for keys where `main_chain` is true */
   def getTxnHashSQL(key: Hash): SQLActionBuilder =

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/UnconfirmedTransactionQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/UnconfirmedTransactionQueries.scala
@@ -28,14 +28,15 @@ import org.alephium.explorer.persistence.model._
 import org.alephium.explorer.persistence.schema.CustomGetResult._
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.explorer.util.SlickUtil._
+import org.alephium.protocol.model.TransactionId
 
 object UnconfirmedTransactionQueries {
 
-  val listHashesQuery: DBActionSR[Transaction.Hash] = {
+  val listHashesQuery: DBActionSR[TransactionId] = {
     sql"""
       SELECT hash
       FROM utransactions
-    """.asAS[Transaction.Hash]
+    """.asAS[TransactionId]
   }
 
   def listPaginatedUnconfirmedTransactionsQuery(
@@ -57,15 +58,15 @@ object UnconfirmedTransactionQueries {
     """.asASE[UnconfirmedTxEntity](unconfirmedTransactionGetResult)
   }
 
-  def listUTXHashesByAddress(address: Address): DBActionSR[Transaction.Hash] = {
+  def listUTXHashesByAddress(address: Address): DBActionSR[TransactionId] = {
     sql"""
       SELECT DISTINCT tx_hash
       FROM uinputs
       WHERE address = $address
-    """.asAS[Transaction.Hash]
+    """.asAS[TransactionId]
   }
 
-  def utxsFromTxs(hashes: ArraySeq[Transaction.Hash]): DBActionSR[UnconfirmedTxEntity] = {
+  def utxsFromTxs(hashes: ArraySeq[TransactionId]): DBActionSR[UnconfirmedTxEntity] = {
     if (hashes.nonEmpty) {
       val params = paramPlaceholder(1, hashes.size)
 
@@ -97,7 +98,7 @@ object UnconfirmedTransactionQueries {
     }
   }
 
-  def uoutputsFromTxs(hashes: ArraySeq[Transaction.Hash]): DBActionSR[UOutputEntity] = {
+  def uoutputsFromTxs(hashes: ArraySeq[TransactionId]): DBActionSR[UOutputEntity] = {
     if (hashes.nonEmpty) {
       val params = paramPlaceholder(1, hashes.size)
 
@@ -131,7 +132,7 @@ object UnconfirmedTransactionQueries {
     }
   }
 
-  def uinputsFromTxs(hashes: ArraySeq[Transaction.Hash]): DBActionSR[UInputEntity] = {
+  def uinputsFromTxs(hashes: ArraySeq[TransactionId]): DBActionSR[UInputEntity] = {
     if (hashes.nonEmpty) {
       val params = paramPlaceholder(1, hashes.size)
 
@@ -162,7 +163,7 @@ object UnconfirmedTransactionQueries {
     }
   }
 
-  def utxFromTxHash(hash: Transaction.Hash): DBActionSR[UnconfirmedTxEntity] = {
+  def utxFromTxHash(hash: TransactionId): DBActionSR[UnconfirmedTxEntity] = {
     sql"""
            |SELECT hash,
            |       chain_from,
@@ -175,7 +176,7 @@ object UnconfirmedTransactionQueries {
            |""".stripMargin.asASE[UnconfirmedTxEntity](unconfirmedTransactionGetResult)
   }
 
-  def uoutputsFromTx(hash: Transaction.Hash): DBActionSR[UOutputEntity] = {
+  def uoutputsFromTx(hash: TransactionId): DBActionSR[UOutputEntity] = {
     sql"""
            |SELECT tx_hash,
            |       hint,
@@ -192,7 +193,7 @@ object UnconfirmedTransactionQueries {
            |""".stripMargin.asASE[UOutputEntity](uoutputGetResult)
   }
 
-  def uinputsFromTx(hash: Transaction.Hash): DBActionSR[UInputEntity] = {
+  def uinputsFromTx(hash: TransactionId): DBActionSR[UInputEntity] = {
     sql"""
            |SELECT tx_hash,
            |       hint,

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/result/GasFromTxsQR.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/result/GasFromTxsQR.scala
@@ -18,8 +18,8 @@ package org.alephium.explorer.persistence.queries.result
 
 import slick.jdbc.{GetResult, PositionedResult}
 
-import org.alephium.explorer.api.model.Transaction
 import org.alephium.explorer.persistence.schema.CustomGetResult._
+import org.alephium.protocol.model.TransactionId
 import org.alephium.util.U256
 
 object GasFromTxsQR {
@@ -35,7 +35,7 @@ object GasFromTxsQR {
 }
 
 /** Query result for [[org.alephium.explorer.persistence.queries.TransactionQueries.gasFromTxsSQL]] */
-final case class GasFromTxsQR(txHash: Transaction.Hash, gasAmount: Int, gasPrice: U256) {
+final case class GasFromTxsQR(txHash: TransactionId, gasAmount: Int, gasPrice: U256) {
 
   def gasInfo(): (Int, U256) =
     (gasAmount, gasPrice)

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/result/InputsFromTxQR.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/result/InputsFromTxQR.scala
@@ -24,6 +24,7 @@ import slick.jdbc.{GetResult, PositionedResult}
 import org.alephium.explorer.Hash
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.persistence.schema.CustomGetResult._
+import org.alephium.protocol.model.TransactionId
 import org.alephium.util.U256
 
 object InputsFromTxQR {
@@ -42,7 +43,7 @@ object InputsFromTxQR {
 }
 
 /** Query result for [[org.alephium.explorer.persistence.queries.InputQueries.inputsFromTxsNoJoin]] */
-final case class InputsFromTxQR(txHash: Transaction.Hash,
+final case class InputsFromTxQR(txHash: TransactionId,
                                 inputOrder: Int,
                                 hint: Int,
                                 outputRefKey: Hash,

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/result/OutputsFromTxQR.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/result/OutputsFromTxQR.scala
@@ -25,6 +25,7 @@ import org.alephium.explorer.Hash
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.persistence.model.OutputEntity
 import org.alephium.explorer.persistence.schema.CustomGetResult._
+import org.alephium.protocol.model.TransactionId
 import org.alephium.util.{TimeStamp, U256}
 
 object OutputsFromTxQR {
@@ -46,7 +47,7 @@ object OutputsFromTxQR {
 }
 
 /** Query result for [[org.alephium.explorer.persistence.queries.OutputQueries.outputsFromTxsNoJoin]] */
-final case class OutputsFromTxQR(txHash: Transaction.Hash,
+final case class OutputsFromTxQR(txHash: TransactionId,
                                  outputOrder: Int,
                                  outputType: OutputEntity.OutputType,
                                  hint: Int,
@@ -56,7 +57,7 @@ final case class OutputsFromTxQR(txHash: Transaction.Hash,
                                  tokens: Option[ArraySeq[Token]],
                                  lockTime: Option[TimeStamp],
                                  message: Option[ByteString],
-                                 spent: Option[Transaction.Hash]) {
+                                 spent: Option[TransactionId]) {
   def toApiOutput(): Output =
     outputType match {
       case OutputEntity.Asset =>

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/result/OutputsQR.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/result/OutputsQR.scala
@@ -25,6 +25,7 @@ import org.alephium.explorer.Hash
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.persistence.model.OutputEntity
 import org.alephium.explorer.persistence.schema.CustomGetResult._
+import org.alephium.protocol.model.TransactionId
 import org.alephium.util.{TimeStamp, U256}
 
 object OutputsQR {
@@ -52,7 +53,7 @@ final case class OutputsQR(outputType: OutputEntity.OutputType,
                            tokens: Option[ArraySeq[Token]],
                            lockTime: Option[TimeStamp],
                            message: Option[ByteString],
-                           spentFinalized: Option[Transaction.Hash]) {
+                           spentFinalized: Option[TransactionId]) {
 
   def toApiOutput(): Output =
     outputType match {

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/result/TxByAddressQR.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/result/TxByAddressQR.scala
@@ -20,13 +20,13 @@ import scala.collection.immutable.ArraySeq
 
 import slick.jdbc.{GetResult, PositionedResult}
 
-import org.alephium.explorer.api.model.{BlockEntry, Transaction}
 import org.alephium.explorer.persistence.schema.CustomGetResult._
+import org.alephium.protocol.model.{BlockHash, TransactionId}
 import org.alephium.util.TimeStamp
 
 object TxByAddressQR {
 
-  private type Tuple = (Transaction.Hash, BlockEntry.Hash, TimeStamp, Int)
+  private type Tuple = (TransactionId, BlockHash, TimeStamp, Int)
 
   implicit val transactionByAddressQRGetResult: GetResult[TxByAddressQR] =
     (result: PositionedResult) =>
@@ -53,12 +53,12 @@ object TxByAddressQR {
 }
 
 /** Query result for [[org.alephium.explorer.persistence.queries.TransactionQueries.getTransactionsByAddressNoJoin]] */
-final case class TxByAddressQR(txHash: Transaction.Hash,
-                               blockHash: BlockEntry.Hash,
+final case class TxByAddressQR(txHash: TransactionId,
+                               blockHash: BlockHash,
                                blockTimestamp: TimeStamp,
                                txOrder: Int) {
 
-  def hashes(): (Transaction.Hash, BlockEntry.Hash) =
+  def hashes(): (TransactionId, BlockHash) =
     (txHash, blockHash)
 
 }

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/BlockDepsSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/BlockDepsSchema.scala
@@ -19,16 +19,16 @@ package org.alephium.explorer.persistence.schema
 import slick.jdbc.PostgresProfile.api._
 import slick.lifted.{Index, PrimaryKey, ProvenShape}
 
-import org.alephium.explorer.api.model.BlockEntry
 import org.alephium.explorer.persistence.model.BlockDepEntity
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
+import org.alephium.protocol.model.BlockHash
 
 object BlockDepsSchema extends Schema[BlockDepEntity]("block_deps") {
 
   class BlockDeps(tag: Tag) extends Table[BlockDepEntity](tag, name) {
-    def hash: Rep[BlockEntry.Hash] = column[BlockEntry.Hash]("hash", O.SqlType("BYTEA"))
-    def dep: Rep[BlockEntry.Hash]  = column[BlockEntry.Hash]("dep", O.SqlType("BYTEA"))
-    def depOrder: Rep[Int]         = column[Int]("dep_order")
+    def hash: Rep[BlockHash] = column[BlockHash]("hash", O.SqlType("BYTEA"))
+    def dep: Rep[BlockHash]  = column[BlockHash]("dep", O.SqlType("BYTEA"))
+    def depOrder: Rep[Int]   = column[Int]("dep_order")
 
     def pk: PrimaryKey = primaryKey("hash_deps_pk", (hash, dep))
     def depIdx: Index  = index("deps_dep_idx", dep)

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/BlockHeaderSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/BlockHeaderSchema.scala
@@ -24,16 +24,17 @@ import slick.lifted.{Index, ProvenShape}
 import slick.sql.SqlAction
 
 import org.alephium.explorer.Hash
-import org.alephium.explorer.api.model.{BlockEntry, GroupIndex, Height}
+import org.alephium.explorer.api.model.{GroupIndex, Height}
 import org.alephium.explorer.persistence.model.BlockHeader
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
+import org.alephium.protocol.model.BlockHash
 import org.alephium.util.TimeStamp
 
 object BlockHeaderSchema extends SchemaMainChain[BlockHeader]("block_headers") {
 
   class BlockHeaders(tag: Tag) extends Table[BlockHeader](tag, name) {
-    def hash: Rep[BlockEntry.Hash] =
-      column[BlockEntry.Hash]("hash", O.PrimaryKey, O.SqlType("bytea"))
+    def hash: Rep[BlockHash] =
+      column[BlockHash]("hash", O.PrimaryKey, O.SqlType("bytea"))
     def timestamp: Rep[TimeStamp]  = column[TimeStamp]("block_timestamp")
     def chainFrom: Rep[GroupIndex] = column[GroupIndex]("chain_from")
     def chainTo: Rep[GroupIndex]   = column[GroupIndex]("chain_to")
@@ -47,7 +48,7 @@ object BlockHeaderSchema extends SchemaMainChain[BlockHeader]("block_headers") {
     def target: Rep[ByteString]    = column[ByteString]("target")
     def hashrate: Rep[BigInteger] =
       column[BigInteger]("hashrate", O.SqlType("DECIMAL(80,0)")) //TODO How much decimal we need? this one is the same as for U256
-    def parent: Rep[Option[BlockEntry.Hash]] = column[Option[BlockEntry.Hash]]("parent")
+    def parent: Rep[Option[BlockHash]] = column[Option[BlockHash]]("parent")
 
     def timestampIdx: Index = index("blocks_timestamp_idx", timestamp)
     def heightIdx: Index    = index("blocks_height_idx", height)

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomGetResult.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomGetResult.scala
@@ -23,9 +23,10 @@ import scala.collection.immutable.ArraySeq
 import akka.util.ByteString
 import slick.jdbc.{GetResult, PositionedResult}
 
-import org.alephium.explorer.{BlockHash, Hash}
+import org.alephium.explorer.Hash
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.persistence.model._
+import org.alephium.protocol.model.{BlockHash, TokenId, TransactionId}
 import org.alephium.serde._
 import org.alephium.util.{TimeStamp, U256}
 
@@ -34,25 +35,28 @@ object CustomGetResult {
   /**
     * GetResult types
     */
-  implicit val blockEntryHashGetResult: GetResult[BlockEntry.Hash] =
-    (result: PositionedResult) =>
-      new BlockEntry.Hash(new BlockHash(ByteString.fromArrayUnsafe(result.nextBytes())))
+  implicit val blockEntryHashGetResult: GetResult[BlockHash] =
+    (result: PositionedResult) => BlockHash.unsafe(ByteString.fromArrayUnsafe(result.nextBytes()))
 
-  implicit val txHashGetResult: GetResult[Transaction.Hash] =
+  implicit val txHashGetResult: GetResult[TransactionId] =
     (result: PositionedResult) =>
-      new Transaction.Hash(new Hash(ByteString.fromArrayUnsafe(result.nextBytes())))
+      TransactionId.unsafe(new Hash(ByteString.fromArrayUnsafe(result.nextBytes())))
 
-  implicit val optionTxHashGetResult: GetResult[Option[Transaction.Hash]] =
+  implicit val tokenIdGetResult: GetResult[TokenId] =
+    (result: PositionedResult) =>
+      TokenId.unsafe(new Hash(ByteString.fromArrayUnsafe(result.nextBytes())))
+
+  implicit val optionTxHashGetResult: GetResult[Option[TransactionId]] =
     (result: PositionedResult) =>
       result
         .nextBytesOption()
-        .map(bytes => new Transaction.Hash(new Hash(ByteString.fromArrayUnsafe(bytes))))
+        .map(bytes => TransactionId.unsafe(new Hash(ByteString.fromArrayUnsafe(bytes))))
 
-  implicit val optionBlockEntryHashGetResult: GetResult[Option[BlockEntry.Hash]] =
+  implicit val optionBlockEntryHashGetResult: GetResult[Option[BlockHash]] =
     (result: PositionedResult) =>
       result
         .nextBytesOption()
-        .map(bytes => new BlockEntry.Hash(new BlockHash(ByteString.fromArrayUnsafe(bytes))))
+        .map(bytes => BlockHash.unsafe(ByteString.fromArrayUnsafe(bytes)))
 
   implicit val timestampGetResult: GetResult[TimeStamp] =
     (result: PositionedResult) => TimeStamp.unsafe(result.nextLong())

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomJdbcTypes.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomJdbcTypes.scala
@@ -29,6 +29,7 @@ import slick.jdbc.PostgresProfile.api._
 import org.alephium.explorer._
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.persistence.model.{AppState, AppStateKey, OutputEntity}
+import org.alephium.protocol.model.{BlockHash, TokenId, TransactionId}
 import org.alephium.serde._
 import org.alephium.util.{TimeStamp, U256}
 
@@ -40,24 +41,23 @@ object CustomJdbcTypes {
       raw => from(Hash.unsafe(ByteString.fromArrayUnsafe(raw)))
     )
 
-  private def buildBlockHashTypes[H: ClassTag](from: BlockHash => H,
-                                               to: H           => BlockHash): JdbcType[H] =
-    MappedJdbcType.base[H, Array[Byte]](
-      to(_).bytes.toArray,
-      raw => from(BlockHash.unsafe(ByteString.fromArrayUnsafe(raw)))
-    )
-
   implicit val hashType: JdbcType[Hash] = buildHashTypes(identity, identity)
 
-  implicit val blockEntryHashType: JdbcType[BlockEntry.Hash] =
-    buildBlockHashTypes(
-      new BlockEntry.Hash(_),
+  implicit val blockEntryHashType: JdbcType[BlockHash] =
+    MappedJdbcType.base[BlockHash, Array[Byte]](
+      _.bytes.toArray,
+      raw => BlockHash.unsafe(ByteString.fromArrayUnsafe(raw))
+    )
+
+  implicit val transactionIdType: JdbcType[TransactionId] =
+    buildHashTypes(
+      TransactionId.unsafe(_),
       _.value
     )
 
-  implicit val transactionHashType: JdbcType[Transaction.Hash] =
+  implicit val tokenIdType: JdbcType[TokenId] =
     buildHashTypes(
-      new Transaction.Hash(_),
+      TokenId.unsafe(_),
       _.value
     )
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomSetParameter.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomSetParameter.scala
@@ -26,14 +26,15 @@ import slick.jdbc.{PositionedParameters, SetParameter}
 import org.alephium.explorer
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.persistence.model.OutputEntity
+import org.alephium.protocol.model.{BlockHash, TokenId, TransactionId}
 import org.alephium.serde._
 import org.alephium.util.{TimeStamp, U256}
 
 /** [[slick.jdbc.SetParameter]] implicits for setting values in SQL queries */
 object CustomSetParameter {
 
-  implicit object BlockEntryHashSetParameter extends SetParameter[BlockEntry.Hash] {
-    override def apply(input: BlockEntry.Hash, params: PositionedParameters): Unit =
+  implicit object BlockEntryHashSetParameter extends SetParameter[BlockHash] {
+    override def apply(input: BlockHash, params: PositionedParameters): Unit =
       params setBytes input.value.bytes.toArray
   }
 
@@ -167,12 +168,17 @@ object CustomSetParameter {
       params setInt input.value
   }
 
-  implicit object TransactionHashSetParameter extends SetParameter[Transaction.Hash] {
-    override def apply(input: Transaction.Hash, params: PositionedParameters): Unit =
-      params setBytes input.value.bytes.toArray
+  implicit object TransactionIdSetParameter extends SetParameter[TransactionId] {
+    override def apply(input: TransactionId, params: PositionedParameters): Unit =
+      params setBytes input.bytes.toArray
   }
 
-  implicit object BlockEntryHashOptionSetParameter extends SetParameter[Option[BlockEntry.Hash]] {
+  implicit object TokenIdSetParameter extends SetParameter[TokenId] {
+    override def apply(input: TokenId, params: PositionedParameters): Unit =
+      params setBytes input.bytes.toArray
+  }
+
+  implicit object BlockEntryHashOptionSetParameter extends SetParameter[Option[BlockHash]] {
 
     /** {{{Params.setBytesOption(input.map(_.value.bytes.toArray[Byte]))}}} sets the value
       * to java.lang.Object instead of null which fails and requires casting at SQL level.
@@ -182,7 +188,7 @@ object CustomSetParameter {
       *
       * To keep this simple `null` is used and which set the column value as expected.
       */
-    override def apply(input: Option[BlockEntry.Hash], params: PositionedParameters): Unit =
+    override def apply(input: Option[BlockHash], params: PositionedParameters): Unit =
       input match {
         case Some(value) =>
           params setBytes value.value.bytes.toArray
@@ -194,8 +200,8 @@ object CustomSetParameter {
       }
   }
 
-  implicit object TransationHashOptionSetParameter extends SetParameter[Option[Transaction.Hash]] {
-    override def apply(input: Option[Transaction.Hash], params: PositionedParameters): Unit =
+  implicit object TransationHashOptionSetParameter extends SetParameter[Option[TransactionId]] {
+    override def apply(input: Option[TransactionId], params: PositionedParameters): Unit =
       input match {
         case Some(value) =>
           params setBytes value.value.bytes.toArray

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/InputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/InputSchema.scala
@@ -23,17 +23,18 @@ import slick.jdbc.PostgresProfile.api._
 import slick.lifted.{Index, PrimaryKey, ProvenShape}
 
 import org.alephium.explorer.Hash
-import org.alephium.explorer.api.model.{Address, BlockEntry, Token, Transaction}
+import org.alephium.explorer.api.model.{Address, Token}
 import org.alephium.explorer.persistence.DBActionW
 import org.alephium.explorer.persistence.model.InputEntity
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
+import org.alephium.protocol.model.{BlockHash, TransactionId}
 import org.alephium.util.{TimeStamp, U256}
 
 object InputSchema extends SchemaMainChain[InputEntity]("inputs") {
 
   class Inputs(tag: Tag) extends Table[InputEntity](tag, name) {
-    def blockHash: Rep[BlockEntry.Hash]        = column[BlockEntry.Hash]("block_hash", O.SqlType("BYTEA"))
-    def txHash: Rep[Transaction.Hash]          = column[Transaction.Hash]("tx_hash", O.SqlType("BYTEA"))
+    def blockHash: Rep[BlockHash]              = column[BlockHash]("block_hash", O.SqlType("BYTEA"))
+    def txHash: Rep[TransactionId]             = column[TransactionId]("tx_hash", O.SqlType("BYTEA"))
     def timestamp: Rep[TimeStamp]              = column[TimeStamp]("block_timestamp")
     def hint: Rep[Int]                         = column[Int]("hint")
     def outputRefKey: Rep[Hash]                = column[Hash]("output_ref_key", O.SqlType("BYTEA"))

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/LatestBlockSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/LatestBlockSchema.scala
@@ -22,15 +22,16 @@ import akka.util.ByteString
 import slick.jdbc.PostgresProfile.api._
 import slick.lifted.{PrimaryKey, ProvenShape}
 
-import org.alephium.explorer.api.model.{BlockEntry, GroupIndex, Height}
+import org.alephium.explorer.api.model.{GroupIndex, Height}
 import org.alephium.explorer.persistence.model.LatestBlock
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
+import org.alephium.protocol.model.BlockHash
 import org.alephium.util.TimeStamp
 
 object LatestBlockSchema extends Schema[LatestBlock]("latest_blocks") {
 
   class LatestBlocks(tag: Tag) extends Table[LatestBlock](tag, name) {
-    def hash: Rep[BlockEntry.Hash] = column[BlockEntry.Hash]("hash", O.SqlType("bytea"))
+    def hash: Rep[BlockHash]       = column[BlockHash]("hash", O.SqlType("bytea"))
     def timestamp: Rep[TimeStamp]  = column[TimeStamp]("block_timestamp")
     def chainFrom: Rep[GroupIndex] = column[GroupIndex]("chain_from")
     def chainTo: Rep[GroupIndex]   = column[GroupIndex]("chain_to")

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/OutputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/OutputSchema.scala
@@ -23,17 +23,18 @@ import slick.jdbc.PostgresProfile.api._
 import slick.lifted.{Index, PrimaryKey, ProvenShape}
 
 import org.alephium.explorer.Hash
-import org.alephium.explorer.api.model.{Address, BlockEntry, Token, Transaction}
+import org.alephium.explorer.api.model.{Address, Token}
 import org.alephium.explorer.persistence.DBActionW
 import org.alephium.explorer.persistence.model.OutputEntity
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
+import org.alephium.protocol.model.{BlockHash, TransactionId}
 import org.alephium.util.{TimeStamp, U256}
 
 object OutputSchema extends SchemaMainChain[OutputEntity]("outputs") {
 
   class Outputs(tag: Tag) extends Table[OutputEntity](tag, name) {
-    def blockHash: Rep[BlockEntry.Hash]          = column[BlockEntry.Hash]("block_hash", O.SqlType("BYTEA"))
-    def txHash: Rep[Transaction.Hash]            = column[Transaction.Hash]("tx_hash", O.SqlType("BYTEA"))
+    def blockHash: Rep[BlockHash]                = column[BlockHash]("block_hash", O.SqlType("BYTEA"))
+    def txHash: Rep[TransactionId]               = column[TransactionId]("tx_hash", O.SqlType("BYTEA"))
     def timestamp: Rep[TimeStamp]                = column[TimeStamp]("block_timestamp")
     def outputType: Rep[OutputEntity.OutputType] = column[OutputEntity.OutputType]("output_type")
     def hint: Rep[Int]                           = column[Int]("hint")
@@ -47,8 +48,8 @@ object OutputSchema extends SchemaMainChain[OutputEntity]("outputs") {
     def message: Rep[Option[ByteString]]     = column[Option[ByteString]]("message")
     def outputOrder: Rep[Int]                = column[Int]("output_order")
     def txOrder: Rep[Int]                    = column[Int]("tx_order")
-    def spentFinalized: Rep[Option[Transaction.Hash]] =
-      column[Option[Transaction.Hash]]("spent_finalized", O.Default(None))
+    def spentFinalized: Rep[Option[TransactionId]] =
+      column[Option[TransactionId]]("spent_finalized", O.Default(None))
 
     def pk: PrimaryKey = primaryKey("outputs_pk", (key, blockHash))
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenInfoSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenInfoSchema.scala
@@ -21,13 +21,13 @@ import slick.lifted.ProvenShape
 
 import org.alephium.explorer.persistence.model.TokenInfoEntity
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
-import org.alephium.protocol.Hash
+import org.alephium.protocol.model.TokenId
 import org.alephium.util.TimeStamp
 
 object TokenInfoSchema extends SchemaMainChain[TokenInfoEntity]("token_info") {
 
   class TokenInfos(tag: Tag) extends Table[TokenInfoEntity](tag, name) {
-    def token: Rep[Hash]         = column[Hash]("token", O.PrimaryKey)
+    def token: Rep[TokenId]      = column[TokenId]("token", O.PrimaryKey)
     def lastUsed: Rep[TimeStamp] = column[TimeStamp]("last_used")
 
     def * : ProvenShape[TokenInfoEntity] =

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenOutputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenOutputSchema.scala
@@ -21,22 +21,23 @@ import slick.jdbc.PostgresProfile.api._
 import slick.lifted.{Index, PrimaryKey, ProvenShape}
 
 import org.alephium.explorer.Hash
-import org.alephium.explorer.api.model.{Address, BlockEntry, Transaction}
+import org.alephium.explorer.api.model.Address
 import org.alephium.explorer.persistence.DBActionW
 import org.alephium.explorer.persistence.model.TokenOutputEntity
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
+import org.alephium.protocol.model.{BlockHash, TokenId, TransactionId}
 import org.alephium.util.{TimeStamp, U256}
 
 object TokenOutputSchema extends SchemaMainChain[TokenOutputEntity]("token_outputs") {
 
   class TokenOutputs(tag: Tag) extends Table[TokenOutputEntity](tag, name) {
-    def blockHash: Rep[BlockEntry.Hash] = column[BlockEntry.Hash]("block_hash", O.SqlType("BYTEA"))
-    def txHash: Rep[Transaction.Hash]   = column[Transaction.Hash]("tx_hash", O.SqlType("BYTEA"))
-    def timestamp: Rep[TimeStamp]       = column[TimeStamp]("block_timestamp")
-    def outputType: Rep[Int]            = column[Int]("output_type")
-    def hint: Rep[Int]                  = column[Int]("hint")
-    def key: Rep[Hash]                  = column[Hash]("key", O.SqlType("BYTEA"))
-    def token: Rep[Hash]                = column[Hash]("token")
+    def blockHash: Rep[BlockHash]  = column[BlockHash]("block_hash", O.SqlType("BYTEA"))
+    def txHash: Rep[TransactionId] = column[TransactionId]("tx_hash", O.SqlType("BYTEA"))
+    def timestamp: Rep[TimeStamp]  = column[TimeStamp]("block_timestamp")
+    def outputType: Rep[Int]       = column[Int]("output_type")
+    def hint: Rep[Int]             = column[Int]("hint")
+    def key: Rep[Hash]             = column[Hash]("key", O.SqlType("BYTEA"))
+    def token: Rep[TokenId]        = column[TokenId]("token")
     def amount: Rep[U256] =
       column[U256]("amount", O.SqlType("DECIMAL(80,0)")) //U256.MaxValue has 78 digits
     def address: Rep[Address]            = column[Address]("address")
@@ -45,8 +46,8 @@ object TokenOutputSchema extends SchemaMainChain[TokenOutputEntity]("token_outpu
     def message: Rep[Option[ByteString]] = column[Option[ByteString]]("message")
     def outputOrder: Rep[Int]            = column[Int]("output_order")
     def txOrder: Rep[Int]                = column[Int]("tx_order")
-    def spentFinalized: Rep[Option[Transaction.Hash]] =
-      column[Option[Transaction.Hash]]("spent_finalized", O.Default(None))
+    def spentFinalized: Rep[Option[TransactionId]] =
+      column[Option[TransactionId]]("spent_finalized", O.Default(None))
 
     def pk: PrimaryKey = primaryKey("token_outputs_pk", (key, token, blockHash))
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenTxPerAddressSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenTxPerAddressSchema.scala
@@ -19,23 +19,23 @@ package org.alephium.explorer.persistence.schema
 import slick.jdbc.PostgresProfile.api._
 import slick.lifted.{Index, PrimaryKey, ProvenShape}
 
-import org.alephium.explorer.api.model.{Address, BlockEntry, Transaction}
+import org.alephium.explorer.api.model.Address
 import org.alephium.explorer.persistence.model.TokenTxPerAddressEntity
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
-import org.alephium.protocol.Hash
+import org.alephium.protocol.model.{BlockHash, TokenId, TransactionId}
 import org.alephium.util.TimeStamp
 
 object TokenPerAddressSchema
     extends SchemaMainChain[TokenTxPerAddressEntity]("token_tx_per_addresses") {
 
   class TokenPerAddresses(tag: Tag) extends Table[TokenTxPerAddressEntity](tag, name) {
-    def address: Rep[Address]           = column[Address]("address")
-    def txHash: Rep[Transaction.Hash]   = column[Transaction.Hash]("tx_hash", O.SqlType("BYTEA"))
-    def blockHash: Rep[BlockEntry.Hash] = column[BlockEntry.Hash]("block_hash", O.SqlType("BYTEA"))
-    def timestamp: Rep[TimeStamp]       = column[TimeStamp]("block_timestamp")
-    def txOrder: Rep[Int]               = column[Int]("tx_order")
-    def mainChain: Rep[Boolean]         = column[Boolean]("main_chain")
-    def token: Rep[Hash]                = column[Hash]("token")
+    def address: Rep[Address]      = column[Address]("address")
+    def txHash: Rep[TransactionId] = column[TransactionId]("tx_hash", O.SqlType("BYTEA"))
+    def blockHash: Rep[BlockHash]  = column[BlockHash]("block_hash", O.SqlType("BYTEA"))
+    def timestamp: Rep[TimeStamp]  = column[TimeStamp]("block_timestamp")
+    def txOrder: Rep[Int]          = column[Int]("tx_order")
+    def mainChain: Rep[Boolean]    = column[Boolean]("main_chain")
+    def token: Rep[TokenId]        = column[TokenId]("token")
 
     def pk: PrimaryKey = primaryKey("token_tx_per_address_pk", (txHash, blockHash, address, token))
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionPerAddressSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionPerAddressSchema.scala
@@ -19,21 +19,22 @@ package org.alephium.explorer.persistence.schema
 import slick.jdbc.PostgresProfile.api._
 import slick.lifted.{Index, PrimaryKey, ProvenShape}
 
-import org.alephium.explorer.api.model.{Address, BlockEntry, Transaction}
+import org.alephium.explorer.api.model.Address
 import org.alephium.explorer.persistence.model.TransactionPerAddressEntity
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
+import org.alephium.protocol.model.{BlockHash, TransactionId}
 import org.alephium.util.TimeStamp
 
 object TransactionPerAddressSchema
     extends SchemaMainChain[TransactionPerAddressEntity]("transaction_per_addresses") {
 
   class TransactionPerAddresses(tag: Tag) extends Table[TransactionPerAddressEntity](tag, name) {
-    def address: Rep[Address]           = column[Address]("address")
-    def txHash: Rep[Transaction.Hash]   = column[Transaction.Hash]("tx_hash", O.SqlType("BYTEA"))
-    def blockHash: Rep[BlockEntry.Hash] = column[BlockEntry.Hash]("block_hash", O.SqlType("BYTEA"))
-    def timestamp: Rep[TimeStamp]       = column[TimeStamp]("block_timestamp")
-    def txOrder: Rep[Int]               = column[Int]("tx_order")
-    def mainChain: Rep[Boolean]         = column[Boolean]("main_chain")
+    def address: Rep[Address]      = column[Address]("address")
+    def txHash: Rep[TransactionId] = column[TransactionId]("tx_hash", O.SqlType("BYTEA"))
+    def blockHash: Rep[BlockHash]  = column[BlockHash]("block_hash", O.SqlType("BYTEA"))
+    def timestamp: Rep[TimeStamp]  = column[TimeStamp]("block_timestamp")
+    def txOrder: Rep[Int]          = column[Int]("tx_order")
+    def mainChain: Rep[Boolean]    = column[Boolean]("main_chain")
 
     def pk: PrimaryKey = primaryKey("txs_per_address_pk", (txHash, blockHash, address))
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionPerTokenSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionPerTokenSchema.scala
@@ -19,22 +19,21 @@ package org.alephium.explorer.persistence.schema
 import slick.jdbc.PostgresProfile.api._
 import slick.lifted.{Index, PrimaryKey, ProvenShape}
 
-import org.alephium.explorer.api.model.{BlockEntry, Transaction}
 import org.alephium.explorer.persistence.model.TransactionPerTokenEntity
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
-import org.alephium.protocol.Hash
+import org.alephium.protocol.model.{BlockHash, TokenId, TransactionId}
 import org.alephium.util.TimeStamp
 
 object TransactionPerTokenSchema
     extends SchemaMainChain[TransactionPerTokenEntity]("transaction_per_token") {
 
   class TransactionPerTokens(tag: Tag) extends Table[TransactionPerTokenEntity](tag, name) {
-    def hash: Rep[Transaction.Hash]     = column[Transaction.Hash]("tx_hash", O.SqlType("BYTEA"))
-    def blockHash: Rep[BlockEntry.Hash] = column[BlockEntry.Hash]("block_hash", O.SqlType("BYTEA"))
-    def token: Rep[Hash]                = column[Hash]("token")
-    def timestamp: Rep[TimeStamp]       = column[TimeStamp]("block_timestamp")
-    def txOrder: Rep[Int]               = column[Int]("tx_order")
-    def mainChain: Rep[Boolean]         = column[Boolean]("main_chain")
+    def hash: Rep[TransactionId]  = column[TransactionId]("tx_hash", O.SqlType("BYTEA"))
+    def blockHash: Rep[BlockHash] = column[BlockHash]("block_hash", O.SqlType("BYTEA"))
+    def token: Rep[TokenId]       = column[TokenId]("token")
+    def timestamp: Rep[TimeStamp] = column[TimeStamp]("block_timestamp")
+    def txOrder: Rep[Int]         = column[Int]("tx_order")
+    def mainChain: Rep[Boolean]   = column[Boolean]("main_chain")
 
     def pk: PrimaryKey = primaryKey("transaction_per_token_pk", (hash, blockHash, token))
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionSchema.scala
@@ -22,20 +22,21 @@ import akka.util.ByteString
 import slick.jdbc.PostgresProfile.api._
 import slick.lifted.{Index, PrimaryKey, ProvenShape}
 
-import org.alephium.explorer.api.model.{BlockEntry, GroupIndex, Transaction}
+import org.alephium.explorer.api.model.GroupIndex
 import org.alephium.explorer.persistence.model.TransactionEntity
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
+import org.alephium.protocol.model.{BlockHash, TransactionId}
 import org.alephium.util.{TimeStamp, U256}
 
 object TransactionSchema extends SchemaMainChain[TransactionEntity]("transactions") {
 
   class Transactions(tag: Tag) extends Table[TransactionEntity](tag, name) {
-    def hash: Rep[Transaction.Hash]     = column[Transaction.Hash]("hash", O.SqlType("BYTEA"))
-    def blockHash: Rep[BlockEntry.Hash] = column[BlockEntry.Hash]("block_hash", O.SqlType("BYTEA"))
-    def timestamp: Rep[TimeStamp]       = column[TimeStamp]("block_timestamp")
-    def chainFrom: Rep[GroupIndex]      = column[GroupIndex]("chain_from")
-    def chainTo: Rep[GroupIndex]        = column[GroupIndex]("chain_to")
-    def gasAmount: Rep[Int]             = column[Int]("gas_amount")
+    def hash: Rep[TransactionId]   = column[TransactionId]("hash", O.SqlType("BYTEA"))
+    def blockHash: Rep[BlockHash]  = column[BlockHash]("block_hash", O.SqlType("BYTEA"))
+    def timestamp: Rep[TimeStamp]  = column[TimeStamp]("block_timestamp")
+    def chainFrom: Rep[GroupIndex] = column[GroupIndex]("chain_from")
+    def chainTo: Rep[GroupIndex]   = column[GroupIndex]("chain_to")
+    def gasAmount: Rep[Int]        = column[Int]("gas_amount")
     def gasPrice: Rep[U256] =
       column[U256]("gas_price", O.SqlType("DECIMAL(80,0)")) //U256.MaxValue has 78 digits
     def txOrder: Rep[Int]               = column[Int]("tx_order")

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/UInputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/UInputSchema.scala
@@ -21,14 +21,15 @@ import slick.jdbc.PostgresProfile.api._
 import slick.lifted.{Index, PrimaryKey, ProvenShape}
 
 import org.alephium.explorer.Hash
-import org.alephium.explorer.api.model.{Address, Transaction}
+import org.alephium.explorer.api.model.Address
 import org.alephium.explorer.persistence.model.UInputEntity
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
+import org.alephium.protocol.model.TransactionId
 
 object UInputSchema extends Schema[UInputEntity]("uinputs") {
 
   class UInputs(tag: Tag) extends Table[UInputEntity](tag, name) {
-    def txHash: Rep[Transaction.Hash]         = column[Transaction.Hash]("tx_hash", O.SqlType("BYTEA"))
+    def txHash: Rep[TransactionId]            = column[TransactionId]("tx_hash", O.SqlType("BYTEA"))
     def hint: Rep[Int]                        = column[Int]("hint")
     def outputRefKey: Rep[Hash]               = column[Hash]("output_ref_key", O.SqlType("BYTEA"))
     def unlockScript: Rep[Option[ByteString]] = column[Option[ByteString]]("unlock_script")

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/UOutputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/UOutputSchema.scala
@@ -23,17 +23,18 @@ import slick.jdbc.PostgresProfile.api._
 import slick.lifted.{Index, PrimaryKey, ProvenShape}
 
 import org.alephium.explorer.Hash
-import org.alephium.explorer.api.model.{Address, Token, Transaction}
+import org.alephium.explorer.api.model.{Address, Token}
 import org.alephium.explorer.persistence.model.UOutputEntity
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
+import org.alephium.protocol.model.TransactionId
 import org.alephium.util.{TimeStamp, U256}
 
 object UOutputSchema extends Schema[UOutputEntity]("uoutputs") {
 
   class UOutputs(tag: Tag) extends Table[UOutputEntity](tag, name) {
-    def txHash: Rep[Transaction.Hash] = column[Transaction.Hash]("tx_hash", O.SqlType("BYTEA"))
-    def hint: Rep[Int]                = column[Int]("hint")
-    def key: Rep[Hash]                = column[Hash]("key", O.SqlType("BYTEA"))
+    def txHash: Rep[TransactionId] = column[TransactionId]("tx_hash", O.SqlType("BYTEA"))
+    def hint: Rep[Int]             = column[Int]("hint")
+    def key: Rep[Hash]             = column[Hash]("key", O.SqlType("BYTEA"))
     def amount: Rep[U256] =
       column[U256]("amount", O.SqlType("DECIMAL(80,0)")) //U256.MaxValue has 78 digits
     def address: Rep[Address]                = column[Address]("address")

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/UTransactionSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/UTransactionSchema.scala
@@ -19,16 +19,17 @@ package org.alephium.explorer.persistence.schema
 import slick.jdbc.PostgresProfile.api._
 import slick.lifted.{Index, ProvenShape}
 
-import org.alephium.explorer.api.model.{GroupIndex, Transaction}
+import org.alephium.explorer.api.model.GroupIndex
 import org.alephium.explorer.persistence.model.UnconfirmedTxEntity
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
+import org.alephium.protocol.model.TransactionId
 import org.alephium.util.{TimeStamp, U256}
 
 object UnconfirmedTxSchema extends Schema[UnconfirmedTxEntity]("utransactions") {
 
   class UnconfirmedTxs(tag: Tag) extends Table[UnconfirmedTxEntity](tag, name) {
-    def hash: Rep[Transaction.Hash] =
-      column[Transaction.Hash]("hash", O.PrimaryKey, O.SqlType("BYTEA"))
+    def hash: Rep[TransactionId] =
+      column[TransactionId]("hash", O.PrimaryKey, O.SqlType("BYTEA"))
     def chainFrom: Rep[GroupIndex] = column[GroupIndex]("chain_from")
     def chainTo: Rep[GroupIndex]   = column[GroupIndex]("chain_to")
     def gasAmount: Rep[Int]        = column[Int]("gas_amount")

--- a/app/src/main/scala/org/alephium/explorer/service/BlockFlowSyncService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/BlockFlowSyncService.scala
@@ -28,13 +28,14 @@ import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
 
 import org.alephium.explorer.{foldFutures, GroupSetting}
-import org.alephium.explorer.api.model.{BlockEntry, GroupIndex, Height}
+import org.alephium.explorer.api.model.{GroupIndex, Height}
 import org.alephium.explorer.cache.BlockCache
 import org.alephium.explorer.persistence.DBRunner._
 import org.alephium.explorer.persistence.dao.BlockDao
 import org.alephium.explorer.persistence.model.BlockEntity
 import org.alephium.explorer.persistence.queries.{BlockQueries, InputUpdateQueries}
 import org.alephium.explorer.util.{Scheduler, TimeUtil}
+import org.alephium.protocol.model.BlockHash
 import org.alephium.util.{Duration, TimeStamp}
 
 /*
@@ -247,7 +248,7 @@ case object BlockFlowSyncService extends StrictLogging {
       }
   }
 
-  private def updateMainChain(hash: BlockEntry.Hash, chainFrom: GroupIndex, chainTo: GroupIndex)(
+  private def updateMainChain(hash: BlockHash, chainFrom: GroupIndex, chainTo: GroupIndex)(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile],
       blockFlowClient: BlockFlowClient,
@@ -309,7 +310,7 @@ case object BlockFlowSyncService extends StrictLogging {
     }
   }
 
-  private def handleMissingMainChainBlock(missing: BlockEntry.Hash, chainFrom: GroupIndex)(
+  private def handleMissingMainChainBlock(missing: BlockHash, chainFrom: GroupIndex)(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile],
       blockFlowClient: BlockFlowClient,

--- a/app/src/main/scala/org/alephium/explorer/service/BlockService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/BlockService.scala
@@ -26,13 +26,14 @@ import org.alephium.explorer.GroupSetting
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.cache.BlockCache
 import org.alephium.explorer.persistence.dao.BlockDao
+import org.alephium.protocol.model.BlockHash
 
 trait BlockService {
-  def getLiteBlockByHash(hash: BlockEntry.Hash)(
+  def getLiteBlockByHash(hash: BlockHash)(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[Option[BlockEntryLite]]
 
-  def getBlockTransactions(hash: BlockEntry.Hash, pagination: Pagination)(
+  def getBlockTransactions(hash: BlockHash, pagination: Pagination)(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]]
 
@@ -51,12 +52,12 @@ trait BlockService {
 
 object BlockService extends BlockService {
 
-  def getLiteBlockByHash(hash: BlockEntry.Hash)(
+  def getLiteBlockByHash(hash: BlockHash)(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[Option[BlockEntryLite]] =
     BlockDao.getLite(hash)
 
-  def getBlockTransactions(hash: BlockEntry.Hash, pagination: Pagination)(
+  def getBlockTransactions(hash: BlockHash, pagination: Pagination)(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]] =
     BlockDao.getTransactions(hash, pagination)

--- a/app/src/main/scala/org/alephium/explorer/service/FlowEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/FlowEntity.scala
@@ -18,19 +18,20 @@ package org.alephium.explorer.service
 
 import scala.collection.immutable.ArraySeq
 
-import org.alephium.explorer.api.model.{BlockEntry, GroupIndex, Height}
+import org.alephium.explorer.api.model.{GroupIndex, Height}
+import org.alephium.protocol.model.BlockHash
 import org.alephium.util.TimeStamp
 
 trait FlowEntity {
-  def hash: BlockEntry.Hash
+  def hash: BlockHash
   def timestamp: TimeStamp
   def chainFrom: GroupIndex
   def chainTo: GroupIndex
   def height: Height
-  def deps: ArraySeq[BlockEntry.Hash]
+  def deps: ArraySeq[BlockHash]
   def mainChain: Boolean
 
-  def parent(groupNum: Int): Option[BlockEntry.Hash] =
+  def parent(groupNum: Int): Option[BlockHash] =
     if (isGenesis) {
       None
     } else {

--- a/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
@@ -26,10 +26,11 @@ import org.alephium.explorer.api.model._
 import org.alephium.explorer.cache.TransactionCache
 import org.alephium.explorer.persistence.dao.{TransactionDao, UnconfirmedTxDao}
 import org.alephium.protocol.Hash
+import org.alephium.protocol.model.{TokenId, TransactionId}
 import org.alephium.util.U256
 
 trait TransactionService {
-  def getTransaction(transactionHash: Transaction.Hash)(
+  def getTransaction(transactionHash: TransactionId)(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[Option[TransactionLike]]
 
@@ -56,7 +57,7 @@ trait TransactionService {
   def getBalance(address: Address)(implicit ec: ExecutionContext,
                                    dc: DatabaseConfig[PostgresProfile]): Future[(U256, U256)]
 
-  def getTokenBalance(address: Address, token: Hash)(
+  def getTokenBalance(address: Address, token: TokenId)(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[(U256, U256)]
 
@@ -72,28 +73,28 @@ trait TransactionService {
 
   def listTokens(pagination: Pagination)(
       implicit ec: ExecutionContext,
-      dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Hash]]
+      dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[TokenId]]
 
-  def listTokenTransactions(token: Hash, pagination: Pagination)(
+  def listTokenTransactions(token: TokenId, pagination: Pagination)(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]]
 
-  def listTokenAddresses(token: Hash, pagination: Pagination)(
+  def listTokenAddresses(token: TokenId, pagination: Pagination)(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Address]]
 
   def listAddressTokens(address: Address)(
       implicit ec: ExecutionContext,
-      dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Hash]]
+      dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[TokenId]]
 
-  def listAddressTokenTransactions(address: Address, token: Hash, pagination: Pagination)(
+  def listAddressTokenTransactions(address: Address, token: TokenId, pagination: Pagination)(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]]
 }
 
 object TransactionService extends TransactionService {
 
-  def getTransaction(transactionHash: Transaction.Hash)(
+  def getTransaction(transactionHash: TransactionId)(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[Option[TransactionLike]] =
     TransactionDao.get(transactionHash).flatMap {
@@ -135,7 +136,7 @@ object TransactionService extends TransactionService {
                                    dc: DatabaseConfig[PostgresProfile]): Future[(U256, U256)] =
     TransactionDao.getBalance(address)
 
-  def getTokenBalance(address: Address, token: Hash)(
+  def getTokenBalance(address: Address, token: TokenId)(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[(U256, U256)] =
     TransactionDao.getTokenBalance(address, token)
@@ -148,25 +149,25 @@ object TransactionService extends TransactionService {
 
   def listTokens(pagination: Pagination)(
       implicit ec: ExecutionContext,
-      dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Hash]] =
+      dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[TokenId]] =
     TransactionDao.listTokens(pagination)
 
-  def listTokenTransactions(token: Hash, pagination: Pagination)(
+  def listTokenTransactions(token: TokenId, pagination: Pagination)(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]] =
     TransactionDao.listTokenTransactions(token, pagination)
 
   def listAddressTokens(address: Address)(
       implicit ec: ExecutionContext,
-      dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Hash]] =
+      dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[TokenId]] =
     TransactionDao.listAddressTokens(address)
 
-  def listTokenAddresses(token: Hash, pagination: Pagination)(
+  def listTokenAddresses(token: TokenId, pagination: Pagination)(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Address]] =
     TransactionDao.listTokenAddresses(token, pagination)
 
-  def listAddressTokenTransactions(address: Address, token: Hash, pagination: Pagination)(
+  def listAddressTokenTransactions(address: Address, token: TokenId, pagination: Pagination)(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]] =
     TransactionDao.listAddressTokenTransactions(address, token, pagination)

--- a/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
@@ -36,7 +36,7 @@ trait TransactionService {
 
   def getOutputRefTransaction(hash: Hash)(
       implicit ec: ExecutionContext,
-      dc: DatabaseConfig[PostgresProfile]): Future[Option[ConfirmedTransaction]]
+      dc: DatabaseConfig[PostgresProfile]): Future[Option[Transaction]]
 
   def getTransactionsByAddress(address: Address, pagination: Pagination)(
       implicit ec: ExecutionContext,
@@ -104,12 +104,9 @@ object TransactionService extends TransactionService {
 
   def getOutputRefTransaction(hash: Hash)(
       implicit ec: ExecutionContext,
-      dc: DatabaseConfig[PostgresProfile]): Future[Option[ConfirmedTransaction]] =
+      dc: DatabaseConfig[PostgresProfile]): Future[Option[Transaction]] =
     TransactionDao
       .getOutputRefTransaction(hash)
-      .map(_.map { tx =>
-        ConfirmedTransaction.from(tx)
-      })
 
   def getTransactionsByAddress(address: Address, pagination: Pagination)(
       implicit ec: ExecutionContext,

--- a/app/src/main/scala/org/alephium/explorer/util/TimeUtil.scala
+++ b/app/src/main/scala/org/alephium/explorer/util/TimeUtil.scala
@@ -57,7 +57,7 @@ object TimeUtil {
       if (next.isBefore(remoteTs)) {
         rec(next.plusMillisUnsafe(1), seq :+ ((l, next)))
       } else if (l == remoteTs) {
-        seq :+ ((remoteTs, remoteTs))
+        seq :+ ((remoteTs, remoteTs.plusMillisUnsafe(1)))
       } else {
         seq :+ ((l, remoteTs))
       }

--- a/app/src/test/scala/org/alephium/explorer/ExplorerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/ExplorerSpec.scala
@@ -51,7 +51,7 @@ import org.alephium.explorer.service.BlockFlowClient
 import org.alephium.explorer.util.TestUtils._
 import org.alephium.json.Json
 import org.alephium.json.Json._
-import org.alephium.protocol.model.{CliqueId, NetworkId}
+import org.alephium.protocol.model.{BlockHash, CliqueId, NetworkId}
 import org.alephium.util.{AVector, Hex, TimeStamp, U256}
 
 trait ExplorerSpec
@@ -195,12 +195,12 @@ trait ExplorerSpec
       blocks.foreach(block => res.contains(block.hash) is true)
     }
 
-    var blocksPage1: ArraySeq[BlockEntry.Hash] = ArraySeq.empty
+    var blocksPage1: ArraySeq[BlockHash] = ArraySeq.empty
     Get(s"/blocks?page=1&limit=${blocks.size / 2 + 1}") ~> routes ~> check {
       blocksPage1 = responseAs[ListBlocks].blocks.map(_.hash)
     }
 
-    var allBlocks: ArraySeq[BlockEntry.Hash] = ArraySeq.empty
+    var allBlocks: ArraySeq[BlockHash] = ArraySeq.empty
     Get(s"/blocks?page=2&limit=${blocks.size / 2 + 1}") ~> routes ~> check {
       val res = responseAs[ListBlocks].blocks.map(_.hash)
 
@@ -368,13 +368,13 @@ object ExplorerSpec {
     private val peer = model.PeerAddress(address, port, 0, 0)
     val HashSegment  = Segment.map(raw => BlockHash.unsafe(Hex.unsafe(raw)))
     val routes: Route =
-      path("blockflow") {
+      path("blockflow" / "blocks") {
         parameters("fromTs".as[Long]) { fromTs =>
           parameters("toTs".as[Long]) { toTs =>
             get {
               complete(
                 Future.successful(
-                  model.FetchResponse(
+                  model.BlocksPerTimeStampRange(
                     AVector.from(
                       blockflow
                         .map(

--- a/app/src/test/scala/org/alephium/explorer/ExplorerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/ExplorerSpec.scala
@@ -32,7 +32,6 @@ import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import akka.testkit.SocketUtil
 import com.typesafe.config.{ConfigFactory, ConfigValueFactory}
-import de.heikoseeberger.akkahttpupickle.UpickleCustomizationSupport
 import org.scalacheck.Gen
 import org.scalatest.Assertion
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
@@ -59,10 +58,7 @@ trait ExplorerSpec
     with ScalatestRouteTest
     with ScalaFutures
     with Eventually
-    with UpickleCustomizationSupport {
-
-  override type Api = Json.type
-  override def api: Api = Json
+    with HttpJsonSupport {
 
   override implicit val patienceConfig = PatienceConfig(timeout = Span(1, Minutes))
   implicit val defaultTimeout          = RouteTestTimeout(5.seconds)
@@ -337,7 +333,7 @@ object ExplorerSpec {
       blockflow: ArraySeq[ArraySeq[model.BlockEntry]],
       networkId: NetworkId)(implicit groupSetting: GroupSetting, system: ActorSystem)
       extends ApiModelCodec
-      with UpickleCustomizationSupport {
+      with HttpJsonSupport {
 
     val blocks = blockflow.flatten
 

--- a/app/src/test/scala/org/alephium/explorer/GenApiModel.scala
+++ b/app/src/test/scala/org/alephium/explorer/GenApiModel.scala
@@ -27,25 +27,29 @@ import org.scalacheck.Gen
 import org.alephium.explorer.GenCoreUtil._
 import org.alephium.explorer.api.model._
 import org.alephium.protocol.ALPH
+import org.alephium.protocol.model.{BlockHash, ContractId, TokenId, TransactionId, TxOutputRef}
 import org.alephium.util.{Base58, Number, U256}
 
 /** Generators for types supplied by `org.alephium.explorer.api.model` package */
 object GenApiModel extends ImplicitConversions {
 
-  val hashGen: Gen[Hash]                        = Gen.const(()).map(_ => Hash.generate)
-  val blockHashGen: Gen[BlockHash]              = Gen.const(()).map(_ => BlockHash.generate)
-  val blockEntryHashGen: Gen[BlockEntry.Hash]   = blockHashGen.map(new BlockEntry.Hash(_))
-  val transactionHashGen: Gen[Transaction.Hash] = hashGen.map(new Transaction.Hash(_))
-  val groupIndexGen: Gen[GroupIndex]            = Gen.posNum[Int].map(GroupIndex.unsafe(_))
-  val heightGen: Gen[Height]                    = Gen.posNum[Int].map(Height.unsafe(_))
-  val addressGen: Gen[Address]                  = hashGen.map(hash => Address.unsafe(Base58.encode(hash.bytes)))
-  val bytesGen: Gen[ByteString]                 = hashGen.map(_.bytes)
-  val hashrateGen: Gen[BigInteger]              = arbitrary[Long].map(BigInteger.valueOf)
-  val amountGen: Gen[U256]                      = Gen.choose(1000L, Number.quadrillion).map(ALPH.nanoAlph)
+  val hashGen: Gen[Hash]                     = Gen.const(()).map(_ => Hash.generate)
+  val blockHashGen: Gen[BlockHash]           = Gen.const(()).map(_ => BlockHash.generate)
+  val blockEntryHashGen: Gen[BlockHash]      = blockHashGen
+  val transactionHashGen: Gen[TransactionId] = hashGen.map(TransactionId.unsafe)
+  val tokenIdGen: Gen[TokenId]               = hashGen.map(TokenId.unsafe)
+  val outputRefKeyGen: Gen[TxOutputRef.Key]  = hashGen.map(new TxOutputRef.Key(_))
+  val contractIdGen: Gen[ContractId]         = hashGen.map(ContractId.unsafe)
+  val groupIndexGen: Gen[GroupIndex]         = Gen.posNum[Int].map(GroupIndex.unsafe(_))
+  val heightGen: Gen[Height]                 = Gen.posNum[Int].map(Height.unsafe(_))
+  val addressGen: Gen[Address]               = hashGen.map(hash => Address.unsafe(Base58.encode(hash.bytes)))
+  val bytesGen: Gen[ByteString]              = hashGen.map(_.bytes)
+  val hashrateGen: Gen[BigInteger]           = arbitrary[Long].map(BigInteger.valueOf)
+  val amountGen: Gen[U256]                   = Gen.choose(1000L, Number.quadrillion).map(ALPH.nanoAlph)
 
   val outputRefGen: Gen[OutputRef] = for {
     hint <- arbitrary[Int]
-    key  <- hashGen
+    key  <- outputRefKeyGen.map(_.value)
   } yield OutputRef(hint, key)
 
   val unlockScriptGen: Gen[ByteString] = hashGen.map(_.bytes)
@@ -58,7 +62,7 @@ object GenApiModel extends ImplicitConversions {
   } yield Input(outputRef, unlockScript, address, amount)
 
   val tokenGen: Gen[Token] = for {
-    id     <- hashGen
+    id     <- tokenIdGen
     amount <- amountGen
   } yield Token(id, amount)
 
@@ -73,7 +77,7 @@ object GenApiModel extends ImplicitConversions {
       spent    <- Gen.option(transactionHashGen)
       message  <- Gen.option(bytesGen)
       hint = 0
-      key <- hashGen
+      key <- outputRefKeyGen.map(_.value)
     } yield AssetOutput(hint, key, amount, address, tokens, lockTime, message, spent)
 
   val contractOutputGen: Gen[ContractOutput] =
@@ -83,7 +87,7 @@ object GenApiModel extends ImplicitConversions {
       tokens  <- Gen.option(tokensGen)
       spent   <- Gen.option(transactionHashGen)
       hint = 0
-      key <- hashGen
+      key <- outputRefKeyGen.map(_.value)
     } yield ContractOutput(hint, key, amount, address, tokens, spent)
 
   val outputGen: Gen[Output] =

--- a/app/src/test/scala/org/alephium/explorer/GenDBModel.scala
+++ b/app/src/test/scala/org/alephium/explorer/GenDBModel.scala
@@ -76,7 +76,7 @@ object GenDBModel {
     for {
       hash      <- transactionHashGen
       blockHash <- blockEntryHashGen
-      token     <- hashGen
+      token     <- tokenIdGen
       timestamp <- timestampGen
       txOrder   <- Gen.posNum[Int]
       mainChain <- Arbitrary.arbitrary[Boolean]
@@ -98,7 +98,7 @@ object GenDBModel {
       timestamp <- timestampGen
       txOrder   <- Gen.posNum[Int]
       mainChain <- Arbitrary.arbitrary[Boolean]
-      token     <- hashGen
+      token     <- tokenIdGen
     } yield
       TokenTxPerAddressEntity(
         address   = address,

--- a/app/src/test/scala/org/alephium/explorer/Generators.scala
+++ b/app/src/test/scala/org/alephium/explorer/Generators.scala
@@ -31,6 +31,7 @@ import org.alephium.explorer.api.model._
 import org.alephium.explorer.persistence.model._
 import org.alephium.explorer.service.BlockFlowClient
 import org.alephium.protocol.{model => protocol, _}
+import org.alephium.protocol.model.BlockHash
 import org.alephium.serde._
 import org.alephium.util.{AVector, Duration, TimeStamp, U256}
 
@@ -42,8 +43,7 @@ object Generators {
     Gen.oneOf(0, 1).map(OutputEntity.OutputType.unsafe)
 
   @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
-  def transactionEntityGen(
-      blockHash: Gen[BlockEntry.Hash] = blockEntryHashGen): Gen[TransactionEntity] =
+  def transactionEntityGen(blockHash: Gen[BlockHash] = blockEntryHashGen): Gen[TransactionEntity] =
     for {
       hash              <- transactionHashGen
       blockHash         <- blockHash
@@ -130,7 +130,7 @@ object Generators {
 
   val addressContractProtocolGen: Gen[protocol.Address.Contract] =
     for {
-      contractId <- hashGen
+      contractId <- contractIdGen
     } yield {
       protocol.Address.contract(contractId)
     }
@@ -216,7 +216,7 @@ object Generators {
       gasAmount  <- Gen.posNum[Int]
       gasPrice   <- Gen.posNum[Long].map(U256.unsafe)
     } yield
-      protocolApi.UnsignedTx(hash.value,
+      protocolApi.UnsignedTx(hash,
                              version,
                              networkId,
                              scriptOpt,
@@ -275,12 +275,12 @@ object Generators {
         BigInteger.ONE.shiftLeft(256 - numZerosAtLeastInHash).subtract(BigInteger.ONE))
 
       protocolApi.BlockEntry(
-        hash.value,
+        hash,
         timestamp,
         chainFrom.value,
         chainTo.value,
         height.value,
-        AVector.from(deps.map(_.value)),
+        AVector.from(deps),
         AVector.from(transactions),
         nonce,
         version,
@@ -294,7 +294,7 @@ object Generators {
       implicit groupSettings: GroupSetting): Gen[BlockEntity] =
     blockEntryProtocolGen.map { entry =>
       val deps = parent
-        .map(p => entry.deps.replace(parentIndex(chainTo), p.hash.value))
+        .map(p => entry.deps.replace(parentIndex(chainTo), p.hash))
         .getOrElse(AVector.empty)
       val height    = Height.unsafe(parent.map(_.height.value + 1).getOrElse(0))
       val timestamp = parent.map(_.timestamp.plusHoursUnsafe(1)).getOrElse(ALPH.GenesisTimestamp)
@@ -535,8 +535,8 @@ object Generators {
 
   /** Generates a [[BlockEntity]] with optional parent */
   @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
-  def updatedTransactionEntityGen(blockHash: Gen[BlockEntry.Hash] = blockEntryHashGen)
-    : Gen[(TransactionEntity, TransactionEntity)] =
+  def updatedTransactionEntityGen(
+      blockHash: Gen[BlockHash] = blockEntryHashGen): Gen[(TransactionEntity, TransactionEntity)] =
     for {
       transaction1 <- transactionEntityGen(blockHash)
       transaction2 <- transactionEntityGen(blockHash)

--- a/app/src/test/scala/org/alephium/explorer/HttpJsonSupport.scala
+++ b/app/src/test/scala/org/alephium/explorer/HttpJsonSupport.scala
@@ -1,0 +1,56 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer
+
+import scala.collection.immutable.Seq
+
+import akka.http.scaladsl.marshalling.{Marshaller, ToEntityMarshaller}
+import akka.http.scaladsl.model.{ContentTypeRange, MediaType}
+import akka.http.scaladsl.model.MediaTypes.`application/json`
+import akka.http.scaladsl.unmarshalling.{FromEntityUnmarshaller, Unmarshaller}
+import akka.util.ByteString
+
+import org.alephium.json.Json
+import org.alephium.json.Json._
+
+//Inspired by
+//https://github.com/hseeberger/akka-http-json/blob/v1.39.2/akka-http-upickle/src/main/scala/de/heikoseeberger/akkahttpupickle/UpickleCustomizationSupport.scala
+trait HttpJsonSupport {
+  type Api = Json.type
+
+  def api: Api = Json
+
+  private val mediaTypes: Seq[MediaType.WithFixedCharset] =
+    List(`application/json`)
+
+  private val stringUnmarshaller =
+    Unmarshaller.byteStringUnmarshaller
+      .forContentTypes(mediaTypes.map(ContentTypeRange.apply): _*)
+      .mapWithCharset {
+        case (ByteString.empty, _) => throw Unmarshaller.NoContentException
+        case (data, charset)       => data.decodeString(charset.nioCharset.name)
+      }
+
+  private val stringMarshaller =
+    Marshaller.oneOf(mediaTypes: _*)(Marshaller.stringMarshaller)
+
+  implicit def unmarshaller[A: Reader]: FromEntityUnmarshaller[A] =
+    stringUnmarshaller.map(read[A](_))
+
+  implicit def marshaller[A: Writer]: ToEntityMarshaller[A] =
+    stringMarshaller.compose(write(_))
+}

--- a/app/src/test/scala/org/alephium/explorer/api/model/ApiModelSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/api/model/ApiModelSpec.scala
@@ -20,6 +20,7 @@ import org.alephium.api.UtilJson._
 import org.alephium.explorer.AlephiumSpec
 import org.alephium.explorer.GenApiModel._
 import org.alephium.explorer.Generators._
+import org.alephium.explorer.api.Json._
 import org.alephium.json.Json._
 
 class ApiModelSpec() extends AlephiumSpec {
@@ -39,7 +40,7 @@ class ApiModelSpec() extends AlephiumSpec {
       val expected = s"""
        |{
        |  "hash": "${tx.hash.value.toHexString}",
-       |  "blockHash": "${tx.blockHash}",
+       |  "blockHash": "${tx.blockHash.value.toHexString}",
        |  "timestamp": ${tx.timestamp.millis},
        |  "inputs": [],
        |  "outputs": [],
@@ -56,7 +57,7 @@ class ApiModelSpec() extends AlephiumSpec {
        |{
        |  "type": "Confirmed",
        |  "hash": "${tx.hash.value.toHexString}",
-       |  "blockHash": "${tx.blockHash}",
+       |  "blockHash": "${tx.blockHash.value.toHexString}",
        |  "timestamp": ${tx.timestamp.millis},
        |  "inputs": [],
        |  "outputs": [],

--- a/app/src/test/scala/org/alephium/explorer/persistence/dao/BlockDaoSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/dao/BlockDaoSpec.scala
@@ -31,7 +31,7 @@ import org.alephium.explorer.{AlephiumSpec, GroupSetting}
 import org.alephium.explorer.GenApiModel._
 import org.alephium.explorer.GenDBModel._
 import org.alephium.explorer.Generators._
-import org.alephium.explorer.api.model.{BlockEntry, GroupIndex, Pagination}
+import org.alephium.explorer.api.model.{GroupIndex, Pagination}
 import org.alephium.explorer.cache.BlockCache
 import org.alephium.explorer.persistence.{DatabaseFixtureForEach, DBRunner}
 import org.alephium.explorer.persistence.model._
@@ -41,9 +41,13 @@ import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.explorer.service.BlockFlowClient
 import org.alephium.explorer.util.TestUtils._
 import org.alephium.json.Json._
-import org.alephium.protocol.model.ChainIndex
+import org.alephium.protocol.model.{BlockHash, ChainIndex}
 import org.alephium.util.{Duration, TimeStamp}
 
+@SuppressWarnings(
+  Array("org.wartremover.warts.JavaSerializable",
+        "org.wartremover.warts.Product",
+        "org.wartremover.warts.Serializable")) // Wartremover is complaining, don't now why :/
 class BlockDaoSpec
     extends AlephiumSpec
     with DatabaseFixtureForEach
@@ -84,7 +88,7 @@ class BlockDaoSpec
 
       val blockheadersQuery =
         BlockHeaderSchema.table.filter(_.hash === block.hash).map(_.hash).result
-      val headerHash: Seq[BlockEntry.Hash] = run(blockheadersQuery).futureValue
+      val headerHash: Seq[BlockHash] = run(blockheadersQuery).futureValue
       headerHash.size is 1
       headerHash.foreach(_.is(block.hash))
       block.transactions.nonEmpty is true

--- a/app/src/test/scala/org/alephium/explorer/persistence/dao/UnconfirmedTxDaoSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/dao/UnconfirmedTxDaoSpec.scala
@@ -27,10 +27,10 @@ import slick.jdbc.PostgresProfile.api._
 import org.alephium.explorer.AlephiumSpec
 import org.alephium.explorer.GenApiModel.{assetOutputGen, utransactionGen}
 import org.alephium.explorer.GenCoreUtil.timestampGen
-import org.alephium.explorer.api.model.Transaction
 import org.alephium.explorer.persistence.{DatabaseFixtureForEach, DBRunner}
 import org.alephium.explorer.persistence.schema._
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
+import org.alephium.protocol.model.TransactionId
 
 class UnconfirmedTxDaoSpec
     extends AlephiumSpec
@@ -99,7 +99,7 @@ class UnconfirmedTxDaoSpec
   }
 
   "listHashes" in {
-    var hashes = Set.empty[Transaction.Hash]
+    var hashes = Set.empty[TransactionId]
     forAll(Gen.listOfN(5, utransactionGen)) { txs =>
       UnconfirmedTxDao.insertMany(txs).futureValue
       hashes = hashes ++ txs.map(_.hash)

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/TokenQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/TokenQueriesSpec.scala
@@ -42,7 +42,7 @@ class TokenQueriesSpec
 
   "Token Queries" should {
     "list token transactions" in {
-      forAll(Gen.listOfN(30, transactionPerTokenEntityGen()), hashGen) {
+      forAll(Gen.listOfN(30, transactionPerTokenEntityGen()), tokenIdGen) {
         case (txPerTokens, token) =>
           run(TransactionPerTokenSchema.table.delete).futureValue
           run(TransactionPerTokenSchema.table ++= txPerTokens.map(_.copy(token = token))).futureValue
@@ -59,7 +59,7 @@ class TokenQueriesSpec
     }
 
     "get token tx hashes by address query" in {
-      forAll(Gen.listOfN(30, tokenTxPerAddressEntityGen()), addressGen, hashGen) {
+      forAll(Gen.listOfN(30, tokenTxPerAddressEntityGen()), addressGen, tokenIdGen) {
         case (txPerAddressTokens, address, token) =>
           run(TokenPerAddressSchema.table.delete).futureValue
           run(

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/TransactionQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/TransactionQueriesSpec.scala
@@ -41,6 +41,7 @@ import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.explorer.service.FinalizerService
 import org.alephium.explorer.util.SlickExplainUtil._
 import org.alephium.protocol.ALPH
+import org.alephium.protocol.model.TransactionId
 import org.alephium.util.{Duration, TimeStamp, U256}
 
 class TransactionQueriesSpec
@@ -277,7 +278,7 @@ class TransactionQueriesSpec
     val to   = timestampMaxValue
     FinalizerService.finalizeOutputsWith(from, to, to.deltaUnsafe(from)).futureValue
 
-    def tx(output: OutputEntity, spent: Option[Transaction.Hash], inputs: ArraySeq[Input]) = {
+    def tx(output: OutputEntity, spent: Option[TransactionId], inputs: ArraySeq[Input]) = {
       Transaction(
         output.txHash,
         output.blockHash,

--- a/app/src/test/scala/org/alephium/explorer/service/BlockFlowSyncServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/BlockFlowSyncServiceSpec.scala
@@ -25,7 +25,7 @@ import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.time.{Seconds, Span}
 
 import org.alephium.api.model.{ChainInfo, ChainParams, HashesAtHeight, SelfClique}
-import org.alephium.explorer.{AlephiumSpec, BlockHash, GroupSetting}
+import org.alephium.explorer.{AlephiumSpec, GroupSetting}
 import org.alephium.explorer.GenApiModel.chainIndexes
 import org.alephium.explorer.GenCoreUtil.timestampMaxValue
 import org.alephium.explorer.Generators._
@@ -36,7 +36,7 @@ import org.alephium.explorer.persistence.dao.BlockDao
 import org.alephium.explorer.persistence.model._
 import org.alephium.explorer.util.Scheduler
 import org.alephium.explorer.util.TestUtils._
-import org.alephium.protocol.model.{ChainIndex, CliqueId, NetworkId}
+import org.alephium.protocol.model.{BlockHash, ChainIndex, CliqueId, NetworkId}
 import org.alephium.util.{AVector, Duration, Hex, Service, TimeStamp}
 
 @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.DefaultArguments"))
@@ -140,7 +140,7 @@ class BlockFlowSyncServiceSpec
     //                                           +---+     +---+   +---+
     //    0       1        2       3       4       5         6       7      8
 
-    def h(str: String) = new BlockEntry.Hash(BlockHash.unsafe(Hex.unsafe(str)))
+    def h(str: String) = BlockHash.unsafe(Hex.unsafe(str))
 
     val block0 = blockEntity(None)
       .copy(timestamp = TimeStamp.now())
@@ -213,7 +213,7 @@ class BlockFlowSyncServiceSpec
       def stopSelfOnce(): Future[Unit]                = Future.unit
       def subServices: ArraySeq[Service]              = ArraySeq.empty
 
-      def fetchBlock(from: GroupIndex, hash: BlockEntry.Hash): Future[BlockEntity] =
+      def fetchBlock(from: GroupIndex, hash: BlockHash): Future[BlockEntity] =
         Future.successful(blockEntities.find(_.hash === hash).get)
 
       def fetchBlocks(fromTs: TimeStamp,
@@ -243,7 +243,7 @@ class BlockFlowSyncServiceSpec
               blocks
                 .filter(block =>
                   block.chainFrom === from && block.chainTo === to && block.height === height)
-                .map(_.hash.value))))
+                .map(_.hash))))
 
       def fetchSelfClique(): Future[SelfClique] =
         Future.successful(
@@ -275,7 +275,7 @@ class BlockFlowSyncServiceSpec
       result.toSet is blocksToCheck.map(_.hash).toSet
     }
 
-    def checkMainChain(mainChain: ArraySeq[BlockEntry.Hash]) = {
+    def checkMainChain(mainChain: ArraySeq[BlockHash]) = {
       val result = BlockDao
         .listMainChain(Pagination.unsafe(0, blocks.size))
         .futureValue

--- a/app/src/test/scala/org/alephium/explorer/service/MempoolSyncServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/MempoolSyncServiceSpec.scala
@@ -28,12 +28,13 @@ import org.scalatest.time.{Minutes, Span}
 import org.alephium.api.model.{ChainInfo, ChainParams, HashesAtHeight, SelfClique}
 import org.alephium.explorer.AlephiumSpec
 import org.alephium.explorer.GenApiModel.utransactionGen
-import org.alephium.explorer.api.model.{BlockEntry, GroupIndex, Height, UnconfirmedTransaction}
+import org.alephium.explorer.api.model.{GroupIndex, Height, UnconfirmedTransaction}
 import org.alephium.explorer.persistence.DatabaseFixtureForEach
 import org.alephium.explorer.persistence.dao.UnconfirmedTxDao
 import org.alephium.explorer.persistence.model._
 import org.alephium.explorer.util.Scheduler
 import org.alephium.explorer.util.TestUtils._
+import org.alephium.protocol.model.BlockHash
 import org.alephium.util.{Service, TimeStamp}
 
 class MempoolSyncServiceSpec
@@ -86,7 +87,7 @@ class MempoolSyncServiceSpec
       def subServices: ArraySeq[Service]              = ArraySeq.empty
       def fetchUnconfirmedTransactions(uri: Uri): Future[ArraySeq[UnconfirmedTransaction]] =
         Future.successful(unconfirmedTransactions)
-      def fetchBlock(from: GroupIndex, hash: BlockEntry.Hash): Future[BlockEntity] =
+      def fetchBlock(from: GroupIndex, hash: BlockHash): Future[BlockEntity] =
         ???
       def fetchBlocks(fromTs: TimeStamp,
                       toTs: TimeStamp,

--- a/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
@@ -25,7 +25,7 @@ import org.scalacheck.Gen
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.time.{Minutes, Span}
 
-import org.alephium.explorer.{AlephiumSpec, BlockHash, GroupSetting}
+import org.alephium.explorer.{AlephiumSpec, GroupSetting}
 import org.alephium.explorer.GenApiModel._
 import org.alephium.explorer.Generators._
 import org.alephium.explorer.api.model._
@@ -35,6 +35,7 @@ import org.alephium.explorer.persistence.dao.{BlockDao, UnconfirmedTxDao}
 import org.alephium.explorer.persistence.model._
 import org.alephium.explorer.persistence.queries.InputUpdateQueries
 import org.alephium.protocol.ALPH
+import org.alephium.protocol.model.BlockHash
 import org.alephium.util.{TimeStamp, U256}
 
 @SuppressWarnings(
@@ -212,7 +213,7 @@ class TransactionServiceSpec
       transactions = ArraySeq(tx1),
       inputs       = ArraySeq(input1),
       outputs      = ArraySeq(output1),
-      deps         = ArraySeq.fill(2 * groupSetting.groupNum - 1)(new BlockEntry.Hash(BlockHash.generate))
+      deps         = ArraySeq.fill(2 * groupSetting.groupNum - 1)(BlockHash.generate)
     )
 
     val blocks = ArraySeq(block0, block1)

--- a/app/src/test/scala/org/alephium/explorer/util/TimeUtilSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/util/TimeUtilSpec.scala
@@ -71,7 +71,7 @@ class TimeUtilSpec extends AlephiumSpec with Matchers {
         ArraySeq(r(0, 2), r(3, 5))
 
       buildTimestampRange(t(0), t(6), s(2)) is
-        ArraySeq(r(0, 2), r(3, 5), r(6, 6))
+        ArraySeq(r(0, 2), r(3, 5), r(6, 7))
 
       buildTimestampRange(t(0), t(7), s(2)) is
         ArraySeq(r(0, 2), r(3, 5), r(6, 7))

--- a/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
@@ -21,20 +21,18 @@ import scala.concurrent.{ExecutionContext, Future}
 
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCodes}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import de.heikoseeberger.akkahttpupickle.UpickleCustomizationSupport
 import org.scalacheck.Gen
 import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
 
 import org.alephium.api.ApiError
-import org.alephium.explorer.{AlephiumSpec, GroupSetting, Hash}
+import org.alephium.explorer.{AlephiumSpec, GroupSetting, Hash, HttpJsonSupport}
 import org.alephium.explorer.GenApiModel._
 import org.alephium.explorer.Generators._
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.cache.TransactionCache
 import org.alephium.explorer.persistence.DatabaseFixtureForEach
 import org.alephium.explorer.service.TransactionService
-import org.alephium.json.Json
 import org.alephium.protocol.model.{TokenId, TransactionId}
 import org.alephium.util.U256
 
@@ -44,10 +42,7 @@ class AddressServerSpec()
     with AkkaDecodeFailureHandler
     with DatabaseFixtureForEach
     with ScalatestRouteTest
-    with UpickleCustomizationSupport {
-  override type Api = Json.type
-
-  override def api: Api = Json
+    with HttpJsonSupport {
 
   "validate and forward `txLimit` query param " in new Fixture {
     var testLimit = 0

--- a/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
@@ -168,7 +168,7 @@ class AddressServerSpec()
 
       override def getOutputRefTransaction(key: Hash)(
           implicit ec: ExecutionContext,
-          dc: DatabaseConfig[PostgresProfile]): Future[Option[ConfirmedTransaction]] =
+          dc: DatabaseConfig[PostgresProfile]): Future[Option[Transaction]] =
         Future.successful(None)
 
       override def getTransactionsNumberByAddress(address: Address)(

--- a/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
@@ -35,6 +35,7 @@ import org.alephium.explorer.cache.TransactionCache
 import org.alephium.explorer.persistence.DatabaseFixtureForEach
 import org.alephium.explorer.service.TransactionService
 import org.alephium.json.Json
+import org.alephium.protocol.model.{TokenId, TransactionId}
 import org.alephium.util.U256
 
 @SuppressWarnings(Array("org.wartremover.warts.Var"))
@@ -160,7 +161,7 @@ class AddressServerSpec()
     val unconfirmedTx = utransactionGen.sample.get
 
     trait EmptyTransactionService extends TransactionService {
-      override def getTransaction(transactionHash: Transaction.Hash)(
+      override def getTransaction(transactionHash: TransactionId)(
           implicit ec: ExecutionContext,
           dc: DatabaseConfig[PostgresProfile]): Future[Option[TransactionLike]] =
         Future.successful(None)
@@ -202,24 +203,24 @@ class AddressServerSpec()
       def listUnconfirmedTransactions(pagination: Pagination)(
           implicit ec: ExecutionContext,
           dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[UnconfirmedTransaction]] = ???
-      def getTokenBalance(address: Address, token: Hash)(
+      def getTokenBalance(address: Address, token: TokenId)(
           implicit ec: ExecutionContext,
           dc: DatabaseConfig[PostgresProfile]): Future[(U256, U256)] = ???
-      def listAddressTokenTransactions(address: Address, token: Hash, pagination: Pagination)(
+      def listAddressTokenTransactions(address: Address, token: TokenId, pagination: Pagination)(
           implicit ec: ExecutionContext,
           dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]] = ???
       def listAddressTokens(address: Address)(
           implicit ec: ExecutionContext,
-          dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Hash]] = ???
-      def listTokenAddresses(token: Hash, pagination: Pagination)(
+          dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[TokenId]] = ???
+      def listTokenAddresses(token: TokenId, pagination: Pagination)(
           implicit ec: ExecutionContext,
           dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Address]] = ???
-      def listTokenTransactions(token: Hash, pagination: Pagination)(
+      def listTokenTransactions(token: TokenId, pagination: Pagination)(
           implicit ec: ExecutionContext,
           dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]] = ???
       def listTokens(pagination: Pagination)(
           implicit ec: ExecutionContext,
-          dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Hash]] = ???
+          dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[TokenId]] = ???
       def areAddressesActive(addresses: ArraySeq[Address])(
           implicit ec: ExecutionContext,
           dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Boolean]] = {

--- a/app/src/test/scala/org/alephium/explorer/web/ChartsServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/ChartsServerSpec.scala
@@ -17,11 +17,10 @@
 package org.alephium.explorer.web
 
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import de.heikoseeberger.akkahttpupickle.UpickleCustomizationSupport
 import org.scalatest.concurrent.ScalaFutures
 
 import org.alephium.api.ApiError
-import org.alephium.explorer.AlephiumSpec
+import org.alephium.explorer.{AlephiumSpec, HttpJsonSupport}
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.persistence.DatabaseFixtureForEach
 import org.alephium.json.Json
@@ -34,7 +33,7 @@ class ChartsServerSpec()
     with DatabaseFixtureForEach
     with ScalaFutures
     with ScalatestRouteTest
-    with UpickleCustomizationSupport {
+    with HttpJsonSupport {
   override type Api = Json.type
 
   override def api: Api = Json

--- a/app/src/test/scala/org/alephium/explorer/web/InfosServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/InfosServerSpec.scala
@@ -33,6 +33,7 @@ import org.alephium.explorer.persistence.{Database, DatabaseFixtureForEach}
 import org.alephium.explorer.service._
 import org.alephium.json.Json
 import org.alephium.protocol.ALPH
+import org.alephium.protocol.model.{BlockHash, TokenId, TransactionId}
 import org.alephium.util.{Duration, TimeStamp, U256}
 
 @SuppressWarnings(Array("org.wartremover.warts.Var"))
@@ -157,12 +158,12 @@ class InfosServerSpec()
     val blockTime   = PerChainDuration(0, 0, 1, 1)
     val blockService = new BlockService {
 
-      def getLiteBlockByHash(hash: BlockEntry.Hash)(
+      def getLiteBlockByHash(hash: BlockHash)(
           implicit ec: ExecutionContext,
           dc: DatabaseConfig[PostgresProfile]): Future[Option[BlockEntryLite]] =
         ???
 
-      def getBlockTransactions(hash: BlockEntry.Hash, pagination: Pagination)(
+      def getBlockTransactions(hash: BlockHash, pagination: Pagination)(
           implicit ec: ExecutionContext,
           dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]] =
         ???
@@ -185,7 +186,7 @@ class InfosServerSpec()
     }
 
     val transactionService = new TransactionService {
-      override def getTransaction(transactionHash: Transaction.Hash)(
+      override def getTransaction(transactionHash: TransactionId)(
           implicit ec: ExecutionContext,
           dc: DatabaseConfig[PostgresProfile]): Future[Option[TransactionLike]] =
         Future.successful(None)
@@ -225,24 +226,24 @@ class InfosServerSpec()
       def listUnconfirmedTransactions(pagination: Pagination)(
           implicit ec: ExecutionContext,
           dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[UnconfirmedTransaction]] = ???
-      def getTokenBalance(address: Address, token: Hash)(
+      def getTokenBalance(address: Address, token: TokenId)(
           implicit ec: ExecutionContext,
           dc: DatabaseConfig[PostgresProfile]): Future[(U256, U256)] = ???
-      def listAddressTokenTransactions(address: Address, token: Hash, pagination: Pagination)(
+      def listAddressTokenTransactions(address: Address, token: TokenId, pagination: Pagination)(
           implicit ec: ExecutionContext,
           dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]] = ???
       def listAddressTokens(address: Address)(
           implicit ec: ExecutionContext,
-          dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Hash]] = ???
-      def listTokenAddresses(token: Hash, pagination: Pagination)(
+          dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[TokenId]] = ???
+      def listTokenAddresses(token: TokenId, pagination: Pagination)(
           implicit ec: ExecutionContext,
           dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Address]] = ???
-      def listTokenTransactions(token: Hash, pagination: Pagination)(
+      def listTokenTransactions(token: TokenId, pagination: Pagination)(
           implicit ec: ExecutionContext,
           dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]] = ???
       def listTokens(pagination: Pagination)(
           implicit ec: ExecutionContext,
-          dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Hash]] = ???
+          dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[TokenId]] = ???
       def areAddressesActive(addresses: ArraySeq[Address])(
           implicit ec: ExecutionContext,
           dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Boolean]] =

--- a/app/src/test/scala/org/alephium/explorer/web/InfosServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/InfosServerSpec.scala
@@ -193,7 +193,7 @@ class InfosServerSpec()
 
       override def getOutputRefTransaction(key: Hash)(
           implicit ec: ExecutionContext,
-          dc: DatabaseConfig[PostgresProfile]): Future[Option[ConfirmedTransaction]] =
+          dc: DatabaseConfig[PostgresProfile]): Future[Option[Transaction]] =
         Future.successful(None)
 
       override def getTransactionsNumberByAddress(address: Address)(

--- a/app/src/test/scala/org/alephium/explorer/web/InfosServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/InfosServerSpec.scala
@@ -20,12 +20,11 @@ import scala.collection.immutable.ArraySeq
 import scala.concurrent.{ExecutionContext, Future}
 
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import de.heikoseeberger.akkahttpupickle.UpickleCustomizationSupport
 import org.scalatest.concurrent.ScalaFutures
 import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
 
-import org.alephium.explorer.{AlephiumSpec, BuildInfo, GroupSetting, Hash}
+import org.alephium.explorer.{AlephiumSpec, BuildInfo, GroupSetting, Hash, HttpJsonSupport}
 import org.alephium.explorer.Generators._
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.cache.{BlockCache, TransactionCache}
@@ -43,7 +42,7 @@ class InfosServerSpec()
     with DatabaseFixtureForEach
     with ScalaFutures
     with ScalatestRouteTest
-    with UpickleCustomizationSupport {
+    with HttpJsonSupport {
   override type Api = Json.type
 
   override def api: Api = Json

--- a/app/src/test/scala/org/alephium/explorer/web/UnconfirmedTransactionServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/UnconfirmedTransactionServerSpec.scala
@@ -19,12 +19,11 @@ package org.alephium.explorer.web
 import scala.concurrent.duration._
 
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
-import de.heikoseeberger.akkahttpupickle.UpickleCustomizationSupport
 import org.scalacheck.Gen
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.time.{Minutes, Span}
 
-import org.alephium.explorer.AlephiumSpec
+import org.alephium.explorer.{AlephiumSpec, HttpJsonSupport}
 import org.alephium.explorer.GenApiModel._
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.persistence.DatabaseFixtureForEach
@@ -39,7 +38,7 @@ class UnconfirmedTransactionServerSpec()
     with ScalatestRouteTest
     with ScalaFutures
     with Eventually
-    with UpickleCustomizationSupport {
+    with HttpJsonSupport {
   override type Api = Json.type
 
   override def api: Api = Json

--- a/app/src/test/scala/org/alephium/explorer/web/UtilsServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/UtilsServerSpec.scala
@@ -18,12 +18,11 @@ package org.alephium.explorer.web
 
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity, StatusCodes}
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import de.heikoseeberger.akkahttpupickle.UpickleCustomizationSupport
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.ScalaFutures
 
 import org.alephium.api.ApiError
-import org.alephium.explorer.{AlephiumSpec, Generators, GroupSetting}
+import org.alephium.explorer.{AlephiumSpec, Generators, GroupSetting, HttpJsonSupport}
 import org.alephium.explorer.api.model.LogbackValue
 import org.alephium.explorer.cache.{BlockCache, TransactionCache}
 import org.alephium.explorer.persistence.{Database, DatabaseFixtureForEach}
@@ -37,7 +36,7 @@ class UtilsServerSpec()
     with DatabaseFixtureForEach
     with ScalaFutures
     with ScalatestRouteTest
-    with UpickleCustomizationSupport
+    with HttpJsonSupport
     with MockFactory {
   override type Api = Json.type
 

--- a/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/DataGenerator.scala
+++ b/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/DataGenerator.scala
@@ -23,9 +23,10 @@ import scala.util.Random
 
 import akka.util.ByteString
 
-import org.alephium.explorer.{BlockHash, GenApiModel, Hash}
+import org.alephium.explorer.{GenApiModel, Hash}
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.persistence.model._
+import org.alephium.protocol.model.{BlockHash, TransactionId}
 import org.alephium.util.{Base58, TimeStamp, U256}
 
 /**
@@ -40,13 +41,13 @@ object DataGenerator {
 
   val timestampMaxValue: TimeStamp = TimeStamp.unsafe(253370764800000L) //Jan 01 9999 00:00:00
 
-  def genTransactions(count: Int                 = 10,
-                      blockHash: BlockEntry.Hash = new BlockEntry.Hash(BlockHash.generate),
-                      blockTimestamp: TimeStamp  = TimeStamp.now(),
-                      mainChain: Boolean         = Random.nextBoolean()): ArraySeq[TransactionEntity] =
+  def genTransactions(count: Int                = 10,
+                      blockHash: BlockHash      = BlockHash.generate,
+                      blockTimestamp: TimeStamp = TimeStamp.now(),
+                      mainChain: Boolean        = Random.nextBoolean()): ArraySeq[TransactionEntity] =
     ArraySeq.fill(count) {
       TransactionEntity(
-        hash              = new Transaction.Hash(Hash.generate),
+        hash              = TransactionId.generate,
         blockHash         = blockHash,
         timestamp         = blockTimestamp,
         chainFrom         = GroupIndex.unsafe(1),
@@ -102,10 +103,10 @@ object DataGenerator {
         )
     }
 
-  def genBlockEntity(transactionsCount: Int     = 10,
-                     blockHash: BlockEntry.Hash = new BlockEntry.Hash(BlockHash.generate),
-                     timestamp: TimeStamp       = TimeStamp.now(),
-                     mainChain: Boolean         = Random.nextBoolean()): BlockEntity = {
+  def genBlockEntity(transactionsCount: Int = 10,
+                     blockHash: BlockHash   = BlockHash.generate,
+                     timestamp: TimeStamp   = TimeStamp.now(),
+                     mainChain: Boolean     = Random.nextBoolean()): BlockEntity = {
     val transactions =
       genTransactions(
         count          = transactionsCount,
@@ -126,7 +127,7 @@ object DataGenerator {
       chainFrom    = GroupIndex.unsafe(0),
       chainTo      = GroupIndex.unsafe(3),
       height       = Height.genesis,
-      deps         = ArraySeq.fill(5)(new BlockEntry.Hash(BlockHash.generate)),
+      deps         = ArraySeq.fill(5)(BlockHash.generate),
       transactions = transactions,
       inputs       = inputs,
       outputs      = outputs,
@@ -146,8 +147,8 @@ object DataGenerator {
   def genTransactionPerAddressEntity(address: Address = genAddress()): TransactionPerAddressEntity =
     TransactionPerAddressEntity(
       address   = address,
-      hash      = new Transaction.Hash(Hash.generate),
-      blockHash = new BlockEntry.Hash(BlockHash.generate),
+      hash      = TransactionId.generate,
+      blockHash = BlockHash.generate,
       timestamp = TimeStamp.now(),
       txOrder   = Random.nextInt(100),
       mainChain = Random.nextBoolean()

--- a/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/BlockHeaderMainChainReadState.scala
+++ b/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/BlockHeaderMainChainReadState.scala
@@ -24,12 +24,12 @@ import akka.util.ByteString
 import org.openjdk.jmh.annotations.{Scope, State}
 
 import org.alephium.crypto.Blake2b
-import org.alephium.explorer.BlockHash
-import org.alephium.explorer.api.model.{BlockEntry, GroupIndex, Height}
+import org.alephium.explorer.api.model.{GroupIndex, Height}
 import org.alephium.explorer.benchmark.db.{DBConnectionPool, DBExecutor}
 import org.alephium.explorer.benchmark.db.BenchmarkSettings._
 import org.alephium.explorer.persistence.model.BlockHeader
 import org.alephium.explorer.persistence.schema.BlockHeaderSchema
+import org.alephium.protocol.model.BlockHash
 import org.alephium.util.TimeStamp
 
 /**
@@ -45,7 +45,7 @@ class BlockHeaderMainChainReadState(dropMainChainIndex: Boolean,
 
   def generateData(currentCacheSize: Int): BlockHeader =
     BlockHeader(
-      hash         = new BlockEntry.Hash(BlockHash.generate),
+      hash         = BlockHash.generate,
       timestamp    = TimeStamp.now(),
       chainFrom    = GroupIndex.unsafe(1),
       chainTo      = GroupIndex.unsafe(16),
@@ -58,7 +58,7 @@ class BlockHeaderMainChainReadState(dropMainChainIndex: Boolean,
       txsCount     = Random.nextInt(),
       target       = ByteString.emptyByteString,
       hashrate     = BigInteger.ONE,
-      parent       = Some(new BlockEntry.Hash(BlockHash.generate))
+      parent       = Some(BlockHash.generate)
     )
 
   def persist(data: Array[BlockHeader]): Unit = {

--- a/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/ListBlocksReadState.scala
+++ b/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/ListBlocksReadState.scala
@@ -24,7 +24,7 @@ import akka.util.ByteString
 import org.openjdk.jmh.annotations.{Scope, State}
 
 import org.alephium.crypto.Blake2b
-import org.alephium.explorer.{BlockHash, GroupSetting, Hash}
+import org.alephium.explorer.GroupSetting
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.benchmark.db.{DBConnectionPool, DBExecutor}
 import org.alephium.explorer.benchmark.db.BenchmarkSettings._
@@ -32,6 +32,7 @@ import org.alephium.explorer.benchmark.db.state.ListBlocksReadStateSettings._
 import org.alephium.explorer.cache.BlockCache
 import org.alephium.explorer.persistence.model.{BlockHeader, TransactionEntity}
 import org.alephium.explorer.persistence.schema.{BlockHeaderSchema, TransactionSchema}
+import org.alephium.protocol.model.{BlockHash, TransactionId}
 import org.alephium.util.{TimeStamp, U256}
 
 /**
@@ -66,7 +67,7 @@ class ListBlocksReadState(reverse: Boolean,
 
   private def generateBlockHeader(): BlockHeader =
     BlockHeader(
-      hash         = new BlockEntry.Hash(BlockHash.generate),
+      hash         = BlockHash.generate,
       timestamp    = TimeStamp.now(),
       chainFrom    = GroupIndex.unsafe(0),
       chainTo      = GroupIndex.unsafe(3),
@@ -79,13 +80,13 @@ class ListBlocksReadState(reverse: Boolean,
       txsCount     = scala.math.abs(Random.nextInt()),
       target       = ByteString.emptyByteString,
       hashrate     = BigInteger.ONE,
-      parent       = Some(new BlockEntry.Hash(BlockHash.generate))
+      parent       = Some(BlockHash.generate)
     )
 
   private def generateTransactions(header: BlockHeader): Seq[TransactionEntity] =
     List.fill(transactionsPerBlock) {
       TransactionEntity(
-        hash              = new Transaction.Hash(Hash.generate),
+        hash              = TransactionId.generate,
         blockHash         = header.hash,
         timestamp         = header.timestamp,
         chainFrom         = GroupIndex.unsafe(1),

--- a/build.sbt
+++ b/build.sbt
@@ -173,7 +173,6 @@ lazy val app = mainProject("app")
     tapirSwaggerUi,
     tapirClient,
     sttpAkkaBackend,
-    akkaHttpJson,
     upickle,
     akkaHttpCors,
     caffeine,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -53,8 +53,7 @@ object Dependencies {
   lazy val tapirClient       = "com.softwaremill.sttp.tapir"   %% "tapir-sttp-client"      % Version.tapir
   lazy val sttpAkkaBackend   = "com.softwaremill.sttp.client3" %% "akka-http-backend"      % Version.sttp
 
-  lazy val akkaHttpJson = "de.heikoseeberger" %% "akka-http-upickle" % "1.39.2"
-  lazy val `upickle`    = "com.lihaoyi"       %% "upickle"           % "2.0.0"
+  lazy val `upickle` = "com.lihaoyi" %% "upickle" % "1.6.0"
 
   lazy val caffeine = "com.github.ben-manes.caffeine" % "caffeine" % "3.0.5"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,10 +17,10 @@
 import sbt._
 
 object Version {
-  lazy val common = "1.4.6"
+  lazy val common = "1.5.0-rc8"
 
-  lazy val akka       = "2.6.19"
-  lazy val tapir      = "1.0.0"
+  lazy val akka       = "2.6.20"
+  lazy val tapir      = "1.0.6"
   lazy val slick      = "3.3.2"
   lazy val postgresql = "42.2.12"
   lazy val sttp       = "3.5.2"
@@ -39,7 +39,7 @@ object Dependencies {
   lazy val alephiumConf     = "org.alephium" %% "alephium-conf"     % Version.common
 
   lazy val akkaTest       = "com.typesafe.akka" %% "akka-testkit"        % Version.akka % Test
-  lazy val akkaHttptest   = "com.typesafe.akka" %% "akka-http-testkit"   % "10.2.9" % Test
+  lazy val akkaHttptest   = "com.typesafe.akka" %% "akka-http-testkit"   % "10.2.10" % Test
   lazy val akkaStream     = "com.typesafe.akka" %% "akka-stream-typed"   % Version.akka
   lazy val akkaStreamTest = "com.typesafe.akka" %% "akka-stream-testkit" % Version.akka % Test
 
@@ -54,7 +54,7 @@ object Dependencies {
   lazy val sttpAkkaBackend   = "com.softwaremill.sttp.client3" %% "akka-http-backend"      % Version.sttp
 
   lazy val akkaHttpJson = "de.heikoseeberger" %% "akka-http-upickle" % "1.39.2"
-  lazy val `upickle`    = "com.lihaoyi"       %% "upickle"           % "1.3.8"
+  lazy val `upickle`    = "com.lihaoyi"       %% "upickle"           % "2.0.0"
 
   lazy val caffeine = "com.github.ben-manes.caffeine" % "caffeine" % "3.0.5"
 


### PR DESCRIPTION
Creating this as a draft as there is still one thing I need to investigate. For some reason if[ I don't manually add manually "type" field in some case class ](https://github.com/alephium/explorer-backend/blob/738ef7b9aebda4ac44dce357c02e35fed50a8731/app/src/main/scala/org/alephium/explorer/api/model/Output.scala#L40-L51) the `openapi.json` then create two types: `AssetOutput` and `AssetOutput1`. This is because some endpoints use directly `AssetOutput` and some other through the `sealed trait Output`. I need to check tapir and upickle to see what changed.

This all PR is the first step to integrate the smart contract events, I thought I could directly start with them, but the changes are quite involving.
BTW I love all the new types, instead of just using `Hash`.