### PR TITLE
Replaced `BlockDao.get(parent)` with `BlockQueries.getBlockChainInfo(parent)`

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/error/ExplorerError.scala
+++ b/app/src/main/scala/org/alephium/explorer/error/ExplorerError.scala
@@ -20,7 +20,9 @@ import scala.concurrent.duration.FiniteDuration
 
 import sttp.model.Uri
 
-import org.alephium.protocol.model.NetworkId
+import org.alephium.explorer.api.model.GroupIndex
+import org.alephium.explorer.persistence.model.BlockEntity
+import org.alephium.protocol.model.{BlockHash, NetworkId}
 
 /** All Explorer errors */
 sealed trait ExplorerError extends Throwable
@@ -30,6 +32,9 @@ sealed trait ConfigError extends ExplorerError
 
 /** Errors that lead to JVM termination */
 sealed trait FatalSystemExit extends ExplorerError
+
+/** Application runtime errors */
+sealed trait RuntimeError extends Throwable
 
 //scalastyle:off null
 @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
@@ -86,4 +91,32 @@ object ExplorerError {
       extends Exception(s"Invalid syncPeriod: ${syncPeriod.toString}. Sync-period must be > 0.")
       with ConfigError
 
+  object BlocksInDifferentChains {
+
+    @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
+    @inline def apply(parent: BlockHash,
+                      parentChainFrom: GroupIndex,
+                      parentChainTo: GroupIndex,
+                      child: BlockEntity): BlocksInDifferentChains =
+      new BlocksInDifferentChains(
+        parent          = parent,
+        parentChainFrom = parentChainFrom,
+        parentChainTo   = parentChainTo,
+        child           = child.hash,
+        childChainFrom  = child.chainFrom,
+        childChainTo    = child.chainTo
+      )
+  }
+
+  /******** Group: [[RuntimeError]] ********/
+  final case class BlocksInDifferentChains(parent: BlockHash,
+                                           parentChainFrom: GroupIndex,
+                                           parentChainTo: GroupIndex,
+                                           child: BlockHash,
+                                           childChainFrom: GroupIndex,
+                                           childChainTo: GroupIndex)
+      extends Exception(
+        s"Parent ($parent) and child ($child) blocks belongs to different chains. " +
+          s"ParentChain: ($parentChainFrom, $parentChainTo). ChildChain: ($childChainFrom, $childChainTo)")
+      with RuntimeError
 }

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
@@ -74,6 +74,16 @@ object BlockQueries extends StrictLogging {
       header <- BlockHeaderSchema.table.filter(_.hash === hash).result.headOption
     } yield header.map(_.toLiteApi)
 
