### PR TITLE
#386: Configure low cache timeout for test-cases

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/cache/BlockCache.scala
+++ b/app/src/main/scala/org/alephium/explorer/cache/BlockCache.scala
@@ -52,9 +52,11 @@ object BlockCache {
   }
 
   // scalastyle:off
-  def apply()(implicit groupSetting: GroupSetting,
-              ec: ExecutionContext,
-              dc: DatabaseConfig[PostgresProfile]): BlockCache = {
+  @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
+  def apply(cacheRowCountReloadTime: FiniteDuration = 10.seconds)(
+      implicit groupSetting: GroupSetting,
+      ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile]): BlockCache = {
     val groupConfig: GroupConfig = groupSetting.groupConfig
 
     @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
@@ -97,8 +99,9 @@ object BlockCache {
           .buildAsync[ChainIndex, Duration](blockTimeAsyncLoader)
       }
 
-    val cacheRowCount: AsyncReloadingCache[Int] = AsyncReloadingCache(0, 10.seconds) { _ =>
-      run(BlockQueries.mainChainQuery.length.result)
+    val cacheRowCount: AsyncReloadingCache[Int] = AsyncReloadingCache(0, cacheRowCountReloadTime) {
+      _ =>
+        run(BlockQueries.mainChainQuery.length.result)
     }
 
     new BlockCache(

--- a/app/src/test/scala/org/alephium/explorer/persistence/dao/BlockDaoSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/dao/BlockDaoSpec.scala
@@ -16,6 +16,7 @@
 
 package org.alephium.explorer.persistence.dao
 
+import scala.concurrent.duration._
 import scala.io.{Codec, Source}
 import scala.util.Random
 
@@ -248,7 +249,7 @@ class BlockDaoSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with D
 
   trait Fixture extends ApiModelCodec {
     implicit val groupSettings: GroupSetting = groupSettingGen.sample.get
-    implicit val blockCache: BlockCache      = BlockCache()
+    implicit val blockCache: BlockCache      = BlockCache(cacheRowCountReloadTime = 1.second)
 
     val blockflow: Seq[Seq[model.BlockEntry]] =
       blockFlowGen(maxChainSize = 5, startTimestamp = TimeStamp.now()).sample.get


### PR DESCRIPTION
- First PR for #386
- As you mentioned in the issue, the cache is the problem. Cache timeout being 10.second caused delayed test completion. This reduces cache timeout to `1.second` for test-cases. 
- Rough benchmarks
  - Test that took 1 minute 21 seconds now finishes in 22 seconds
  - Test that took 3 minutes 2 seconds now finishes in 43 seconds
     - Out of the 43 seconds, roughly 30 second are used by data generation `genBlockEntityWithOptionalParent()`
     
If you are ok with this change, will replicate it for other caches and test-cases accessing `BlockCache`.