### PR TITLE
#375: Time ranged transactions

### DIFF
--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -762,6 +762,154 @@
         }
       }
     },
+    "/addresses/{address}/timeranged-transactions": {
+      "get": {
+        "tags": [
+          "Addresses"
+        ],
+        "description": "List transactions of a given address within a time-range",
+        "operationId": "getAddressesAddressTimeranged-transactions",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "fromTs",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": "0"
+            }
+          },
+          {
+            "name": "toTs",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": "0"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number per page",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "reverse",
+            "in": "query",
+            "description": "Reverse pagination",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Transaction"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequest"
+                },
+                "example": {
+                  "detail": "Something bad in the request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unauthorized"
+                },
+                "example": {
+                  "detail": "You shall not pass"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFound"
+                },
+                "example": {
+                  "resource": "wallet-name",
+                  "detail": "wallet-name not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                },
+                "example": {
+                  "detail": "Ouch"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailable"
+                },
+                "example": {
+                  "detail": "Self clique unsynced"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/addresses/{address}/total-transactions": {
       "get": {
         "tags": [
@@ -3050,7 +3198,6 @@
         "operationId": "putUtilsSanity-check",
         "responses": {
           "200": {
-            
           },
           "400": {
             "description": "BadRequest",
@@ -3147,7 +3294,6 @@
         },
         "responses": {
           "200": {
-            
           },
           "400": {
             "description": "BadRequest",
@@ -3240,7 +3386,6 @@
         },
         "responses": {
           "200": {
-            
           },
           "400": {
             "description": "BadRequest",

--- a/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
@@ -77,7 +77,7 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
       .in(path[Address]("address")(Codecs.explorerAddressTapirCodec))
       .in("timeranged-transactions")
       .in(timeIntervalQuery)
-      .in(paginator(Pagination.`100K`))
+      .in(paginator(Pagination.thousand))
       .out(jsonBody[ArraySeq[Transaction]])
       .description("List transactions of a given address within a time-range")
 

--- a/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
@@ -22,8 +22,7 @@ import sttp.tapir._
 import sttp.tapir.generic.auto._
 
 import org.alephium.api.{alphJsonBody => jsonBody}
-import org.alephium.explorer.api.BaseEndpoint
-import org.alephium.explorer.api.Codecs
+import org.alephium.api.model.TimeInterval
 import org.alephium.explorer.api.model._
 import org.alephium.protocol.model.TokenId
 
@@ -71,6 +70,16 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
       .in(pagination)
       .out(jsonBody[ArraySeq[Transaction]])
       .description("List transactions of a given address")
+
+  val getTransactionsByAddressTimeRanged
+    : BaseEndpoint[(Address, TimeInterval, Pagination), ArraySeq[Transaction]] =
+    addressesEndpoint.get
+      .in(path[Address]("address")(Codecs.explorerAddressTapirCodec))
+      .in("timeranged-transactions")
+      .in(timeIntervalQuery)
+      .in(paginator(Pagination.`100K`))
+      .out(jsonBody[ArraySeq[Transaction]])
+      .description("List transactions of a given address within a time-range")
 
   val getTotalTransactionsByAddress: BaseEndpoint[Address, Int] =
     addressesEndpoint.get

--- a/app/src/main/scala/org/alephium/explorer/api/QueryParams.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/QueryParams.scala
@@ -32,6 +32,9 @@ trait QueryParams extends TapirCodecs {
     fromJson[TokenId]
 
   val pagination: EndpointInput[Pagination] =
+    paginator(Pagination.maxLimit)
+
+  def paginator(maxLimit: Int): EndpointInput[Pagination] =
     query[Option[Int]]("page")
       .description("Page number")
       .map({
@@ -47,7 +50,7 @@ trait QueryParams extends TapirCodecs {
             case None        => Pagination.defaultLimit
           })(Some(_))
           .validate(Validator.min(0))
-          .validate(Validator.max(Pagination.maxLimit)))
+          .validate(Validator.max(maxLimit)))
       .and(query[Option[Boolean]]("reverse")
         .description("Reverse pagination")
         .map({

--- a/app/src/main/scala/org/alephium/explorer/api/model/Pagination.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/Pagination.scala
@@ -23,6 +23,7 @@ object Pagination {
   val defaultPage: Int  = 1
   val defaultLimit: Int = 20
   val maxLimit: Int     = 100
+  val `100K`: Int     = 100_000
 
   @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
   def unsafe(offset: Int, limit: Int, reverse: Boolean = false): Pagination = {

--- a/app/src/main/scala/org/alephium/explorer/api/model/Pagination.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/Pagination.scala
@@ -23,7 +23,7 @@ object Pagination {
   val defaultPage: Int  = 1
   val defaultLimit: Int = 20
   val maxLimit: Int     = 100
-  val `100K`: Int     = 100_000
+  val `100K`: Int       = 100000
 
   @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
   def unsafe(offset: Int, limit: Int, reverse: Boolean = false): Pagination = {

--- a/app/src/main/scala/org/alephium/explorer/api/model/Pagination.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/Pagination.scala
@@ -23,7 +23,7 @@ object Pagination {
   val defaultPage: Int  = 1
   val defaultLimit: Int = 20
   val maxLimit: Int     = 100
-  val `100K`: Int       = 100000
+  val thousand: Int     = 1000
 
   @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
   def unsafe(offset: Int, limit: Int, reverse: Boolean = false): Pagination = {

--- a/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
+++ b/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
@@ -40,6 +40,7 @@ trait Documentation
       getOutputRefTransaction,
       getAddressInfo,
       getTransactionsByAddress,
+      getTransactionsByAddressTimeRanged,
       getTotalTransactionsByAddress,
       addressUnconfirmedTransactions,
       getAddressBalance,

--- a/app/src/main/scala/org/alephium/explorer/persistence/dao/TransactionDao.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/dao/TransactionDao.scala
@@ -28,7 +28,7 @@ import org.alephium.explorer.persistence.queries.TokenQueries._
 import org.alephium.explorer.persistence.queries.TransactionQueries._
 import org.alephium.protocol.Hash
 import org.alephium.protocol.model.{TokenId, TransactionId}
-import org.alephium.util.U256
+import org.alephium.util.{TimeStamp, U256}
 
 object TransactionDao {
 
@@ -50,6 +50,14 @@ object TransactionDao {
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]] =
     run(getTransactionsByAddressSQL(address, pagination))
+
+  def getByAddressTimeRangedSQL(address: Address,
+                                fromTime: TimeStamp,
+                                toTime: TimeStamp,
+                                pagination: Pagination)(
+      implicit ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]] =
+    run(getTransactionsByAddressTimeRangedSQL(address, fromTime, toTime, pagination))
 
   def getNumberByAddressSQLNoJoin(address: Address)(
       implicit ec: ExecutionContext,

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
@@ -197,7 +197,7 @@ object TransactionQueries extends StrictLogging {
       FROM transaction_per_addresses
       WHERE main_chain = true
         AND address = $address
-        AND block_timestamp between $fromTime AND $toTime
+        AND block_timestamp BETWEEN $fromTime AND $toTime
       ORDER BY block_timestamp DESC, tx_order
       LIMIT $limit
       OFFSET $offset

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
@@ -178,6 +178,33 @@ object TransactionQueries extends StrictLogging {
     """.asAS[TxByAddressQR]
   }
 
+  /**
+    * Get transactions by address for a given time-range
+    *
+    * @param address   Address to query
+    * @param fromTime  From TimeStamp of the time-range
+    * @param toTime    To TimeStamp of the time-range
+    * @param offset    Page number (starting from 0)
+    * @param limit     Maximum rows
+    * @return          [[TxByAddressQR]]
+    */
+  def getTxHashesByAddressQuerySQLNoJoinTimeRanged(address: Address,
+                                                   fromTime: TimeStamp,
+                                                   toTime: TimeStamp,
+                                                   offset: Int,
+                                                   limit: Int): DBActionSR[TxByAddressQR] = {
+    sql"""
+      SELECT tx_hash, block_hash, block_timestamp, tx_order
+      FROM transaction_per_addresses
+      WHERE main_chain = true
+        AND address = $address
+        AND block_timestamp between $fromTime AND $toTime
+      ORDER BY block_timestamp DESC, tx_order
+      LIMIT $limit
+      OFFSET $offset
+    """.asAS[TxByAddressQR]
+  }
+
   def getTransactionsByBlockHash(blockHash: BlockHash)(
       implicit ec: ExecutionContext): DBActionSR[Transaction] = {
     for {

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
@@ -235,6 +235,24 @@ object TransactionQueries extends StrictLogging {
     } yield txs
   }
 
+  def getTransactionsByAddressTimeRangedSQL(
+      address: Address,
+      fromTime: TimeStamp,
+      toTime: TimeStamp,
+      pagination: Pagination)(implicit ec: ExecutionContext): DBActionR[ArraySeq[Transaction]] = {
+    val offset = pagination.offset
+    val limit  = pagination.limit
+    val toDrop = offset * limit
+    for {
+      txHashesTs <- getTxHashesByAddressQuerySQLNoJoinTimeRanged(address,
+                                                                 fromTime,
+                                                                 toTime,
+                                                                 toDrop,
+                                                                 limit)
+      txs <- getTransactionsSQL(txHashesTs)
+    } yield txs
+  }
+
   def getTransactionsByAddressNoJoin(address: Address, pagination: Pagination)(
       implicit ec: ExecutionContext): DBActionR[ArraySeq[Transaction]] = {
     val offset = pagination.offset

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
@@ -186,7 +186,6 @@ object TransactionQueries extends StrictLogging {
     * @param toTime    To TimeStamp of the time-range
     * @param offset    Page number (starting from 0)
     * @param limit     Maximum rows
-    * @return          [[TxByAddressQR]]
     */
   def getTxHashesByAddressQuerySQLNoJoinTimeRanged(address: Address,
                                                    fromTime: TimeStamp,

--- a/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
@@ -27,7 +27,7 @@ import org.alephium.explorer.cache.TransactionCache
 import org.alephium.explorer.persistence.dao.{TransactionDao, UnconfirmedTxDao}
 import org.alephium.protocol.Hash
 import org.alephium.protocol.model.{TokenId, TransactionId}
-import org.alephium.util.U256
+import org.alephium.util.{TimeStamp, U256}
 
 trait TransactionService {
   def getTransaction(transactionHash: TransactionId)(
@@ -43,6 +43,13 @@ trait TransactionService {
       dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]]
 
   def getTransactionsByAddressSQL(address: Address, pagination: Pagination)(
+      implicit ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]]
+
+  def getTransactionsByAddressTimeRangedSQL(address: Address,
+                                            fromTime: TimeStamp,
+                                            toTime: TimeStamp,
+                                            pagination: Pagination)(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]]
 
@@ -117,6 +124,14 @@ object TransactionService extends TransactionService {
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]] =
     TransactionDao.getByAddressSQL(address, pagination)
+
+  def getTransactionsByAddressTimeRangedSQL(address: Address,
+                                            fromTime: TimeStamp,
+                                            toTime: TimeStamp,
+                                            pagination: Pagination)(
+      implicit ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]] =
+    TransactionDao.getByAddressTimeRangedSQL(address, fromTime, toTime, pagination)
 
   def listUnconfirmedTransactionsByAddress(address: Address)(
       implicit ec: ExecutionContext,

--- a/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
@@ -49,6 +49,14 @@ class AddressServer(transactionService: TransactionService)(
           transactionService
             .getTransactionsByAddressSQL(address, pagination)
       }),
+      route(getTransactionsByAddressTimeRanged.serverLogicSuccess[Future] {
+        case (address, timeInterval, pagination) =>
+          transactionService
+            .getTransactionsByAddressTimeRangedSQL(address,
+                                                   timeInterval.from,
+                                                   timeInterval.to,
+                                                   pagination)
+      }),
       route(addressUnconfirmedTransactions.serverLogicSuccess[Future] { address =>
         transactionService
           .listUnconfirmedTransactionsByAddress(address)

--- a/app/src/test/scala/org/alephium/explorer/GenDBModel.scala
+++ b/app/src/test/scala/org/alephium/explorer/GenDBModel.scala
@@ -19,7 +19,9 @@ import org.scalacheck.{Arbitrary, Gen}
 
 import org.alephium.explorer.GenApiModel._
 import org.alephium.explorer.GenCoreUtil._
+import org.alephium.explorer.api.model.Address
 import org.alephium.explorer.persistence.model._
+import org.alephium.util.TimeStamp
 
 /** Test-data generators for types in package [[org.alephium.explorer.persistence.model]]  */
 @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
@@ -54,14 +56,17 @@ object GenDBModel {
         toTransactionPerAddressEntity(input, output)
     }
 
-  def genTransactionPerAddressEntity(): Gen[TransactionPerAddressEntity] =
+  def genTransactionPerAddressEntity(
+      addressGen: Gen[Address]     = addressGen,
+      timestampGen: Gen[TimeStamp] = timestampGen,
+      mainChain: Gen[Boolean]      = Arbitrary.arbitrary[Boolean]): Gen[TransactionPerAddressEntity] =
     for {
       address   <- addressGen
       hash      <- transactionHashGen
       blockHash <- blockEntryHashGen
       timestamp <- timestampGen
       txOrder   <- Gen.posNum[Int]
-      mainChain <- Arbitrary.arbitrary[Boolean]
+      mainChain <- mainChain
     } yield
       TransactionPerAddressEntity(
         address   = address,

--- a/app/src/test/scala/org/alephium/explorer/TestQueries.scala
+++ b/app/src/test/scala/org/alephium/explorer/TestQueries.scala
@@ -1,0 +1,35 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer
+
+import slick.jdbc.PostgresProfile.api._
+
+import org.alephium.explorer.persistence._
+import org.alephium.explorer.persistence.model.TransactionPerAddressEntity
+import org.alephium.explorer.persistence.schema.TransactionPerAddressSchema
+
+object TestQueries {
+
+  def insert(entities: Seq[TransactionPerAddressEntity]): DBActionW[Option[Int]] =
+    TransactionPerAddressSchema.table ++= entities
+
+  def clearTransactionPerAddressTable(): DBActionW[Int] =
+    TransactionPerAddressSchema.table.delete
+
+  def clearAndInsert(entities: Seq[TransactionPerAddressEntity]): DBActionW[Option[Int]] =
+    clearTransactionPerAddressTable() andThen insert(entities)
+}

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/TransactionQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/TransactionQueriesSpec.scala
@@ -464,7 +464,7 @@ class TransactionQueriesSpec
             run(TestQueries.clearAndInsert(entities)).futureValue
 
             entities foreach { entity =>
-              //run the query for each entity and expect the entity to be returned
+              //run the query for each entity and expect that same entity to be returned
               val query =
                 TransactionQueries
                   .getTxHashesByAddressQuerySQLNoJoinTimeRanged(address  = entity.address,

--- a/app/src/test/scala/org/alephium/explorer/service/EmptyTransactionService.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/EmptyTransactionService.scala
@@ -25,9 +25,8 @@ import slick.jdbc.PostgresProfile
 import org.alephium.explorer._
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.cache.TransactionCache
-import org.alephium.explorer.service.TransactionService
 import org.alephium.protocol.model.{TokenId, TransactionId}
-import org.alephium.util.U256
+import org.alephium.util.{TimeStamp, U256}
 
 trait EmptyTransactionService extends TransactionService {
   override def getTransaction(transactionHash: TransactionId)(
@@ -46,6 +45,14 @@ trait EmptyTransactionService extends TransactionService {
     Future.successful(0)
 
   override def getTransactionsByAddressSQL(address: Address, pagination: Pagination)(
+      implicit ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]] =
+    Future.successful(ArraySeq.empty)
+
+  override def getTransactionsByAddressTimeRangedSQL(address: Address,
+                                                     fromTime: TimeStamp,
+                                                     toTime: TimeStamp,
+                                                     pagination: Pagination)(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]] =
     Future.successful(ArraySeq.empty)

--- a/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/TransactionsPerAddressReadState.scala
+++ b/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/TransactionsPerAddressReadState.scala
@@ -1,0 +1,87 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.benchmark.db.state
+
+import org.openjdk.jmh.annotations.{Scope, State}
+import org.scalacheck.Gen
+
+import org.alephium.explorer.GenApiModel._
+import org.alephium.explorer.GenDBModel._
+import org.alephium.explorer.api.model.Address
+import org.alephium.explorer.benchmark.db.{DBConnectionPool, DBExecutor}
+import org.alephium.explorer.benchmark.db.BenchmarkSettings._
+import org.alephium.explorer.persistence.model.TransactionPerAddressEntity
+import org.alephium.explorer.persistence.schema.TransactionPerAddressSchema
+import org.alephium.util.TimeStamp
+
+/**
+  * @param addressCount                  Number of Address to generated
+  * @param transactionsPerAddress        Number of Transactions to create per Address with unique `block_timestamp`.
+  *                                      This implies 1 transactions per block.
+  * @param transactionsPerAddressPerDay  Number of Transactions to create per Address with same `block_timestamp`
+  *                                      This implies multiple transactions per block.
+  */
+@State(Scope.Thread)
+@SuppressWarnings(Array("org.wartremover.warts.Overloading"))
+class TransactionsPerAddressReadState(val addressCount: Int,
+                                      val transactionsPerAddress: Int,
+                                      val transactionsPerAddressPerDay: Int,
+                                      val db: DBExecutor)
+    extends ReadBenchmarkState[String](addressCount, db) {
+
+  import config.profile.api._
+
+  def this() =
+    this(
+      addressCount                 = 1,
+      transactionsPerAddress       = 10000,
+      transactionsPerAddressPerDay = 5,
+      db                           = DBExecutor(dbName, dbHost, dbPort, DBConnectionPool.Disabled)
+    )
+
+  override def generateData(currentCacheSize: Int): String =
+    addressGen.sample.get.value
+
+  private def genTransactions(address: String): Seq[TransactionPerAddressEntity] =
+    (0 to transactionsPerAddress) flatMap { timeStamp =>
+      val transactionsPerDayGen =
+        genTransactionPerAddressEntity(
+          addressGen   = Gen.const(Address.unsafe(address)),
+          timestampGen = Gen.const(TimeStamp.unsafe(timeStamp.toLong))
+        )
+
+      Gen.listOfN(transactionsPerAddressPerDay, transactionsPerDayGen).sample.get
+    }
+
+  override def persist(addresses: Array[String]): Unit = {
+    //start a fresh database (TODO: moved these to TestQueries)
+    val _ = db.dropTableIfExists(TransactionPerAddressSchema.table)
+    val _ = db.runNow(TransactionPerAddressSchema.table.schema.create, batchWriteTimeout)
+
+    //generate data for all addresses
+    addresses.zipWithIndex foreach {
+      case (address, addressIndex) =>
+        val transactionsForThisAddress = genTransactions(address)
+        logger.info(s"Persisting addresses: ${addressIndex + 1}/${addresses.length}")
+        val action = TransactionPerAddressSchema.table ++= transactionsForThisAddress
+        db.runNow(action, batchWriteTimeout)
+    }
+
+    logger.info("Persisting data complete")
+  }
+
+}


### PR DESCRIPTION
- First version for #375
- Pagination was required so backend does not allow large limits to go through. `100000` being the max limit. Defaults to `20` just like other APIs (Uses existing pagination code). 
- Added `TestQueries` for issue #368. Didn't seem like it was nice to add queries like `clearTable()` to production code. Will update that issue's description if you ok with this.
- Is there a tool that generates `explorer-backend-openapi.json`? Updated this one here by hand.

`/addresses/[address]/timeranged-transactions?fromTs=x&toTs=y`
OR
`/addresses/[address]/timeranged-transactions?fromTs=x&toTs=y&limit=100000`
OR 
`/addresses/[address]/timeranged-transactions?fromTs=x&toTs=y&limit=100000&page=1`