+  /** For a given `BlockHash` returns its basic chain information */
+  def getBlockChainInfo(hash: BlockHash): DBActionR[Option[(GroupIndex, GroupIndex, Boolean)]] =
+    BlockHeaderSchema.table
+      .filter(_.hash === hash)
+      .map { block =>
+        (block.chainFrom, block.chainTo, block.mainChain)
+      }
+      .result
+      .headOption
+
   def getBlockEntryAction(hash: BlockHash)(
       implicit ec: ExecutionContext): DBActionR[Option[BlockEntry]] =
     for {

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
@@ -76,12 +76,14 @@ object BlockQueries extends StrictLogging {
 
   /** For a given `BlockHash` returns its basic chain information */
   def getBlockChainInfo(hash: BlockHash): DBActionR[Option[(GroupIndex, GroupIndex, Boolean)]] =
-    BlockHeaderSchema.table
-      .filter(_.hash === hash)
-      .map { block =>
-        (block.chainFrom, block.chainTo, block.mainChain)
-      }
-      .result
+    sql"""
+       |SELECT chain_from,
+       |       chain_to,
+       |       main_chain
+       |FROM block_headers
+       |WHERE hash = $hash
+       |""".stripMargin
+      .asAS[(GroupIndex, GroupIndex, Boolean)]
       .headOption
 
   def getBlockEntryAction(hash: BlockHash)(

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomGetResult.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomGetResult.scala
@@ -243,4 +243,12 @@ object CustomGetResult {
         reserved    = result.<<,
         locked      = result.<<
     )
+
+  implicit val chainFromToAndMainChain: GetResult[(GroupIndex, GroupIndex, Boolean)] =
+    (result: PositionedResult) => {
+      val chainFrom = groupIndexGetResult(result)
+      val chainTo   = groupIndexGetResult(result)
+      val mainChain = result.nextBoolean()
+      (chainFrom, chainTo, mainChain)
+    }
 }

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockQueriesSpec.scala
@@ -27,7 +27,7 @@ import org.scalatest.time.{Minutes, Span}
 import slick.jdbc.PostgresProfile.api._
 
 import org.alephium.explorer.{AlephiumSpec, GroupSetting}
-import org.alephium.explorer.GenApiModel.{blockEntryHashGen, groupIndexGen, heightGen}
+import org.alephium.explorer.GenApiModel.{blockEntryHashGen, blockHashGen, groupIndexGen, heightGen}
 import org.alephium.explorer.Generators._
 import org.alephium.explorer.api.model.{GroupIndex, Height}
 import org.alephium.explorer.persistence.{DatabaseFixtureForEach, DBRunner}
@@ -351,6 +351,37 @@ class BlockQueriesSpec
 
         actualResult should not contain hashToIgnore //ignored hash is not included
         actualResult should contain theSameElementsAs expectedResult
+      }
+    }
+  }
+
+  "getBlockChainInfo" should {
+    "return none" when {
+      "database is empty" in {
+        val blockHash = blockHashGen.sample.get
+        run(BlockQueries.getBlockChainInfo(blockHash)).futureValue is None
+      }
+    }
+
+    "return chainInfo for existing blocks or else None" in {
+      forAll(Gen.nonEmptyListOf(blockHeaderGen)) { blockHeaders =>
+        val blockToRemove  = Random.shuffle(blockHeaders).head //the block to remove
+        val blocksToInsert = blockHeaders.filter(_ != blockToRemove) //blocks to insert
+
+        //insert only the blocks
+        run(BlockQueries.insertBlockHeaders(blocksToInsert)).futureValue is blocksToInsert.size
+
+        //returns None for non-existing block
+        run(BlockQueries.getBlockChainInfo(blockToRemove.hash)).futureValue is None
+
+        //inserted blocks should return expected chainFrom, chainTo and mainChain information
+        blocksToInsert foreach { block =>
+          val (chainFrom, chainTo, mainChain) =
+            run(BlockQueries.getBlockChainInfo(block.hash)).futureValue.get
+          block.chainFrom is chainFrom
+          block.chainTo is chainTo
+          block.mainChain is mainChain
+        }
       }
     }
   }

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockQueriesSpec.scala
@@ -365,10 +365,10 @@ class BlockQueriesSpec
 
     "return chainInfo for existing blocks or else None" in {
       forAll(Gen.nonEmptyListOf(blockHeaderGen)) { blockHeaders =>
-        val blockToRemove  = Random.shuffle(blockHeaders).head //the block to remove
+        val blockToRemove  = Random.shuffle(blockHeaders).head //block to remove
         val blocksToInsert = blockHeaders.filter(_ != blockToRemove) //blocks to insert
 
-        //insert only the blocks
+        //insert blocks
         run(BlockQueries.insertBlockHeaders(blocksToInsert)).futureValue is blocksToInsert.size
 
         //returns None for non-existing block


### PR DESCRIPTION
- Implements [this comment](https://github.com/alephium/explorer-backend/issues/328#issuecomment-1225295656) to reduce the amount of data read (inputs, outputs, transactions etc) when fetching `parent`.
- Replaced `assert(block.chainFrom == parentBlock.chainFrom && block.chainTo == parentBlock.chainTo)` with error `BlocksInDifferentChains` for better log message incase of error. 

It seems issue #358 is invalid after this because the full block is not being read anymore? Should it be closed?