### PR TITLE
#364: Moved `fetchAndBuildTimeStampRange` to `TimeUtil`

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/error/ExplorerError.scala
+++ b/app/src/main/scala/org/alephium/explorer/error/ExplorerError.scala
@@ -23,6 +23,7 @@ import sttp.model.Uri
 import org.alephium.explorer.api.model.GroupIndex
 import org.alephium.explorer.persistence.model.BlockEntity
 import org.alephium.protocol.model.{BlockHash, NetworkId}
+import org.alephium.util.TimeStamp
 
 /** All Explorer errors */
 sealed trait ExplorerError extends Throwable
@@ -64,6 +65,11 @@ object ExplorerError {
 
   final case class InvalidProtocolInput(error: String)
       extends Exception(s"Cannot decode protocol input: $error")
+      with FatalSystemExit
+
+  final case class RemoteTimeStampIsBeforeLocal(localTs: TimeStamp, remoteTs: TimeStamp)
+      extends Exception(
+        s"Max remote timestamp ($remoteTs) cannot be be before local timestamp ($localTs)")
       with FatalSystemExit
 
   /******** Group: [[ConfigError]] ********/

--- a/app/src/main/scala/org/alephium/explorer/service/BlockFlowSyncService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/BlockFlowSyncService.scala
@@ -185,12 +185,7 @@ case object BlockFlowSyncService extends StrictLogging {
       localTs  <- getLocalMaxTimestamp()
       remoteTs <- getRemoteMaxTimestamp()
     } yield {
-      TimeUtil.buildTimeStampRangeOrEmpty(
-        step     = step,
-        backStep = backStep,
-        localTs  = localTs,
-        remoteTs = remoteTs
-      ) match {
+      TimeUtil.buildTimeStampRangeOrEmpty(step, backStep, localTs, remoteTs) match {
         case Failure(exception) =>
           logger.error("Failed to get TimeStamp range", exception)
           //See issue #246. sys.exit need to be removed for graceful termination.

--- a/app/src/main/scala/org/alephium/explorer/service/BlockFlowSyncService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/BlockFlowSyncService.scala
@@ -21,6 +21,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import scala.collection.immutable.ArraySeq
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.{Duration => ScalaDuration, FiniteDuration}
+import scala.util.{Failure, Success}
 
 import com.typesafe.scalalogging.StrictLogging
 import slick.basic.DatabaseConfig
@@ -183,7 +184,22 @@ case object BlockFlowSyncService extends StrictLogging {
     for {
       localTs  <- getLocalMaxTimestamp()
       remoteTs <- getRemoteMaxTimestamp()
-    } yield fetchAndBuildTimeStampRange(step, backStep, localTs, remoteTs)
+    } yield {
+      TimeUtil.buildTimeStampRangeOrEmpty(
+        step     = step,
+        backStep = backStep,
+        localTs  = localTs,
+        remoteTs = remoteTs
+      ) match {
+        case Failure(exception) =>
+          logger.error("Failed to get TimeStamp range", exception)
+          //See issue #246. sys.exit need to be removed for graceful termination.
+          sys.exit(0)
+
+        case Success(result) =>
+          result
+      }
+    }
 
   /** @see [[org.alephium.explorer.persistence.queries.BlockQueries.numOfBlocksAndMaxBlockTimestamp]] */
   def getLocalMaxTimestamp()(implicit ec: ExecutionContext,
@@ -328,32 +344,6 @@ case object BlockFlowSyncService extends StrictLogging {
     logger.debug(s"Downloading missing block $missing")
     blockFlowClient.fetchBlock(chainFrom, missing).flatMap { block =>
       insert(block).map(_ => ())
-    }
-  }
-
-  def fetchAndBuildTimeStampRange(
-      step: Duration,
-      backStep: Duration,
-      localTs: Option[(TimeStamp, Int)],
-      remoteTs: Option[(TimeStamp, Int)]): (ArraySeq[(TimeStamp, TimeStamp)], Int) = {
-    (for {
-      (localTs, localNbOfBlocks) <- localTs.map {
-        case (ts, nb) => (ts.plusMillisUnsafe(1), nb)
-      }
-      (remoteTs, remoteNbOfBlocks) <- remoteTs.map {
-        case (ts, nb) => (ts.plusMillisUnsafe(1), nb)
-      }
-    } yield {
-      if (remoteTs.isBefore(localTs)) {
-        logger.error("max remote ts can't be before local one")
-        sys.exit(0)
-      } else {
-        (TimeUtil.buildTimestampRange(localTs.minusUnsafe(backStep), remoteTs, step),
-         remoteNbOfBlocks - localNbOfBlocks)
-      }
-    }) match {
-      case None      => (ArraySeq.empty, 0)
-      case Some(res) => res
     }
   }
 }

--- a/app/src/main/scala/org/alephium/explorer/util/TimeUtil.scala
+++ b/app/src/main/scala/org/alephium/explorer/util/TimeUtil.scala
@@ -84,12 +84,7 @@ object TimeUtil {
       backStep: Duration,
       localTs: Option[(TimeStamp, Int)],
       remoteTs: Option[(TimeStamp, Int)]): Try[(ArraySeq[(TimeStamp, TimeStamp)], Int)] =
-    buildTimeStampRangeOption(
-      step     = step,
-      backStep = backStep,
-      localTs  = localTs,
-      remoteTs = remoteTs
-    ) match {
+    buildTimeStampRangeOption(step, backStep, localTs, remoteTs) match {
       case None         => Success((ArraySeq.empty, 0))
       case Some(result) => result
     }
@@ -102,12 +97,7 @@ object TimeUtil {
       remoteTs: Option[(TimeStamp, Int)]): Option[Try[(ArraySeq[(TimeStamp, TimeStamp)], Int)]] =
     localTs.zip(remoteTs) map {
       case ((localTs, localNbOfBlocks), (remoteTs, remoteNbOfBlocks)) =>
-        buildTimeStampRange(
-          step     = step,
-          backStep = backStep,
-          localTs  = localTs,
-          remoteTs = remoteTs
-        ) map { result =>
+        buildTimeStampRange(step, backStep, localTs, remoteTs) map { result =>
           val numOfBlocks = remoteNbOfBlocks - localNbOfBlocks
           (result, numOfBlocks)
         }

--- a/app/src/test/scala/org/alephium/explorer/service/BlockFlowSyncServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/BlockFlowSyncServiceSpec.scala
@@ -47,23 +47,6 @@ class BlockFlowSyncServiceSpec
     with Eventually {
   override implicit val patienceConfig = PatienceConfig(timeout = Span(50, Seconds))
 
-  "fetch and build timestamp range" in new Fixture {
-
-    def th(ts: TimeStamp, height: Int) = Option((ts, height))
-
-    BlockFlowSyncService
-      .fetchAndBuildTimeStampRange(s(10), s(5), th(t(20), 5), th(t(40), 8))
-      .is((ArraySeq(r(16, 26), r(27, 37), r(38, 41)), 3))
-
-    BlockFlowSyncService
-      .fetchAndBuildTimeStampRange(s(10), s(5), None, th(t(40), 8))
-      .is((ArraySeq.empty, 0))
-
-    BlockFlowSyncService
-      .fetchAndBuildTimeStampRange(s(10), s(5), th(t(20), 5), None)
-      .is((ArraySeq.empty, 0))
-  }
-
   "start/sync/stop" in new Fixture {
     using(Scheduler("")) { implicit scheduler =>
       checkBlocks(ArraySeq.empty)

--- a/app/src/test/scala/org/alephium/explorer/util/TimeUtilSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/util/TimeUtilSpec.scala
@@ -20,9 +20,14 @@ import java.time.{Instant, LocalDateTime, OffsetTime, ZoneId}
 
 import scala.collection.immutable.ArraySeq
 
+import org.scalacheck.Gen
+import org.scalatest.OptionValues._
+import org.scalatest.TryValues._
 import org.scalatest.matchers.should.Matchers
 
 import org.alephium.explorer.AlephiumSpec
+import org.alephium.explorer.GenCoreUtil._
+import org.alephium.explorer.error.ExplorerError.RemoteTimeStampIsBeforeLocal
 import org.alephium.explorer.util.TimeUtil._
 import org.alephium.util.{Duration, TimeStamp}
 
@@ -84,6 +89,103 @@ class TimeUtilSpec extends AlephiumSpec with Matchers {
 
       buildTimestampRange(t(0), t(1), s(0)) is
         ArraySeq.empty
+    }
+  }
+
+  "buildTimeStampRange" should {
+    "return valid timestamp ranges" when {
+      "local timestamp is behind remote timestamp" in {
+        val actual =
+          TimeUtil
+            .buildTimeStampRange(
+              step     = Duration.ofMillisUnsafe(10),
+              backStep = Duration.ofMillisUnsafe(5),
+              localTs  = TimeStamp.unsafe(20), //local is behind remote
+              remoteTs = TimeStamp.unsafe(40) //remote is ahead
+            )
+            .success
+            .value
+
+        val expected =
+          ArraySeq((TimeStamp.unsafe(16), TimeStamp.unsafe(26)),
+                   (TimeStamp.unsafe(27), TimeStamp.unsafe(37)),
+                   (TimeStamp.unsafe(38), TimeStamp.unsafe(41)))
+
+        expected is actual
+      }
+    }
+
+    "return failure" when {
+      "local timestamp is ahead of remote timestamp" in {
+        forAll(Gen.posNum[Long], Gen.posNum[Short]) {
+          case (timestamp, aheadBy) =>
+            val localTs  = TimeStamp.unsafe(timestamp + (aheadBy max 1)) //max 1 so that local is ahead by at least 1
+            val remoteTs = TimeStamp.unsafe(timestamp)
+
+            TimeUtil
+              .buildTimeStampRange(step     = Duration.ofMillisUnsafe(10),
+                                   backStep = Duration.ofMillisUnsafe(5),
+                                   localTs  = localTs,
+                                   remoteTs = remoteTs)
+              .failure
+              .exception is RemoteTimeStampIsBeforeLocal(localTs, remoteTs)
+        }
+      }
+    }
+  }
+
+  "buildTimeStampRangeOption" should {
+    "return None" when {
+      "local timestamp is None" in {
+        forAll(Gen.posNum[Long], Gen.posNum[Long], timestampGen, Gen.posNum[Int]) {
+          case (step, backStep, timeStamp, numOfBlocks) =>
+            TimeUtil
+              .buildTimeStampRangeOption(step     = Duration.ofMillisUnsafe(step),
+                                         backStep = Duration.ofMillisUnsafe(backStep),
+                                         localTs  = Some((timeStamp, numOfBlocks)),
+                                         remoteTs = None)
+              .is(None)
+        }
+      }
+
+      "remote timestamp is None" in {
+        forAll(Gen.posNum[Long], Gen.posNum[Long], timestampGen, Gen.posNum[Int]) {
+          case (step, backStep, timeStamp, numOfBlocks) =>
+            TimeUtil
+              .buildTimeStampRangeOption(step     = Duration.ofMillisUnsafe(step),
+                                         backStep = Duration.ofMillisUnsafe(backStep),
+                                         localTs  = None,
+                                         remoteTs = Some((timeStamp, numOfBlocks)))
+              .is(None)
+        }
+      }
+    }
+
+    "return total number of blocks (remoteNumOfBlocks - localNumOfBlocks)" when {
+      "all inputs are valid" in {
+        //Test: When all inputs are valid, NumOfBlocks should be (remoteNumOfBlocks - localNumOfBlocks)
+        forAll(Gen.posNum[Long], Gen.posNum[Int], Gen.posNum[Int]) {
+          case (timestamp, localNumOfBlocks, remoteNumOfBlocks) =>
+            //localNumBlocks should be greater than or equal to remoteNumBlocks
+            val localBlocks = remoteNumOfBlocks min localNumOfBlocks
+
+            //Only test for numOfBlocks. It should be (remote - local)
+            val (_, numOfBlocks) =
+              TimeUtil
+                .buildTimeStampRangeOption(
+                  step     = Duration.ofMillisUnsafe(0),
+                  backStep = Duration.ofMillisUnsafe(0),
+                  localTs  = Some((TimeStamp.unsafe(timestamp), localBlocks)),
+                  remoteTs = Some((TimeStamp.unsafe(timestamp + 1), remoteNumOfBlocks))
+                )
+                .value
+                .success
+                .value
+
+            //Num of blocks returned should be (remote - local)
+            numOfBlocks is (remoteNumOfBlocks - localBlocks)
+        }
+      }
     }
   }
 


### PR DESCRIPTION
- Resolves #364
- Splits `fetchAndBuildTimeStampRange()` into smaller functions. 
- Implemented existing test-case using ScalaCheck for coverage and added few more covering failure scenarios.
  - Moved existing test-cases without [these abbreviated functions `t` `s` `r`, `th`](https://github.com/alephium/explorer-backend/blob/64495d3f72cd804804c1a9f5e1a75d115c81c230/app/src/test/scala/org/alephium/explorer/service/BlockFlowSyncServiceSpec.scala#L54). Seem more readable without ‘em. But please let me know if you’d like them used anyway.  