### PR TITLE
#337: Implements `WriteOnly`/`SyncOnly` mode

### DIFF
--- a/app/src/main/resources/application.conf
+++ b/app/src/main/resources/application.conf
@@ -12,7 +12,7 @@ explorer {
     # WriteOnly = Starts Explorer in write-only mode
     # ReadWrite = Starts Explorer in read-write mode
     boot-mode = ReadWrite
-    boot-mode = ${?EXPLORER_READONLY}
+    boot-mode = ${?EXPLORER_BOOT_MODE}
 
     # Sync interval for BlockFlowSyncService & MempoolSyncService
     sync-period = 5 seconds

--- a/app/src/main/resources/application.conf
+++ b/app/src/main/resources/application.conf
@@ -8,10 +8,11 @@ explorer {
     host = "localhost"
     host = ${?EXPLORER_HOST}
 
-    # true = Starts Explorer in read-only mode
-    # false = Starts Explorer in read-write mode
-    read-only = false
-    read-only = ${?EXPLORER_READONLY}
+    # ReadOnly = Starts Explorer in read-only mode
+    # WriteOnly = Starts Explorer in write-only mode
+    # ReadWrite = Starts Explorer in read-write mode
+    boot-mode = ReadWrite
+    boot-mode = ${?EXPLORER_READONLY}
 
     # Sync interval for BlockFlowSyncService & MempoolSyncService
     sync-period = 5 seconds

--- a/app/src/main/scala/org/alephium/explorer/config/BootMode.scala
+++ b/app/src/main/scala/org/alephium/explorer/config/BootMode.scala
@@ -1,0 +1,57 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.config
+
+import scala.util.{Failure, Success, Try}
+
+import org.alephium.explorer.error.ExplorerError.InvalidBootMode
+
+/** Configures Explorer's boot-up */
+sealed trait BootMode {
+  def productPrefix: String
+}
+
+object BootMode {
+
+  /** [[BootMode]]s with reads enabled */
+  sealed trait Readable extends BootMode
+
+  /** Serve HTTP requests only. Disables Sync. */
+  case object ReadOnly extends Readable
+
+  /** Enables both Read and Sync */
+  case object ReadWrite extends Readable
+
+  /** Enables Sync only */
+  case object WriteOnly extends BootMode
+
+  /** All boot modes */
+  def all: Array[BootMode] =
+    Array(ReadOnly, ReadWrite, WriteOnly)
+
+  /** @return [[BootMode]] that matches [[BootMode.productPrefix]] */
+  def apply(mode: String): Option[BootMode] =
+    all.find(_.productPrefix == mode)
+
+  /** @return [[BootMode]] if found else fails */
+  def validate(mode: String): Try[BootMode] =
+    BootMode(mode) match {
+      case Some(mode) => Success(mode)
+      case None       => Failure(InvalidBootMode(mode))
+    }
+
+}

--- a/app/src/main/scala/org/alephium/explorer/config/ExplorerConfig.scala
+++ b/app/src/main/scala/org/alephium/explorer/config/ExplorerConfig.scala
@@ -103,6 +103,11 @@ object ExplorerConfig {
       validateSyncPeriod(input).get
     }
 
+  implicit val bootUpMode: ValueReader[BootMode] =
+    ValueReader[String](Ficus.stringValueReader).map { input =>
+      BootMode.validate(input).get
+    }
+
   implicit val explorerConfigReader: ValueReader[ExplorerConfig] =
     valueReader { implicit cfg =>
       val explorer  = as[Explorer]("explorer")
@@ -122,7 +127,7 @@ object ExplorerConfig {
           blockflow.apiKey,
           host,
           port,
-          explorer.readOnly,
+          explorer.bootMode,
           explorer.syncPeriod,
           explorer.tokenSupplyServiceSyncPeriod,
           explorer.hashRateServiceSyncPeriod,
@@ -144,7 +149,7 @@ object ExplorerConfig {
 
   private final case class Explorer(host: String,
                                     port: Int,
-                                    readOnly: Boolean,
+                                    bootMode: BootMode,
                                     syncPeriod: FiniteDuration,
                                     tokenSupplyServiceSyncPeriod: FiniteDuration,
                                     hashRateServiceSyncPeriod: FiniteDuration,
@@ -165,7 +170,7 @@ final case class ExplorerConfig private (groupNum: Int,
                                          maybeBlockFlowApiKey: Option[ApiKey],
                                          host: String,
                                          port: Int,
-                                         readOnly: Boolean,
+                                         bootMode: BootMode,
                                          syncPeriod: FiniteDuration,
                                          tokenSupplyServiceSyncPeriod: FiniteDuration,
                                          hashRateServiceSyncPeriod: FiniteDuration,

--- a/app/src/main/scala/org/alephium/explorer/error/ExplorerError.scala
+++ b/app/src/main/scala/org/alephium/explorer/error/ExplorerError.scala
@@ -21,6 +21,7 @@ import scala.concurrent.duration.FiniteDuration
 import sttp.model.Uri
 
 import org.alephium.explorer.api.model.GroupIndex
+import org.alephium.explorer.config.BootMode
 import org.alephium.explorer.persistence.model.BlockEntity
 import org.alephium.protocol.model.{BlockHash, NetworkId}
 import org.alephium.util.TimeStamp
@@ -95,6 +96,11 @@ object ExplorerError {
 
   final case class InvalidSyncPeriod(syncPeriod: FiniteDuration)
       extends Exception(s"Invalid syncPeriod: ${syncPeriod.toString}. Sync-period must be > 0.")
+      with ConfigError
+
+  final case class InvalidBootMode(mode: String)
+      extends Exception(
+        s"Invalid boot-mode: $mode. Valid modes are: ${BootMode.all.map(_.productPrefix).mkString(", ")}.")
       with ConfigError
 
   object BlocksInDifferentChains {

--- a/app/src/test/scala/org/alephium/explorer/config/BootModeSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/config/BootModeSpec.scala
@@ -1,0 +1,45 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.config
+
+import scala.util.{Failure, Success}
+
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+
+import org.alephium.explorer.AlephiumSpec
+import org.alephium.explorer.error.ExplorerError.InvalidBootMode
+
+class BootModeSpec extends AlephiumSpec with ScalaCheckDrivenPropertyChecks {
+
+  "validate" should {
+    "fail" when {
+      "input mode is invalid" in {
+        forAll { mode: String =>
+          BootMode.validate(mode) is Failure(InvalidBootMode(mode))
+        }
+      }
+    }
+
+    "succeed" when {
+      "input mode is valid" in {
+        BootMode.all foreach { mode =>
+          BootMode.validate(mode.productPrefix) is Success(mode)
+        }
+      }
+    }
+  }
+}

--- a/app/src/test/scala/org/alephium/explorer/persistence/DatabaseSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/DatabaseSpec.scala
@@ -25,6 +25,7 @@ import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
 
 import org.alephium.explorer.AlephiumSpec
+import org.alephium.explorer.config.BootMode
 
 /** Temporary placeholder. These tests should be merged into ApplicationSpec  */
 class DatabaseSpec extends AlephiumSpec with ScalaFutures {
@@ -39,7 +40,7 @@ class DatabaseSpec extends AlephiumSpec with ScalaFutures {
       "readOnly mode" in {
         val databaseConfig = DatabaseConfig.forConfig[PostgresProfile]("db", DatabaseFixture.config)
         val database: Database =
-          new Database(readOnly = true)(executionContext, databaseConfig)
+          new Database(BootMode.ReadOnly)(executionContext, databaseConfig)
 
         Try(database.startSelfOnce().futureValue) is Success(())
       }
@@ -47,7 +48,7 @@ class DatabaseSpec extends AlephiumSpec with ScalaFutures {
       "readWrite mode" in {
         val databaseConfig = DatabaseConfig.forConfig[PostgresProfile]("db", DatabaseFixture.config)
         val database: Database =
-          new Database(readOnly = false)(executionContext, databaseConfig)
+          new Database(BootMode.ReadWrite)(executionContext, databaseConfig)
 
         Try(database.startSelfOnce().futureValue) is Success(())
       }

--- a/app/src/test/scala/org/alephium/explorer/web/InfosServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/InfosServerSpec.scala
@@ -27,6 +27,7 @@ import org.alephium.explorer.Generators._
 import org.alephium.explorer.HttpFixture._
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.cache.{BlockCache, TransactionCache}
+import org.alephium.explorer.config.BootMode
 import org.alephium.explorer.persistence.{Database, DatabaseFixtureForAll}
 import org.alephium.explorer.service._
 import org.alephium.protocol.ALPH
@@ -78,9 +79,10 @@ class InfosServerSpec()
       Future.successful(ArraySeq(blockTime))
   }
 
-  implicit val groupSetting: GroupSetting         = groupSettingGen.sample.get
-  implicit val blockCache: BlockCache             = BlockCache()
-  implicit val transactionCache: TransactionCache = TransactionCache(new Database(false))
+  implicit val groupSetting: GroupSetting = groupSettingGen.sample.get
+  implicit val blockCache: BlockCache     = BlockCache()
+  implicit val transactionCache: TransactionCache = TransactionCache(
+    new Database(BootMode.ReadWrite))
   val transactionService = new EmptyTransactionService {
     override def getTotalNumber()(implicit cache: TransactionCache): Int = 10
   }

--- a/app/src/test/scala/org/alephium/explorer/web/UtilsServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/UtilsServerSpec.scala
@@ -25,6 +25,7 @@ import org.alephium.explorer._
 import org.alephium.explorer.HttpFixture._
 import org.alephium.explorer.api.model.LogbackValue
 import org.alephium.explorer.cache.{BlockCache, TransactionCache}
+import org.alephium.explorer.config.BootMode
 import org.alephium.explorer.persistence.{Database, DatabaseFixtureForAll}
 import org.alephium.explorer.service._
 import org.alephium.json.Json
@@ -37,10 +38,11 @@ class UtilsServerSpec()
     with HttpServerFixture
     with MockFactory {
 
-  implicit val blockFlowClient: BlockFlowClient   = mock[BlockFlowClient]
-  implicit val groupSettings: GroupSetting        = Generators.groupSettingGen.sample.get
-  implicit val blockCache: BlockCache             = BlockCache()
-  implicit val transactionCache: TransactionCache = TransactionCache(new Database(false))
+  implicit val blockFlowClient: BlockFlowClient = mock[BlockFlowClient]
+  implicit val groupSettings: GroupSetting      = Generators.groupSettingGen.sample.get
+  implicit val blockCache: BlockCache           = BlockCache()
+  implicit val transactionCache: TransactionCache = TransactionCache(
+    new Database(BootMode.ReadWrite))
 
   val utilsServer =
     new UtilsServer()


### PR DESCRIPTION
- Resolves #337
- Added `WriteOnly` (or `SyncOnly` mode). Named it `WriteOnly` to follow the existing naming convention. 
- Uses `ExecutionContext.Implicits.global` for `WriteOnly` mode since `ActorSystem` is not available.

## Configuration

```properties
# ReadOnly = Starts Explorer in read-only mode
# WriteOnly = Starts Explorer in write-only mode
# ReadWrite = Starts Explorer in read-write mode
boot-mode = WriteOnly
```