### PR TITLE
Improve test framework

### DIFF
--- a/app/src/test/scala/org/alephium/explorer/AlephiumActorSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/AlephiumActorSpec.scala
@@ -24,7 +24,7 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfterAll
 
 trait AlephiumActorSpecLike
-    extends AlephiumSpec
+    extends AlephiumFutureSpec
     with TestKitBase
     with ImplicitSender
     with BeforeAndAfterAll {
@@ -34,7 +34,7 @@ trait AlephiumActorSpecLike
   implicit lazy val system: ActorSystem =
     ActorSystem(name, ConfigFactory.parseString(AlephiumActorSpec.config))
 
-  implicit lazy val executionContext: ExecutionContext = system.dispatcher
+  override implicit lazy val executionContext: ExecutionContext = system.dispatcher
 
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)

--- a/app/src/test/scala/org/alephium/explorer/AlephiumSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/AlephiumSpec.scala
@@ -22,6 +22,7 @@ import org.scalacheck.Shrink
 import org.scalactic.Equality
 import org.scalactic.source.Position
 import org.scalatest.Assertion
+import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.matchers.dsl.ResultOfATypeInvocation
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -44,3 +45,7 @@ trait AlephiumSpec
     // scalastyle:on scalatest-matcher
   }
 }
+
+trait AlephiumFutures extends ScalaFutures with Eventually with IntegrationPatience
+
+trait AlephiumFutureSpec extends AlephiumSpec with AlephiumFutures

--- a/app/src/test/scala/org/alephium/explorer/AlephiumSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/AlephiumSpec.scala
@@ -17,6 +17,7 @@
 package org.alephium.explorer
 
 import scala.annotation.nowarn
+import scala.concurrent.ExecutionContext
 
 import org.scalacheck.Shrink
 import org.scalactic.Equality
@@ -46,6 +47,8 @@ trait AlephiumSpec
   }
 }
 
-trait AlephiumFutures extends ScalaFutures with Eventually with IntegrationPatience
+trait AlephiumFutures extends ScalaFutures with Eventually with IntegrationPatience {
+  implicit def executionContext: ExecutionContext = ExecutionContext.Implicits.global
+}
 
 trait AlephiumFutureSpec extends AlephiumSpec with AlephiumFutures

--- a/app/src/test/scala/org/alephium/explorer/ExplorerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/ExplorerSpec.scala
@@ -30,8 +30,7 @@ import io.vertx.ext.web._
 import org.scalacheck.Gen
 import org.scalatest.Assertion
 import org.scalatest.Inspectors
-import org.scalatest.concurrent.{Eventually, ScalaFutures}
-import org.scalatest.time.{Minutes, Span}
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
 import sttp.model.StatusCode
@@ -56,14 +55,9 @@ import org.alephium.json.Json._
 import org.alephium.protocol.model.{BlockHash, CliqueId, NetworkId}
 import org.alephium.util.{AVector, TimeStamp, U256}
 
