### PR TITLE
#299: Endpoint to fetch transactions for a list of addresses

### DIFF
--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -762,6 +762,140 @@
         }
       }
     },
+    "/addresses/transactions": {
+      "post": {
+        "tags": [
+          "Addresses"
+        ],
+        "description": "List transactions for given addresses",
+        "operationId": "postAddressesTransactions",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number per page",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "reverse",
+            "in": "query",
+            "description": "Reverse pagination",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "maxItems": 80
+              }
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Transaction"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequest"
+                },
+                "example": {
+                  "detail": "Something bad in the request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unauthorized"
+                },
+                "example": {
+                  "detail": "You shall not pass"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFound"
+                },
+                "example": {
+                  "resource": "wallet-name",
+                  "detail": "wallet-name not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                },
+                "example": {
+                  "detail": "Ouch"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailable"
+                },
+                "example": {
+                  "detail": "Self clique unsynced"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/addresses/{address}/timeranged-transactions": {
       "get": {
         "tags": [

--- a/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
@@ -71,6 +71,15 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
       .out(jsonBody[ArraySeq[Transaction]])
       .description("List transactions of a given address")
 
+  lazy val getTransactionsByAddresses
+    : BaseEndpoint[(ArraySeq[Address], Pagination), ArraySeq[Transaction]] =
+    addressesEndpoint.post
+      .in(jsonBody[ArraySeq[Address]].validate(Validator.maxSize(activeAddressesMaxSize)))
+      .in("transactions")
+      .in(pagination)
+      .out(jsonBody[ArraySeq[Transaction]])
+      .description("List transactions for given addresses")
+
   val getTransactionsByAddressTimeRanged
     : BaseEndpoint[(Address, TimeInterval, Pagination), ArraySeq[Transaction]] =
     addressesEndpoint.get

--- a/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
+++ b/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
@@ -40,6 +40,7 @@ trait Documentation
       getOutputRefTransaction,
       getAddressInfo,
       getTransactionsByAddress,
+      getTransactionsByAddresses,
       getTransactionsByAddressTimeRanged,
       getTotalTransactionsByAddress,
       addressUnconfirmedTransactions,

--- a/app/src/main/scala/org/alephium/explorer/persistence/dao/TransactionDao.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/dao/TransactionDao.scala
@@ -51,6 +51,11 @@ object TransactionDao {
       dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]] =
     run(getTransactionsByAddressSQL(address, pagination))
 
+  def getByAddresses(addresses: ArraySeq[Address], pagination: Pagination)(
+      implicit ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]] =
+    run(getTransactionsByAddresses(addresses, pagination))
+
   def getByAddressTimeRangedSQL(address: Address,
                                 fromTime: TimeStamp,
                                 toTime: TimeStamp,

--- a/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
@@ -53,6 +53,10 @@ trait TransactionService {
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]]
 
+  def getTransactionsByAddresses(addresses: ArraySeq[Address], pagination: Pagination)(
+      implicit ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]]
+
   def listUnconfirmedTransactionsByAddress(address: Address)(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[UnconfirmedTransaction]]
@@ -132,6 +136,11 @@ object TransactionService extends TransactionService {
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]] =
     TransactionDao.getByAddressTimeRangedSQL(address, fromTime, toTime, pagination)
+
+  def getTransactionsByAddresses(addresses: ArraySeq[Address], pagination: Pagination)(
+      implicit ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]] =
+    TransactionDao.getByAddresses(addresses, pagination)
 
   def listUnconfirmedTransactionsByAddress(address: Address)(
       implicit ec: ExecutionContext,

--- a/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
@@ -44,6 +44,11 @@ class AddressServer(transactionService: TransactionService)(
           transactionService
             .getTransactionsByAddress(address, pagination)
       }),
+      route(getTransactionsByAddresses.serverLogicSuccess[Future] {
+        case (addresses, pagination) =>
+          transactionService
+            .getTransactionsByAddresses(addresses, pagination)
+      }),
       route(getTransactionsByAddressDEPRECATED.serverLogicSuccess[Future] {
         case (address, pagination) =>
           transactionService

--- a/app/src/test/scala/org/alephium/explorer/ExplorerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/ExplorerSpec.scala
@@ -293,6 +293,25 @@ trait ExplorerSpec
     }
   }
 
+  "get all transactions for addresses" in {
+    forAll(Gen.someOf(transactions)) { transactions =>
+      val limitedAddresses = transactions.flatMap(_.outputs.map(_.address)).take(txLimit)
+      val addressesBody    = limitedAddresses.map(address => s""""$address"""").mkString("[", ",", "]")
+
+      Post("/addresses/transactions", addressesBody) check { response =>
+        val expectedTransactions =
+          transactions.filter(_.outputs.exists(limitedAddresses.contains)).take(txLimit)
+
+        val res = response.as[ArraySeq[Transaction]]
+
+        res.size is limitedAddresses.size
+        Inspectors.forAll(expectedTransactions) { transaction =>
+          res.map(_.hash) should contain(transaction.hash)
+        }
+      }
+    }
+  }
+
   "generate the documentation" in {
     Get("/docs") check { response =>
       response.code is StatusCode.Ok

--- a/app/src/test/scala/org/alephium/explorer/service/EmptyTransactionService.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/EmptyTransactionService.scala
@@ -49,6 +49,11 @@ trait EmptyTransactionService extends TransactionService {
       dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]] =
     Future.successful(ArraySeq.empty)
 
+  override def getTransactionsByAddresses(addresses: ArraySeq[Address], pagination: Pagination)(
+      implicit ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]] =
+    Future.successful(ArraySeq.empty)
+
   override def getTransactionsByAddressTimeRangedSQL(address: Address,
                                                      fromTime: TimeStamp,
                                                      toTime: TimeStamp,


### PR DESCRIPTION
- Resolves #299
- Following `areAddressesActive` this endpoint is also a `POST` request. 
  - Endpoint: `/addresses/transactions`
  - Requires an array of addresses as JSON body `["address1", "address2"]`