-trait ExplorerSpec
-    extends AlephiumActorSpecLike
-    with ScalaFutures
-    with HttpRouteFixture
-    with Eventually {
+trait ExplorerSpec extends AlephiumActorSpecLike with AlephiumFutureSpec with HttpRouteFixture {
 
-  override val name: String            = "ExploreSpec"
-  override implicit val patienceConfig = PatienceConfig(timeout = Span(1, Minutes))
+  override val name: String = "ExploreSpec"
 
   implicit val groupSetting: GroupSetting = groupSettingGen.sample.get
 
@@ -331,9 +325,8 @@ object ExplorerSpec {
       with BaseEndpoint
       with ScalaFutures
       with QueryParams
-      with Server {
-
-    override implicit val patienceConfig = PatienceConfig(timeout = Span(1, Minutes))
+      with Server
+      with IntegrationPatience {
 
     val blocks = blockflow.flatten
 

--- a/app/src/test/scala/org/alephium/explorer/HttpFixture.scala
+++ b/app/src/test/scala/org/alephium/explorer/HttpFixture.scala
@@ -24,12 +24,12 @@ import io.vertx.core.Vertx
 import io.vertx.core.http.HttpServer
 import io.vertx.ext.web._
 import org.scalatest.{Assertion, BeforeAndAfterAll, Suite}
-import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import sttp.client3._
 import sttp.client3.asynchttpclient.future.AsyncHttpClientFutureBackend
 import sttp.model.{Method, Uri}
 import sttp.tapir.server.vertx.VertxFutureServerInterpreter._
 
+import org.alephium.explorer.AlephiumFutures
 import org.alephium.json.Json._
 
 object HttpFixture {
@@ -132,7 +132,8 @@ trait HttpFixture {
 }
 
 @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
-trait HttpRouteFixture extends HttpFixture with BeforeAndAfterAll with ScalaFutures { this: Suite =>
+trait HttpRouteFixture extends HttpFixture with BeforeAndAfterAll with AlephiumFutures {
+  this: Suite =>
 
   def port: Int
 
@@ -172,13 +173,8 @@ trait HttpRouteFixture extends HttpFixture with BeforeAndAfterAll with ScalaFutu
 
 @SuppressWarnings(
   Array("org.wartremover.warts.DefaultArguments", "org.wartremover.warts.NonUnitStatements"))
-trait HttpServerFixture
-    extends HttpRouteFixture
-    with BeforeAndAfterAll
-    with ScalaFutures
-    with IntegrationPatience {
+trait HttpServerFixture extends HttpRouteFixture {
   this: Suite =>
-  implicit def executionContext: ExecutionContext
   def routes: ArraySeq[Router => Route]
   val port: Int = SocketUtil.temporaryLocalPort(SocketUtil.Both)
 

--- a/app/src/test/scala/org/alephium/explorer/HttpFixture.scala
+++ b/app/src/test/scala/org/alephium/explorer/HttpFixture.scala
@@ -24,8 +24,7 @@ import io.vertx.core.Vertx
 import io.vertx.core.http.HttpServer
 import io.vertx.ext.web._
 import org.scalatest.{Assertion, BeforeAndAfterAll, Suite}
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{Seconds, Span}
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import sttp.client3._
 import sttp.client3.asynchttpclient.future.AsyncHttpClientFutureBackend
 import sttp.model.{Method, Uri}
@@ -173,11 +172,13 @@ trait HttpRouteFixture extends HttpFixture with BeforeAndAfterAll with ScalaFutu
 
 @SuppressWarnings(
   Array("org.wartremover.warts.DefaultArguments", "org.wartremover.warts.NonUnitStatements"))
-trait HttpServerFixture extends HttpRouteFixture with BeforeAndAfterAll with ScalaFutures {
+trait HttpServerFixture
+    extends HttpRouteFixture
+    with BeforeAndAfterAll
+    with ScalaFutures
+    with IntegrationPatience {
   this: Suite =>
-
   implicit def executionContext: ExecutionContext
-  override implicit val patienceConfig = PatienceConfig(timeout = Span(5, Seconds))
   def routes: ArraySeq[Router => Route]
   val port: Int = SocketUtil.temporaryLocalPort(SocketUtil.Both)
 

--- a/app/src/test/scala/org/alephium/explorer/SyncServicesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/SyncServicesSpec.scala
@@ -17,7 +17,7 @@
 package org.alephium.explorer
 
 import scala.collection.immutable.ArraySeq
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 import scala.util._
 
 import com.typesafe.config.ConfigFactory
@@ -39,9 +39,6 @@ class SyncServicesSpec
     with Matchers
     with ScalaCheckDrivenPropertyChecks
     with MockFactory {
-
-  implicit val executionContext: ExecutionContext =
-    ExecutionContext.global
 
   "getBlockFlowPeers" should {
     val explorerConfig: ExplorerConfig =

--- a/app/src/test/scala/org/alephium/explorer/SyncServicesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/SyncServicesSpec.scala
@@ -24,9 +24,7 @@ import com.typesafe.config.ConfigFactory
 import org.scalacheck.Gen
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.TryValues._
-import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.time.{Seconds, Span}
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 import org.alephium.explorer.GenCoreApi._
@@ -37,13 +35,10 @@ import org.alephium.explorer.service.BlockFlowClient
 
 /** Temporary placeholder. These tests should be merged into ApplicationSpec  */
 class SyncServicesSpec
-    extends AlephiumSpec
+    extends AlephiumFutureSpec
     with Matchers
     with ScalaCheckDrivenPropertyChecks
-    with ScalaFutures
     with MockFactory {
-
-  override implicit val patienceConfig = PatienceConfig(timeout = Span(5, Seconds))
 
   implicit val executionContext: ExecutionContext =
     ExecutionContext.global

--- a/app/src/test/scala/org/alephium/explorer/cache/AsyncReloadingCacheSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/cache/AsyncReloadingCacheSpec.scala
@@ -21,12 +21,9 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 
-import org.scalatest.concurrent.{Eventually, ScalaFutures}
-import org.scalatest.concurrent.PatienceConfiguration.Timeout
+import org.alephium.explorer.AlephiumFutureSpec
 
-import org.alephium.explorer.AlephiumSpec
-
-class AsyncReloadingCacheSpec extends AlephiumSpec with ScalaFutures with Eventually {
+class AsyncReloadingCacheSpec extends AlephiumFutureSpec {
 
   implicit val executionContext: ExecutionContext = ExecutionContext.global
 
@@ -45,13 +42,13 @@ class AsyncReloadingCacheSpec extends AlephiumSpec with ScalaFutures with Eventu
     cache.get() is 1 //Returns initial cached value. There is time left to expiration
     reloadCount.get() is 0 //No reload yet
 
-    eventually(Timeout(1.5.seconds))(cache.get() is 2) //eventually reload occurs with cache updated
+    eventually(cache.get() is 2) //eventually reload occurs with cache updated
     reloadCount.get() is 1 //first reload
 
-    eventually(Timeout(1.5.seconds))(cache.get() is 3) //another reload & cache updated
+    eventually(cache.get() is 3) //another reload & cache updated
     reloadCount.get() is 2 //second reload
 
-    eventually(Timeout(1.5.seconds))(cache.get() is 4) //another reload & cache updated
+    eventually(cache.get() is 4) //another reload & cache updated
     reloadCount.get() is 3 //third reload
   }
 
@@ -109,13 +106,13 @@ class AsyncReloadingCacheSpec extends AlephiumSpec with ScalaFutures with Eventu
     reloadCount.get() is 1 //Initial value gets returned so not reload occur.
 
     cache.expireAndReload()
-    eventually(Timeout(1.second)) {
+    eventually {
       concurrentlyReadCache(3)
       reloadCount.get() is 2
     }
 
     cache.expireAndReload()
-    eventually(Timeout(1.second)) {
+    eventually {
       concurrentlyReadCache(4)
       reloadCount.get() is 3
     }

--- a/app/src/test/scala/org/alephium/explorer/cache/AsyncReloadingCacheSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/cache/AsyncReloadingCacheSpec.scala
@@ -18,14 +18,12 @@ package org.alephium.explorer.cache
 
 import java.util.concurrent.atomic.AtomicInteger
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 import scala.concurrent.duration._
 
 import org.alephium.explorer.AlephiumFutureSpec
 
 class AsyncReloadingCacheSpec extends AlephiumFutureSpec {
-
-  implicit val executionContext: ExecutionContext = ExecutionContext.global
 
   "reload cache after expiration while returning existing value even during reloading" in {
     val reloadCount = new AtomicInteger() //number of times reload was executed

--- a/app/src/test/scala/org/alephium/explorer/cache/CaffeineAsyncCacheSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/cache/CaffeineAsyncCacheSpec.scala
@@ -19,11 +19,10 @@ package org.alephium.explorer.cache
 import java.util.concurrent.{CompletableFuture, Executor, TimeUnit}
 
 import com.github.benmanes.caffeine.cache.{AsyncCacheLoader, Caffeine}
-import org.scalatest.concurrent.ScalaFutures
 
-import org.alephium.explorer.AlephiumSpec
+import org.alephium.explorer.AlephiumFutureSpec
 
-class CaffeineAsyncCacheSpec extends AlephiumSpec with ScalaFutures {
+class CaffeineAsyncCacheSpec extends AlephiumFutureSpec {
 
   "return None for getIfPresent when cache is empty (NullPointerException check)" in {
     val cache =

--- a/app/src/test/scala/org/alephium/explorer/persistence/DatabaseFixtureForAll.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/DatabaseFixtureForAll.scala
@@ -16,25 +16,36 @@
 
 package org.alephium.explorer.persistence
 
+import com.typesafe.scalalogging.StrictLogging
 import org.scalatest.{BeforeAndAfterAll, Suite}
 import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
 
+import org.alephium.explorer.AlephiumFutures
+
 /**
   * Creates and drops a new database connection for all test-cases in a test class.
   */
-trait DatabaseFixtureForAll extends BeforeAndAfterAll { this: Suite =>
+@SuppressWarnings(Array("org.wartremover.warts.PlatformDefault"))
+trait DatabaseFixtureForAll extends BeforeAndAfterAll with AlephiumFutures with StrictLogging {
+  this: Suite =>
+
+  val dbName: String = getClass.getSimpleName.toLowerCase
 
   implicit val databaseConfig: DatabaseConfig[PostgresProfile] =
-    DatabaseFixture.createDatabaseConfig()
+    DatabaseFixture.createDatabaseConfig(dbName)
 
   override def beforeAll(): Unit = {
     super.beforeAll()
+    DatabaseFixture.createDb(dbName)
     DatabaseFixture.dropCreateTables()
+    logger.debug(s"Test database $dbName created")
   }
 
   override def afterAll(): Unit = {
     super.afterAll()
     databaseConfig.db.close()
+    DatabaseFixture.dropDb(dbName)
+    logger.debug(s"Test database $dbName dropped")
   }
 }

--- a/app/src/test/scala/org/alephium/explorer/persistence/DatabaseSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/DatabaseSpec.scala
@@ -18,8 +18,6 @@ package org.alephium.explorer.persistence
 
 import scala.util._
 
-import slick.basic.DatabaseConfig
-import slick.jdbc.PostgresProfile
 import org.alephium.explorer.AlephiumFutureSpec
 import org.alephium.explorer.config.BootMode
 
@@ -29,7 +27,6 @@ class DatabaseSpec extends AlephiumFutureSpec with DatabaseFixtureForEach {
   "initialiseDatabase" should {
     "successfully connect" when {
       "readOnly mode" in {
-        val databaseConfig = DatabaseConfig.forConfig[PostgresProfile]("db", DatabaseFixture.config)
         val database: Database =
           new Database(BootMode.ReadOnly)(executionContext, databaseConfig)
 
@@ -37,7 +34,6 @@ class DatabaseSpec extends AlephiumFutureSpec with DatabaseFixtureForEach {
       }
 
       "readWrite mode" in {
-        val databaseConfig = DatabaseConfig.forConfig[PostgresProfile]("db", DatabaseFixture.config)
         val database: Database =
           new Database(BootMode.ReadWrite)(executionContext, databaseConfig)
 

--- a/app/src/test/scala/org/alephium/explorer/persistence/DatabaseSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/DatabaseSpec.scala
@@ -16,7 +16,6 @@
 
 package org.alephium.explorer.persistence
 
-import scala.concurrent.ExecutionContext
 import scala.util._
 
 import slick.basic.DatabaseConfig
@@ -26,9 +25,6 @@ import org.alephium.explorer.config.BootMode
 
 /** Temporary placeholder. These tests should be merged into ApplicationSpec  */
 class DatabaseSpec extends AlephiumFutureSpec with DatabaseFixtureForEach {
-
-  implicit val executionContext: ExecutionContext =
-    ExecutionContext.global
 
   "initialiseDatabase" should {
     "successfully connect" when {

--- a/app/src/test/scala/org/alephium/explorer/persistence/DatabaseSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/DatabaseSpec.scala
@@ -19,18 +19,13 @@ package org.alephium.explorer.persistence
 import scala.concurrent.ExecutionContext
 import scala.util._
 
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{Seconds, Span}
 import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
-
-import org.alephium.explorer.AlephiumSpec
+import org.alephium.explorer.AlephiumFutureSpec
 import org.alephium.explorer.config.BootMode
 
 /** Temporary placeholder. These tests should be merged into ApplicationSpec  */
-class DatabaseSpec extends AlephiumSpec with ScalaFutures {
-
-  override implicit val patienceConfig = PatienceConfig(timeout = Span(5, Seconds))
+class DatabaseSpec extends AlephiumFutureSpec with DatabaseFixtureForEach {
 
   implicit val executionContext: ExecutionContext =
     ExecutionContext.global

--- a/app/src/test/scala/org/alephium/explorer/persistence/dao/BlockDaoSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/dao/BlockDaoSpec.scala
@@ -22,12 +22,10 @@ import scala.util.Random
 
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
-import org.scalatest.concurrent.{Eventually, ScalaFutures}
-import org.scalatest.time.{Minutes, Span}
 import slick.jdbc.PostgresProfile.api._
 
 import org.alephium.api.{model, ApiModelCodec}
-import org.alephium.explorer.{AlephiumSpec, GroupSetting}
+import org.alephium.explorer.{AlephiumFutureSpec, GroupSetting}
 import org.alephium.explorer.GenApiModel._
 import org.alephium.explorer.GenDBModel._
 import org.alephium.explorer.Generators._
@@ -48,14 +46,8 @@ import org.alephium.util.{Duration, TimeStamp}
   Array("org.wartremover.warts.JavaSerializable",
         "org.wartremover.warts.Product",
         "org.wartremover.warts.Serializable")) // Wartremover is complaining, don't now why :/
-class BlockDaoSpec
-    extends AlephiumSpec
-    with DatabaseFixtureForEach
-    with DBRunner
-    with ScalaFutures
-    with Eventually {
+class BlockDaoSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with DBRunner {
   implicit val executionContext: ExecutionContext = ExecutionContext.global
-  override implicit val patienceConfig            = PatienceConfig(timeout = Span(1, Minutes))
 
   "updateMainChainStatus correctly" in new Fixture {
     forAll(Gen.oneOf(blockEntities), arbitrary[Boolean]) {

--- a/app/src/test/scala/org/alephium/explorer/persistence/dao/BlockDaoSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/dao/BlockDaoSpec.scala
@@ -16,7 +16,6 @@
 
 package org.alephium.explorer.persistence.dao
 
-import scala.concurrent.ExecutionContext
 import scala.io.{Codec, Source}
 import scala.util.Random
 
@@ -47,7 +46,6 @@ import org.alephium.util.{Duration, TimeStamp}
         "org.wartremover.warts.Product",
         "org.wartremover.warts.Serializable")) // Wartremover is complaining, don't now why :/
 class BlockDaoSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with DBRunner {
-  implicit val executionContext: ExecutionContext = ExecutionContext.global
 
   "updateMainChainStatus correctly" in new Fixture {
     forAll(Gen.oneOf(blockEntities), arbitrary[Boolean]) {

--- a/app/src/test/scala/org/alephium/explorer/persistence/dao/UnconfirmedTxDaoSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/dao/UnconfirmedTxDaoSpec.scala
@@ -17,7 +17,6 @@
 package org.alephium.explorer.persistence.dao
 
 import scala.collection.immutable.ArraySeq
-import scala.concurrent.ExecutionContext
 
 import org.scalacheck.Gen
 import slick.jdbc.PostgresProfile.api._
@@ -31,7 +30,6 @@ import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.protocol.model.TransactionId
 
 class UnconfirmedTxDaoSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with DBRunner {
-  implicit val executionContext: ExecutionContext = ExecutionContext.global
 
   "insertMany" in {
     forAll(Gen.listOfN(5, utransactionGen)) { txs =>

--- a/app/src/test/scala/org/alephium/explorer/persistence/dao/UnconfirmedTxDaoSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/dao/UnconfirmedTxDaoSpec.scala
@@ -20,11 +20,9 @@ import scala.collection.immutable.ArraySeq
 import scala.concurrent.ExecutionContext
 
 import org.scalacheck.Gen
-import org.scalatest.concurrent.{Eventually, ScalaFutures}
-import org.scalatest.time.{Minutes, Span}
 import slick.jdbc.PostgresProfile.api._
 
-import org.alephium.explorer.AlephiumSpec
+import org.alephium.explorer.AlephiumFutureSpec
 import org.alephium.explorer.GenApiModel.{assetOutputGen, utransactionGen}
 import org.alephium.explorer.GenCoreUtil.timestampGen
 import org.alephium.explorer.persistence.{DatabaseFixtureForEach, DBRunner}
@@ -32,14 +30,8 @@ import org.alephium.explorer.persistence.schema._
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.protocol.model.TransactionId
 
-class UnconfirmedTxDaoSpec
-    extends AlephiumSpec
-    with DatabaseFixtureForEach
-    with DBRunner
-    with ScalaFutures
-    with Eventually {
+class UnconfirmedTxDaoSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with DBRunner {
   implicit val executionContext: ExecutionContext = ExecutionContext.global
-  override implicit val patienceConfig            = PatienceConfig(timeout = Span(1, Minutes))
 
   "insertMany" in {
     forAll(Gen.listOfN(5, utransactionGen)) { txs =>

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/AppStateQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/AppStateQueriesSpec.scala
@@ -16,8 +16,6 @@
 
 package org.alephium.explorer.persistence.queries
 
-import scala.concurrent.ExecutionContext
-
 import slick.jdbc.PostgresProfile.api._
 
 import org.alephium.explorer.AlephiumFutureSpec
@@ -27,8 +25,6 @@ import org.alephium.explorer.persistence.model.AppState
 import org.alephium.explorer.persistence.schema.AppStateSchema
 
 class AppStateQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with DBRunner {
-
-  implicit val executionContext: ExecutionContext = ExecutionContext.global
 
   "insert" should {
     "write LastFinalizedInputTime key-value" in {

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/AppStateQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/AppStateQueriesSpec.scala
@@ -18,24 +18,17 @@ package org.alephium.explorer.persistence.queries
 
 import scala.concurrent.ExecutionContext
 
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{Minutes, Span}
 import slick.jdbc.PostgresProfile.api._
 
-import org.alephium.explorer.AlephiumSpec
+import org.alephium.explorer.AlephiumFutureSpec
 import org.alephium.explorer.GenCoreUtil._
 import org.alephium.explorer.persistence.{DatabaseFixtureForEach, DBRunner}
 import org.alephium.explorer.persistence.model.AppState
 import org.alephium.explorer.persistence.schema.AppStateSchema
 
-class AppStateQueriesSpec
-    extends AlephiumSpec
-    with DatabaseFixtureForEach
-    with DBRunner
-    with ScalaFutures {
+class AppStateQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with DBRunner {
 
   implicit val executionContext: ExecutionContext = ExecutionContext.global
-  override implicit val patienceConfig            = PatienceConfig(timeout = Span(1, Minutes))
 
   "insert" should {
     "write LastFinalizedInputTime key-value" in {

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockDepQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockDepQueriesSpec.scala
@@ -16,8 +16,6 @@
 
 package org.alephium.explorer.persistence.queries
 
-import scala.concurrent.ExecutionContext
-
 import org.scalacheck.Gen
 import slick.jdbc.PostgresProfile.api._
 
@@ -27,8 +25,6 @@ import org.alephium.explorer.persistence.queries.BlockDepQueries._
 import org.alephium.explorer.persistence.schema.BlockDepsSchema
 
 class BlockDepQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with DBRunner {
-
-  implicit val executionContext: ExecutionContext = ExecutionContext.global
 
   "insert and ignore block_deps" in {
 

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockDepQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockDepQueriesSpec.scala
@@ -19,23 +19,16 @@ package org.alephium.explorer.persistence.queries
 import scala.concurrent.ExecutionContext
 
 import org.scalacheck.Gen
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{Minutes, Span}
 import slick.jdbc.PostgresProfile.api._
 
-import org.alephium.explorer.{AlephiumSpec, Generators}
+import org.alephium.explorer.{AlephiumFutureSpec, Generators}
 import org.alephium.explorer.persistence.{DatabaseFixtureForEach, DBRunner}
 import org.alephium.explorer.persistence.queries.BlockDepQueries._
 import org.alephium.explorer.persistence.schema.BlockDepsSchema
 
-class BlockDepQueriesSpec
-    extends AlephiumSpec
-    with DatabaseFixtureForEach
-    with DBRunner
-    with ScalaFutures {
+class BlockDepQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with DBRunner {
 
   implicit val executionContext: ExecutionContext = ExecutionContext.global
-  override implicit val patienceConfig            = PatienceConfig(timeout = Span(1, Minutes))
 
   "insert and ignore block_deps" in {
 

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockQueriesSpec.scala
@@ -17,7 +17,6 @@
 package org.alephium.explorer.persistence.queries
 
 import scala.collection.immutable.ArraySeq
-import scala.concurrent.ExecutionContext
 import scala.math.Ordering.Implicits.infixOrderingOps
 import scala.util.Random
 
@@ -33,8 +32,6 @@ import org.alephium.explorer.persistence.model.BlockHeader
 import org.alephium.explorer.persistence.schema._
 
 class BlockQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with DBRunner {
-
-  implicit val executionContext: ExecutionContext = ExecutionContext.global
 
   /**
     * Finds a block with maximum height. If two blocks have the same

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockQueriesSpec.scala
@@ -22,11 +22,9 @@ import scala.math.Ordering.Implicits.infixOrderingOps
 import scala.util.Random
 
 import org.scalacheck.Gen
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{Minutes, Span}
 import slick.jdbc.PostgresProfile.api._
 
-import org.alephium.explorer.{AlephiumSpec, GroupSetting}
+import org.alephium.explorer.{AlephiumFutureSpec, GroupSetting}
 import org.alephium.explorer.GenApiModel.{blockEntryHashGen, blockHashGen, groupIndexGen, heightGen}
 import org.alephium.explorer.Generators._
 import org.alephium.explorer.api.model.{GroupIndex, Height}
@@ -34,14 +32,9 @@ import org.alephium.explorer.persistence.{DatabaseFixtureForEach, DBRunner}
 import org.alephium.explorer.persistence.model.BlockHeader
 import org.alephium.explorer.persistence.schema._
 
-class BlockQueriesSpec
-    extends AlephiumSpec
-    with DatabaseFixtureForEach
-    with DBRunner
-    with ScalaFutures {
+class BlockQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with DBRunner {
 
   implicit val executionContext: ExecutionContext = ExecutionContext.global
-  override implicit val patienceConfig            = PatienceConfig(timeout = Span(1000, Minutes))
 
   /**
     * Finds a block with maximum height. If two blocks have the same

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/InputQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/InputQueriesSpec.scala
@@ -16,8 +16,6 @@
 
 package org.alephium.explorer.persistence.queries
 
-import scala.concurrent.ExecutionContext
-
 import org.scalacheck.Gen
 import slick.jdbc.PostgresProfile.api._
 
@@ -30,8 +28,6 @@ import org.alephium.explorer.persistence.queries.result.{InputsFromTxQR, InputsQ
 import org.alephium.explorer.persistence.schema.InputSchema
 
 class InputQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with DBRunner {
-
-  implicit val executionContext: ExecutionContext = ExecutionContext.global
 
   "insertInputs" should {
     "insert and ignore inputs" in {

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/InputQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/InputQueriesSpec.scala
@@ -19,11 +19,9 @@ package org.alephium.explorer.persistence.queries
 import scala.concurrent.ExecutionContext
 
 import org.scalacheck.Gen
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{Minutes, Span}
 import slick.jdbc.PostgresProfile.api._
 
-import org.alephium.explorer.AlephiumSpec
+import org.alephium.explorer.AlephiumFutureSpec
 import org.alephium.explorer.Generators._
 import org.alephium.explorer.persistence.{DatabaseFixtureForEach, DBRunner}
 import org.alephium.explorer.persistence.model.InputEntity
@@ -31,14 +29,9 @@ import org.alephium.explorer.persistence.queries.InputQueries._
 import org.alephium.explorer.persistence.queries.result.{InputsFromTxQR, InputsQR}
 import org.alephium.explorer.persistence.schema.InputSchema
 
-class InputQueriesSpec
-    extends AlephiumSpec
-    with DatabaseFixtureForEach
-    with DBRunner
-    with ScalaFutures {
+class InputQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with DBRunner {
 
   implicit val executionContext: ExecutionContext = ExecutionContext.global
-  override implicit val patienceConfig            = PatienceConfig(timeout = Span(1, Minutes))
 
   "insertInputs" should {
     "insert and ignore inputs" in {

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/InputUpdateQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/InputUpdateQueriesSpec.scala
@@ -16,8 +16,6 @@
 
 package org.alephium.explorer.persistence.queries
 
-import scala.concurrent.ExecutionContext
-
 import slick.jdbc.PostgresProfile.api._
 
 import org.alephium.explorer.AlephiumFutureSpec
@@ -27,8 +25,6 @@ import org.alephium.explorer.persistence.schema.{InputSchema, OutputSchema}
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 
 class InputUpdateQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with DBRunner {
-
-  implicit val executionContext: ExecutionContext = ExecutionContext.global
 
   "Input Update" should {
     "update inputs when address is already set" in {

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/InputUpdateQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/InputUpdateQueriesSpec.scala
@@ -18,24 +18,17 @@ package org.alephium.explorer.persistence.queries
 
 import scala.concurrent.ExecutionContext
 
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{Minutes, Span}
 import slick.jdbc.PostgresProfile.api._
 
-import org.alephium.explorer.AlephiumSpec
+import org.alephium.explorer.AlephiumFutureSpec
 import org.alephium.explorer.Generators._
 import org.alephium.explorer.persistence.{DatabaseFixtureForEach, DBRunner}
 import org.alephium.explorer.persistence.schema.{InputSchema, OutputSchema}
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 
-class InputUpdateQueriesSpec
-    extends AlephiumSpec
-    with DatabaseFixtureForEach
-    with DBRunner
-    with ScalaFutures {
+class InputUpdateQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with DBRunner {
 
   implicit val executionContext: ExecutionContext = ExecutionContext.global
-  override implicit val patienceConfig            = PatienceConfig(timeout = Span(1, Minutes))
 
   "Input Update" should {
     "update inputs when address is already set" in {

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/OutputQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/OutputQueriesSpec.scala
@@ -19,11 +19,9 @@ package org.alephium.explorer.persistence.queries
 import scala.concurrent.ExecutionContext
 
 import org.scalacheck.Gen
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{Minutes, Span}
 import slick.jdbc.PostgresProfile.api._
 
-import org.alephium.explorer.AlephiumSpec
+import org.alephium.explorer.AlephiumFutureSpec
 import org.alephium.explorer.GenApiModel._
 import org.alephium.explorer.Generators._
 import org.alephium.explorer.persistence.{DatabaseFixtureForEach, DBRunner}
@@ -33,14 +31,9 @@ import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.explorer.persistence.schema.OutputSchema
 import org.alephium.explorer.util.SlickExplainUtil._
 
-class OutputQueriesSpec
-    extends AlephiumSpec
-    with DatabaseFixtureForEach
-    with DBRunner
-    with ScalaFutures {
+class OutputQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with DBRunner {
 
   implicit val executionContext: ExecutionContext = ExecutionContext.global
-  override implicit val patienceConfig            = PatienceConfig(timeout = Span(1, Minutes))
 
   "insert and ignore outputs" in {
 

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/OutputQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/OutputQueriesSpec.scala
@@ -16,8 +16,6 @@
 
 package org.alephium.explorer.persistence.queries
 
-import scala.concurrent.ExecutionContext
-
 import org.scalacheck.Gen
 import slick.jdbc.PostgresProfile.api._
 
@@ -32,8 +30,6 @@ import org.alephium.explorer.persistence.schema.OutputSchema
 import org.alephium.explorer.util.SlickExplainUtil._
 
 class OutputQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with DBRunner {
-
-  implicit val executionContext: ExecutionContext = ExecutionContext.global
 
   "insert and ignore outputs" in {
 

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/TokenQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/TokenQueriesSpec.scala
@@ -19,11 +19,9 @@ package org.alephium.explorer.persistence.queries
 import scala.concurrent.ExecutionContext
 
 import org.scalacheck.Gen
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{Minutes, Span}
 import slick.jdbc.PostgresProfile.api._
 
-import org.alephium.explorer.AlephiumSpec
+import org.alephium.explorer.AlephiumFutureSpec
 import org.alephium.explorer.GenApiModel._
 import org.alephium.explorer.GenDBModel._
 import org.alephium.explorer.persistence.{DatabaseFixtureForEach, DBRunner}
@@ -31,14 +29,9 @@ import org.alephium.explorer.persistence.queries.TokenQueries
 import org.alephium.explorer.persistence.queries.result.TxByAddressQR
 import org.alephium.explorer.persistence.schema._
 
-class TokenQueriesSpec
-    extends AlephiumSpec
-    with DatabaseFixtureForEach
-    with DBRunner
-    with ScalaFutures {
+class TokenQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with DBRunner {
 
   implicit val executionContext: ExecutionContext = ExecutionContext.global
-  override implicit val patienceConfig            = PatienceConfig(timeout = Span(1, Minutes))
 
   "Token Queries" should {
     "list token transactions" in {

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/TokenQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/TokenQueriesSpec.scala
@@ -16,8 +16,6 @@
 
 package org.alephium.explorer.persistence.queries
 
-import scala.concurrent.ExecutionContext
-
 import org.scalacheck.Gen
 import slick.jdbc.PostgresProfile.api._
 
@@ -30,8 +28,6 @@ import org.alephium.explorer.persistence.queries.result.TxByAddressQR
 import org.alephium.explorer.persistence.schema._
 
 class TokenQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with DBRunner {
-
-  implicit val executionContext: ExecutionContext = ExecutionContext.global
 
   "Token Queries" should {
     "list token transactions" in {

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/TransactionQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/TransactionQueriesSpec.scala
@@ -21,11 +21,9 @@ import scala.concurrent.ExecutionContext
 import scala.util.Random
 
 import org.scalacheck.Gen
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{Minutes, Span}
 import slick.jdbc.PostgresProfile.api._
 
-import org.alephium.explorer.{AlephiumSpec, Hash, TestQueries}
+import org.alephium.explorer.{AlephiumFutureSpec, Hash, TestQueries}
 import org.alephium.explorer.GenApiModel._
 import org.alephium.explorer.GenCoreUtil._
 import org.alephium.explorer.GenDBModel._
@@ -44,13 +42,7 @@ import org.alephium.protocol.ALPH
 import org.alephium.protocol.model.TransactionId
 import org.alephium.util.{Duration, TimeStamp, U256}
 
-class TransactionQueriesSpec
-    extends AlephiumSpec
-    with DatabaseFixtureForEach
-    with DBRunner
-    with ScalaFutures {
-
-  override implicit val patienceConfig = PatienceConfig(timeout = Span(1, Minutes))
+class TransactionQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with DBRunner {
 
   implicit val executionContext: ExecutionContext = ExecutionContext.global
 

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/TransactionQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/TransactionQueriesSpec.scala
@@ -17,7 +17,6 @@
 package org.alephium.explorer.persistence.queries
 
 import scala.collection.immutable.ArraySeq
-import scala.concurrent.ExecutionContext
 import scala.util.Random
 
 import org.scalacheck.Gen
@@ -43,8 +42,6 @@ import org.alephium.protocol.model.TransactionId
 import org.alephium.util.{Duration, TimeStamp, U256}
 
 class TransactionQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with DBRunner {
-
-  implicit val executionContext: ExecutionContext = ExecutionContext.global
 
   "compute locked balance when empty" in new Fixture {
     val balance = run(TransactionQueries.getBalanceAction(address)).futureValue

--- a/app/src/test/scala/org/alephium/explorer/persistence/schema/CustomJdbcTypesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/schema/CustomJdbcTypesSpec.scala
@@ -16,8 +16,6 @@
 
 package org.alephium.explorer.persistence.schema
 
-import scala.concurrent.ExecutionContext
-
 import slick.jdbc.PostgresProfile.api._
 import slick.lifted.ProvenShape
 
@@ -31,7 +29,6 @@ import org.alephium.protocol.ALPH
 import org.alephium.util._
 
 class CustomJdbcTypesSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with DBRunner {
-  implicit val executionContext: ExecutionContext = ExecutionContext.global
 
   "convert TimeStamp" in new Fixture {
 

--- a/app/src/test/scala/org/alephium/explorer/persistence/schema/CustomJdbcTypesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/schema/CustomJdbcTypesSpec.scala
@@ -18,12 +18,10 @@ package org.alephium.explorer.persistence.schema
 
 import scala.concurrent.ExecutionContext
 
-import org.scalatest.concurrent.{Eventually, ScalaFutures}
-import org.scalatest.time.{Minutes, Span}
 import slick.jdbc.PostgresProfile.api._
 import slick.lifted.ProvenShape
 
-import org.alephium.explorer.{AlephiumSpec, Generators}
+import org.alephium.explorer.{AlephiumFutureSpec, Generators}
 import org.alephium.explorer.persistence.{DatabaseFixtureForEach, DBRunner}
 import org.alephium.explorer.persistence.queries.OutputQueries
 import org.alephium.explorer.persistence.schema.CustomGetResult._
@@ -32,14 +30,8 @@ import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.protocol.ALPH
 import org.alephium.util._
 
-class CustomJdbcTypesSpec
-    extends AlephiumSpec
-    with DatabaseFixtureForEach
-    with DBRunner
-    with ScalaFutures
-    with Eventually {
+class CustomJdbcTypesSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with DBRunner {
   implicit val executionContext: ExecutionContext = ExecutionContext.global
-  override implicit val patienceConfig            = PatienceConfig(timeout = Span(1, Minutes))
 
   "convert TimeStamp" in new Fixture {
 

--- a/app/src/test/scala/org/alephium/explorer/service/BlockFlowSyncServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/BlockFlowSyncServiceSpec.scala
@@ -85,8 +85,6 @@ class BlockFlowSyncServiceSpec extends AlephiumFutureSpec with DatabaseFixtureFo
       eventually(checkMainChain(mainChain))
 
       checkLatestHeight(8)
-
-      databaseConfig.db.close
     }
   }
 

--- a/app/src/test/scala/org/alephium/explorer/service/BlockFlowSyncServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/BlockFlowSyncServiceSpec.scala
@@ -20,12 +20,10 @@ import scala.collection.immutable.ArraySeq
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 
-import org.scalatest.concurrent.{Eventually, ScalaFutures}
-import org.scalatest.time.{Seconds, Span}
 import sttp.model.Uri
 
 import org.alephium.api.model.{ChainInfo, ChainParams, HashesAtHeight, SelfClique}
-import org.alephium.explorer.{AlephiumSpec, GroupSetting}
+import org.alephium.explorer.{AlephiumFutureSpec, GroupSetting}
 import org.alephium.explorer.GenApiModel.chainIndexes
 import org.alephium.explorer.GenCoreUtil.timestampMaxValue
 import org.alephium.explorer.Generators._
@@ -40,12 +38,7 @@ import org.alephium.protocol.model.{BlockHash, ChainIndex, CliqueId, NetworkId}
 import org.alephium.util.{AVector, Duration, Hex, Service, TimeStamp}
 
 @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.DefaultArguments"))
-class BlockFlowSyncServiceSpec
-    extends AlephiumSpec
-    with DatabaseFixtureForAll
-    with ScalaFutures
-    with Eventually {
-  override implicit val patienceConfig = PatienceConfig(timeout = Span(50, Seconds))
+class BlockFlowSyncServiceSpec extends AlephiumFutureSpec with DatabaseFixtureForAll {
 
   "start/sync/stop" in new Fixture {
     using(Scheduler("")) { implicit scheduler =>

--- a/app/src/test/scala/org/alephium/explorer/service/BlockFlowSyncServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/BlockFlowSyncServiceSpec.scala
@@ -94,8 +94,7 @@ class BlockFlowSyncServiceSpec extends AlephiumFutureSpec with DatabaseFixtureFo
     def s(l: Long)            = Duration.ofMillisUnsafe(l)
     def r(l1: Long, l2: Long) = (t(l1), t(l2))
 
-    implicit val executionContext: ExecutionContext = ExecutionContext.global
-    implicit val groupSetting: GroupSetting         = groupSettingGen.sample.get
+    implicit val groupSetting: GroupSetting = groupSettingGen.sample.get
 
     def blockEntity(parent: Option[BlockEntity],
                     chainFrom: GroupIndex = GroupIndex.unsafe(0),
@@ -182,7 +181,7 @@ class BlockFlowSyncServiceSpec extends AlephiumFutureSpec with DatabaseFixtureFo
     def blocks: ArraySeq[BlockEntry] = blockFlow.flatten
 
     implicit val blockFlowClient: BlockFlowClient = new BlockFlowClient {
-      implicit val executionContext: ExecutionContext = ExecutionContext.global
+      implicit val executionContext: ExecutionContext = implicitly
       def startSelfOnce(): Future[Unit]               = Future.unit
       def stopSelfOnce(): Future[Unit]                = Future.unit
       def subServices: ArraySeq[Service]              = ArraySeq.empty

--- a/app/src/test/scala/org/alephium/explorer/service/FinalizerServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/FinalizerServiceSpec.scala
@@ -18,9 +18,7 @@ package org.alephium.explorer.service
 
 import scala.concurrent.ExecutionContext
 
-import org.scalatest.concurrent.ScalaFutures
-
-import org.alephium.explorer.AlephiumSpec
+import org.alephium.explorer.AlephiumFutureSpec
 import org.alephium.explorer.Generators._
 import org.alephium.explorer.persistence.{DatabaseFixtureForEach, DBRunner}
 import org.alephium.explorer.persistence.model.AppState.LastFinalizedInputTime
@@ -28,11 +26,7 @@ import org.alephium.explorer.persistence.model.InputEntity
 import org.alephium.explorer.persistence.queries.{AppStateQueries, InputQueries}
 import org.alephium.util.{Duration, TimeStamp}
 
-class FinalizerServiceSpec
-    extends AlephiumSpec
-    with DatabaseFixtureForEach
-    with DBRunner
-    with ScalaFutures {
+class FinalizerServiceSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with DBRunner {
   implicit val executionContext: ExecutionContext = ExecutionContext.global
   "getStartEndTime - return nothing if there's no input" in new Fixture {
     run(FinalizerService.getStartEndTime()).futureValue is None

--- a/app/src/test/scala/org/alephium/explorer/service/FinalizerServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/FinalizerServiceSpec.scala
@@ -16,8 +16,6 @@
 
 package org.alephium.explorer.service
 
-import scala.concurrent.ExecutionContext
-
 import org.alephium.explorer.AlephiumFutureSpec
 import org.alephium.explorer.Generators._
 import org.alephium.explorer.persistence.{DatabaseFixtureForEach, DBRunner}
@@ -27,7 +25,7 @@ import org.alephium.explorer.persistence.queries.{AppStateQueries, InputQueries}
 import org.alephium.util.{Duration, TimeStamp}
 
 class FinalizerServiceSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with DBRunner {
-  implicit val executionContext: ExecutionContext = ExecutionContext.global
+
   "getStartEndTime - return nothing if there's no input" in new Fixture {
     run(FinalizerService.getStartEndTime()).futureValue is None
   }

--- a/app/src/test/scala/org/alephium/explorer/service/HashrateServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/HashrateServiceSpec.scala
@@ -21,11 +21,9 @@ import java.time.Instant
 import scala.collection.immutable.ArraySeq
 import scala.concurrent.ExecutionContext
 
-import org.scalatest.concurrent.{Eventually, ScalaFutures}
-import org.scalatest.time.{Minutes, Span}
 import slick.jdbc.PostgresProfile.api._
 
-import org.alephium.explorer.AlephiumSpec
+import org.alephium.explorer.AlephiumFutureSpec
 import org.alephium.explorer.Generators._
 import org.alephium.explorer.api.model.{Hashrate, IntervalType}
 import org.alephium.explorer.persistence.{DatabaseFixtureForEach, DBRunner}
@@ -33,14 +31,8 @@ import org.alephium.explorer.persistence.queries.HashrateQueries._
 import org.alephium.explorer.persistence.schema.BlockHeaderSchema
 import org.alephium.util._
 
-class HashrateServiceSpec
-    extends AlephiumSpec
-    with DatabaseFixtureForEach
-    with DBRunner
-    with ScalaFutures
-    with Eventually {
+class HashrateServiceSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with DBRunner {
   implicit val executionContext: ExecutionContext = ExecutionContext.global
-  override implicit val patienceConfig            = PatienceConfig(timeout = Span(1, Minutes))
 
   "hourly hashrates" in new Fixture {
 

--- a/app/src/test/scala/org/alephium/explorer/service/HashrateServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/HashrateServiceSpec.scala
@@ -19,7 +19,6 @@ package org.alephium.explorer.service
 import java.time.Instant
 
 import scala.collection.immutable.ArraySeq
-import scala.concurrent.ExecutionContext
 
 import slick.jdbc.PostgresProfile.api._
 
@@ -32,7 +31,6 @@ import org.alephium.explorer.persistence.schema.BlockHeaderSchema
 import org.alephium.util._
 
 class HashrateServiceSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with DBRunner {
-  implicit val executionContext: ExecutionContext = ExecutionContext.global
 
   "hourly hashrates" in new Fixture {
 

--- a/app/src/test/scala/org/alephium/explorer/service/MempoolSyncServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/MempoolSyncServiceSpec.scala
@@ -63,8 +63,6 @@ class MempoolSyncServiceSpec extends AlephiumFutureSpec with DatabaseFixtureForE
           .map(_.hash)
           .toSet
       }
-
-      databaseConfig.db.close
     }
   }
 

--- a/app/src/test/scala/org/alephium/explorer/service/MempoolSyncServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/MempoolSyncServiceSpec.scala
@@ -67,12 +67,10 @@ class MempoolSyncServiceSpec extends AlephiumFutureSpec with DatabaseFixtureForE
   }
 
   trait Fixture {
-    implicit val executionContext: ExecutionContext = ExecutionContext.global
-
     var unconfirmedTransactions: ArraySeq[UnconfirmedTransaction] = ArraySeq.empty
 
     implicit val blockFlowClient: BlockFlowClient = new BlockFlowClient {
-      implicit val executionContext: ExecutionContext = ExecutionContext.global
+      implicit val executionContext: ExecutionContext = implicitly
       def startSelfOnce(): Future[Unit]               = Future.unit
       def stopSelfOnce(): Future[Unit]                = Future.unit
       def subServices: ArraySeq[Service]              = ArraySeq.empty

--- a/app/src/test/scala/org/alephium/explorer/service/MempoolSyncServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/MempoolSyncServiceSpec.scala
@@ -21,12 +21,10 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 
 import org.scalacheck.Gen
-import org.scalatest.concurrent.{Eventually, ScalaFutures}
-import org.scalatest.time.{Minutes, Span}
 import sttp.model.Uri
 
 import org.alephium.api.model.{ChainInfo, ChainParams, HashesAtHeight, SelfClique}
-import org.alephium.explorer.AlephiumSpec
+import org.alephium.explorer.AlephiumFutureSpec
 import org.alephium.explorer.GenApiModel.utransactionGen
 import org.alephium.explorer.api.model.{GroupIndex, Height, UnconfirmedTransaction}
 import org.alephium.explorer.persistence.DatabaseFixtureForEach
@@ -37,12 +35,7 @@ import org.alephium.explorer.util.TestUtils._
 import org.alephium.protocol.model.BlockHash
 import org.alephium.util.{Service, TimeStamp}
 
-class MempoolSyncServiceSpec
-    extends AlephiumSpec
-    with DatabaseFixtureForEach
-    with ScalaFutures
-    with Eventually {
-  override implicit val patienceConfig = PatienceConfig(timeout = Span(1, Minutes))
+class MempoolSyncServiceSpec extends AlephiumFutureSpec with DatabaseFixtureForEach {
 
   "start/sync/stop" in new Fixture {
     using(Scheduler("test")) { implicit scheduler =>

--- a/app/src/test/scala/org/alephium/explorer/service/TokenSupplyServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TokenSupplyServiceSpec.scala
@@ -251,8 +251,6 @@ class TokenSupplyServiceSpec extends AlephiumFutureSpec with DatabaseFixtureForE
           .futureValue
           .map(_.circulating) is Some(amounts.head)
       }
-
-      databaseConfig.db.close
     }
 
     def blockAmount(blockEntity: BlockEntity): U256 =

--- a/app/src/test/scala/org/alephium/explorer/service/TokenSupplyServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TokenSupplyServiceSpec.scala
@@ -21,11 +21,9 @@ import java.time.Instant
 import scala.collection.immutable.ArraySeq
 import scala.concurrent.ExecutionContext
 
-import org.scalatest.concurrent.{Eventually, ScalaFutures}
-import org.scalatest.time.{Seconds, Span}
 import slick.jdbc.PostgresProfile.api._
 
-import org.alephium.explorer.{AlephiumSpec, GroupSetting}
+import org.alephium.explorer.{AlephiumFutureSpec, GroupSetting}
 import org.alephium.explorer.GenApiModel.transactionHashGen
 import org.alephium.explorer.Generators._
 import org.alephium.explorer.api.model._
@@ -39,14 +37,8 @@ import org.alephium.protocol.ALPH
 import org.alephium.util.{Duration, TimeStamp, U256}
 
 @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.DefaultArguments"))
-class TokenSupplyServiceSpec
-    extends AlephiumSpec
-    with DatabaseFixtureForEach
-    with DBRunner
-    with ScalaFutures
-    with Eventually {
+class TokenSupplyServiceSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with DBRunner {
   implicit val executionContext: ExecutionContext = ExecutionContext.global
-  override implicit val patienceConfig            = PatienceConfig(timeout = Span(50, Seconds))
 
   "Build days range" in {
     val launchTime = ALPH.LaunchTimestamp //2021-11-08T11:20:06+00:00

--- a/app/src/test/scala/org/alephium/explorer/service/TokenSupplyServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TokenSupplyServiceSpec.scala
@@ -19,7 +19,6 @@ package org.alephium.explorer.service
 import java.time.Instant
 
 import scala.collection.immutable.ArraySeq
-import scala.concurrent.ExecutionContext
 
 import slick.jdbc.PostgresProfile.api._
 
@@ -38,7 +37,6 @@ import org.alephium.util.{Duration, TimeStamp, U256}
 
 @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.DefaultArguments"))
 class TokenSupplyServiceSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with DBRunner {
-  implicit val executionContext: ExecutionContext = ExecutionContext.global
 
   "Build days range" in {
     val launchTime = ALPH.LaunchTimestamp //2021-11-08T11:20:06+00:00

--- a/app/src/test/scala/org/alephium/explorer/service/TransactionHistoryServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TransactionHistoryServiceSpec.scala
@@ -21,11 +21,9 @@ import java.time.Instant
 import scala.collection.immutable.ArraySeq
 import scala.concurrent.ExecutionContext
 
-import org.scalatest.concurrent.{Eventually, ScalaFutures}
-import org.scalatest.time.{Minutes, Span}
 import slick.jdbc.PostgresProfile.api._
 
-import org.alephium.explorer.{AlephiumSpec, GroupSetting}
+import org.alephium.explorer.{AlephiumFutureSpec, GroupSetting}
 import org.alephium.explorer.Generators._
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.persistence.{DatabaseFixtureForEach, DBRunner}
@@ -34,13 +32,10 @@ import org.alephium.explorer.persistence.schema.TransactionSchema
 import org.alephium.util._
 
 class TransactionHistoryServiceSpec
-    extends AlephiumSpec
+    extends AlephiumFutureSpec
     with DatabaseFixtureForEach
-    with DBRunner
-    with ScalaFutures
-    with Eventually {
+    with DBRunner {
   implicit val executionContext: ExecutionContext = ExecutionContext.global
-  override implicit val patienceConfig            = PatienceConfig(timeout = Span(1, Minutes))
 
   def ts(str: String): TimeStamp = {
     TimeStamp.unsafe(Instant.parse(str).toEpochMilli)

--- a/app/src/test/scala/org/alephium/explorer/service/TransactionHistoryServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TransactionHistoryServiceSpec.scala
@@ -19,7 +19,6 @@ package org.alephium.explorer.service
 import java.time.Instant
 
 import scala.collection.immutable.ArraySeq
-import scala.concurrent.ExecutionContext
 
 import slick.jdbc.PostgresProfile.api._
 
@@ -35,7 +34,6 @@ class TransactionHistoryServiceSpec
     extends AlephiumFutureSpec
     with DatabaseFixtureForEach
     with DBRunner {
-  implicit val executionContext: ExecutionContext = ExecutionContext.global
 
   def ts(str: String): TimeStamp = {
     TimeStamp.unsafe(Instant.parse(str).toEpochMilli)

--- a/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
@@ -19,7 +19,7 @@ package org.alephium.explorer.service
 import java.math.BigInteger
 
 import scala.collection.immutable.ArraySeq
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
 import org.scalacheck.Gen
 
@@ -41,8 +41,6 @@ import org.alephium.util.{TimeStamp, U256}
         "org.wartremover.warts.DefaultArguments",
         "org.wartremover.warts.AsInstanceOf"))
 class TransactionServiceSpec extends AlephiumFutureSpec with DatabaseFixtureForEach {
-
-  implicit val executionContext: ExecutionContext = ExecutionContext.global
 
   "limit the number of transactions in address details" in new Fixture {
 

--- a/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
@@ -22,10 +22,8 @@ import scala.collection.immutable.ArraySeq
 import scala.concurrent.{ExecutionContext, Future}
 
 import org.scalacheck.Gen
-import org.scalatest.concurrent.{Eventually, ScalaFutures}
-import org.scalatest.time.{Minutes, Span}
 
-import org.alephium.explorer.{AlephiumSpec, GroupSetting}
+import org.alephium.explorer.{AlephiumFutureSpec, GroupSetting}
 import org.alephium.explorer.GenApiModel._
 import org.alephium.explorer.Generators._
 import org.alephium.explorer.api.model._
@@ -42,14 +40,9 @@ import org.alephium.util.{TimeStamp, U256}
   Array("org.wartremover.warts.Var",
         "org.wartremover.warts.DefaultArguments",
         "org.wartremover.warts.AsInstanceOf"))
-class TransactionServiceSpec
-    extends AlephiumSpec
-    with DatabaseFixtureForEach
-    with ScalaFutures
-    with Eventually {
+class TransactionServiceSpec extends AlephiumFutureSpec with DatabaseFixtureForEach {
 
   implicit val executionContext: ExecutionContext = ExecutionContext.global
-  override implicit val patienceConfig            = PatienceConfig(timeout = Span(1, Minutes))
 
   "limit the number of transactions in address details" in new Fixture {
 

--- a/app/src/test/scala/org/alephium/explorer/util/SchedulerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/util/SchedulerSpec.scala
@@ -24,20 +24,13 @@ import scala.concurrent.duration._
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 import org.scalacheck.Gen
-import org.scalatest.concurrent.{Eventually, ScalaFutures}
-import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-import org.alephium.explorer.AlephiumSpec
+import org.alephium.explorer.AlephiumFutureSpec
 import org.alephium.explorer.util.TestUtils._
 
-class SchedulerSpec
-    extends AlephiumSpec
-    with ScalaCheckDrivenPropertyChecks
-    with Matchers
-    with Eventually
-    with ScalaFutures {
+class SchedulerSpec extends AlephiumFutureSpec with ScalaCheckDrivenPropertyChecks with Matchers {
 
   implicit val executionContext: ExecutionContext = ExecutionContext.global
 
@@ -122,7 +115,7 @@ class SchedulerSpec
           Future(scheduleTimes.add(System.nanoTime()))
         }
 
-        eventually(Timeout(10.seconds)) {
+        eventually {
           //wait until at least 6 schedules have occurs
           scheduleTimes.size() should be > 6
         }
@@ -157,7 +150,7 @@ class SchedulerSpec
             }
 
             //scheduledTime - testStartTime is 3 seconds
-            eventually(Timeout(5.seconds)) {
+            eventually {
               //expect the task to be executed between [2.5 .. 3.9] seconds.
               (executionTime - startTime) should (be >= 2500L and be <= 3900L)
             }
@@ -180,7 +173,7 @@ class SchedulerSpec
               }
             }
 
-            eventually(Timeout(10.seconds)) {
+            eventually {
               //expect the task to be executed between [2.9 .. 4.9] seconds.
               (executionTime - startTime) should (be >= 2900L and be <= 4900L)
             }
@@ -208,7 +201,7 @@ class SchedulerSpec
             }
           }
 
-          eventually(Timeout(2.seconds)) {
+          eventually {
             //allow at least 50 init invocations
             initInvocations.get() should be >= 50
           }
@@ -273,7 +266,7 @@ class SchedulerSpec
             Future(state.incrementAndGet()).map(_ => ())
           }
 
-          eventually(Timeout(2.seconds)) {
+          eventually {
             blockExecuted.get() should be >= 50 //allow block to get executed a number of times
           }
 

--- a/app/src/test/scala/org/alephium/explorer/util/SchedulerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/util/SchedulerSpec.scala
@@ -19,7 +19,7 @@ import java.time._
 import java.util.concurrent.ConcurrentLinkedDeque
 import java.util.concurrent.atomic.AtomicInteger
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
@@ -31,8 +31,6 @@ import org.alephium.explorer.AlephiumFutureSpec
 import org.alephium.explorer.util.TestUtils._
 
 class SchedulerSpec extends AlephiumFutureSpec with ScalaCheckDrivenPropertyChecks with Matchers {
-
-  implicit val executionContext: ExecutionContext = ExecutionContext.global
 
   val zoneIds: Iterable[ZoneId] =
     ZoneId.getAvailableZoneIds.asScala.map(ZoneId.of)

--- a/app/src/test/scala/org/alephium/explorer/web/ChartsServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/ChartsServerSpec.scala
@@ -16,8 +16,6 @@
 
 package org.alephium.explorer.web
 
-import org.scalatest.concurrent.ScalaFutures
-
 import org.alephium.api.ApiError
 import org.alephium.explorer._
 import org.alephium.explorer.HttpFixture._
@@ -29,7 +27,6 @@ import org.alephium.util.{Duration, TimeStamp}
 class ChartsServerSpec()
     extends AlephiumActorSpecLike
     with DatabaseFixtureForAll
-    with ScalaFutures
     with HttpServerFixture {
 
   val chartServer     = new ChartsServer()

--- a/app/src/test/scala/org/alephium/explorer/web/UnconfirmedTransactionServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/UnconfirmedTransactionServerSpec.scala
@@ -17,7 +17,6 @@
 package org.alephium.explorer.web
 
 import org.scalacheck.Gen
-import org.scalatest.concurrent.{Eventually, ScalaFutures}
 
 import org.alephium.explorer.{AlephiumActorSpecLike, HttpServerFixture}
 import org.alephium.explorer.GenApiModel._
@@ -30,9 +29,7 @@ import org.alephium.explorer.persistence.dao.UnconfirmedTxDao
 class UnconfirmedTransactionServerSpec()
     extends AlephiumActorSpecLike
     with HttpServerFixture
-    with DatabaseFixtureForAll
-    with ScalaFutures
-    with Eventually {
+    with DatabaseFixtureForAll {
 
   val utxServer = new UnconfirmedTransactionServer()
 

--- a/app/src/test/scala/org/alephium/explorer/web/UtilsServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/UtilsServerSpec.scala
@@ -17,7 +17,6 @@
 package org.alephium.explorer.web
 
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.concurrent.ScalaFutures
 import sttp.model.StatusCode
 
 import org.alephium.api.ApiError
@@ -34,7 +33,6 @@ import org.alephium.json.Json
 class UtilsServerSpec()
     extends AlephiumActorSpecLike
     with DatabaseFixtureForAll
-    with ScalaFutures
     with HttpServerFixture
     with MockFactory {
 

--- a/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/spec/ReadBenchmarkStateSpec.scala
+++ b/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/spec/ReadBenchmarkStateSpec.scala
@@ -20,9 +20,7 @@ import java.util.concurrent.RejectedExecutionException
 
 import scala.concurrent.duration._
 
-import org.scalatest.concurrent.ScalaFutures
-
-import org.alephium.explorer.AlephiumSpec
+import org.alephium.explorer.AlephiumFutureSpec
 import org.alephium.explorer.benchmark.db.DBExecutor
 import org.alephium.explorer.benchmark.db.state._
 import org.alephium.explorer.util.TestUtils._
@@ -32,7 +30,7 @@ import org.alephium.explorer.util.TestUtils._
   *   - [[ByteaReadState]]
   *   - [[VarcharReadState]]
   */
-class ReadBenchmarkStateSpec extends AlephiumSpec with ScalaFutures {
+class ReadBenchmarkStateSpec extends AlephiumFutureSpec {
 
   //total number of rows to generate
   val testDataCount = 10


### PR DESCRIPTION
Big refactor for our test framework:

- Define `AlephiumFutureSpec` to clean the usage of `ScalaFutures/PatienceConfig` which was spread all over the place
- Define an `ExecutionContext` inside `AlephiumFutureSpec` to avoid declaring it everywhere.

Finally the big change that started this PR, which I think will fix https://github.com/alephium/explorer-backend/issues/323

Until now we were using the default `postgres` database for all our test and we were dropping/recreating the tables for each tests.
With this PR we are now creating one database per test, we thus avoid conflict where two parallel test are using the same databae (which lead to the deadlocks).

I did re-run all jobs several time without any issue so far :crossed_fingers: 