### PR TITLE
#386: Move cache time period configuration to `application.conf`

### DIFF
--- a/app/src/main/resources/application.conf
+++ b/app/src/main/resources/application.conf
@@ -33,6 +33,11 @@ explorer {
     # Sync interval for TransactionHistoryService
     transaction-history-service-sync-period = 15 minutes
     transaction-history-service-sync-period = ${?EXPLORER_TRANSACTION_HISTORY_SERVICE_SYNC_PERIOD}
+
+    # Cache reloading intervals for BlockCache
+    cache-row-count-reload-period = 10 seconds
+    cache-block-times-reload-period = 5 seconds
+    cache-latest-blocks-reload-period = 5 seconds
 }
 
 blockflow {

--- a/app/src/main/scala/org/alephium/explorer/ExplorerState.scala
+++ b/app/src/main/scala/org/alephium/explorer/ExplorerState.scala
@@ -47,7 +47,11 @@ sealed trait ExplorerState extends Service with StrictLogging {
     new Database(config.bootMode)(executionContext, databaseConfig)
 
   implicit lazy val blockCache: BlockCache =
-    BlockCache()(groupSettings, executionContext, database.databaseConfig)
+    BlockCache(config.cacheRowCountReloadPeriod,
+               config.cacheBlockTimesReloadPeriod,
+               config.cacheLatestBlocksReloadPeriod)(groupSettings,
+                                                     executionContext,
+                                                     database.databaseConfig)
 
   lazy val transactionCache: TransactionCache =
     TransactionCache(database)(executionContext)

--- a/app/src/main/scala/org/alephium/explorer/config/ExplorerConfig.scala
+++ b/app/src/main/scala/org/alephium/explorer/config/ExplorerConfig.scala
@@ -132,7 +132,10 @@ object ExplorerConfig {
           explorer.tokenSupplyServiceSyncPeriod,
           explorer.hashRateServiceSyncPeriod,
           explorer.finalizerServiceSyncPeriod,
-          explorer.transactionHistoryServiceSyncPeriod
+          explorer.transactionHistoryServiceSyncPeriod,
+          explorer.cacheRowCountReloadPeriod,
+          explorer.cacheBlockTimesReloadPeriod,
+          explorer.cacheLatestBlocksReloadPeriod
         )
       }).get
     }
@@ -154,7 +157,10 @@ object ExplorerConfig {
                                     tokenSupplyServiceSyncPeriod: FiniteDuration,
                                     hashRateServiceSyncPeriod: FiniteDuration,
                                     finalizerServiceSyncPeriod: FiniteDuration,
-                                    transactionHistoryServiceSyncPeriod: FiniteDuration)
+                                    transactionHistoryServiceSyncPeriod: FiniteDuration,
+                                    cacheRowCountReloadPeriod: FiniteDuration,
+                                    cacheBlockTimesReloadPeriod: FiniteDuration,
+                                    cacheLatestBlocksReloadPeriod: FiniteDuration)
 }
 
 /**
@@ -175,4 +181,7 @@ final case class ExplorerConfig private (groupNum: Int,
                                          tokenSupplyServiceSyncPeriod: FiniteDuration,
                                          hashRateServiceSyncPeriod: FiniteDuration,
                                          finalizerServiceSyncPeriod: FiniteDuration,
-                                         transactionHistoryServiceSyncPeriod: FiniteDuration)
+                                         transactionHistoryServiceSyncPeriod: FiniteDuration,
+                                         cacheRowCountReloadPeriod: FiniteDuration,
+                                         cacheBlockTimesReloadPeriod: FiniteDuration,
+                                         cacheLatestBlocksReloadPeriod: FiniteDuration)

--- a/app/src/test/scala/org/alephium/explorer/cache/TestBlockCache.scala
+++ b/app/src/test/scala/org/alephium/explorer/cache/TestBlockCache.scala
@@ -1,0 +1,40 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.cache
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+import slick.basic.DatabaseConfig
+import slick.jdbc.PostgresProfile
+
+import org.alephium.explorer.GroupSetting
+
+object TestBlockCache {
+
+  /**
+    * @return Test instance of [[BlockCache]] for faster cache reloads
+    *         than configured periods in `application.conf`
+    * */
+  def apply()(implicit groupSetting: GroupSetting,
+              ec: ExecutionContext,
+              dc: DatabaseConfig[PostgresProfile]): BlockCache =
+    BlockCache(cacheRowCountReloadPeriod     = 1.second,
+               cacheBlockTimesReloadPeriod   = 1.second,
+               cacheLatestBlocksReloadPeriod = 1.second)
+
+}

--- a/app/src/test/scala/org/alephium/explorer/persistence/dao/BlockDaoSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/dao/BlockDaoSpec.scala
@@ -16,7 +16,6 @@
 
 package org.alephium.explorer.persistence.dao
 
-import scala.concurrent.duration._
 import scala.io.{Codec, Source}
 import scala.util.Random
 
@@ -30,7 +29,7 @@ import org.alephium.explorer.GenApiModel._
 import org.alephium.explorer.GenDBModel._
 import org.alephium.explorer.Generators._
 import org.alephium.explorer.api.model.{GroupIndex, Pagination}
-import org.alephium.explorer.cache.BlockCache
+import org.alephium.explorer.cache.{BlockCache, TestBlockCache}
 import org.alephium.explorer.persistence.{DatabaseFixtureForEach, DBRunner}
 import org.alephium.explorer.persistence.model._
 import org.alephium.explorer.persistence.queries.InputUpdateQueries
@@ -249,7 +248,7 @@ class BlockDaoSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with D
 
   trait Fixture extends ApiModelCodec {
     implicit val groupSettings: GroupSetting = groupSettingGen.sample.get
-    implicit val blockCache: BlockCache      = BlockCache(cacheRowCountReloadTime = 1.second)
+    implicit val blockCache: BlockCache      = TestBlockCache()
 
     val blockflow: Seq[Seq[model.BlockEntry]] =
       blockFlowGen(maxChainSize = 5, startTimestamp = TimeStamp.now()).sample.get

--- a/app/src/test/scala/org/alephium/explorer/service/BlockFlowSyncServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/BlockFlowSyncServiceSpec.scala
@@ -28,7 +28,7 @@ import org.alephium.explorer.GenApiModel.chainIndexes
 import org.alephium.explorer.GenCoreUtil.timestampMaxValue
 import org.alephium.explorer.Generators._
 import org.alephium.explorer.api.model._
-import org.alephium.explorer.cache.BlockCache
+import org.alephium.explorer.cache.{BlockCache, TestBlockCache}
 import org.alephium.explorer.persistence.DatabaseFixtureForAll
 import org.alephium.explorer.persistence.dao.BlockDao
 import org.alephium.explorer.persistence.model._
@@ -174,7 +174,7 @@ class BlockFlowSyncServiceSpec extends AlephiumFutureSpec with DatabaseFixtureFo
     def blockFlow: ArraySeq[ArraySeq[BlockEntry]] =
       blockEntitiesToBlockEntries(blockFlowEntity)
 
-    implicit val blockCache: BlockCache = BlockCache()
+    implicit val blockCache: BlockCache = TestBlockCache()
 
     def blockEntities = ArraySeq.from(blockFlowEntity.flatten)
 

--- a/app/src/test/scala/org/alephium/explorer/service/TokenSupplyServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TokenSupplyServiceSpec.scala
@@ -26,7 +26,7 @@ import org.alephium.explorer.{AlephiumFutureSpec, GroupSetting}
 import org.alephium.explorer.GenApiModel.transactionHashGen
 import org.alephium.explorer.Generators._
 import org.alephium.explorer.api.model._
-import org.alephium.explorer.cache.BlockCache
+import org.alephium.explorer.cache.{BlockCache, TestBlockCache}
 import org.alephium.explorer.persistence._
 import org.alephium.explorer.persistence.dao.BlockDao
 import org.alephium.explorer.persistence.model._
@@ -153,7 +153,7 @@ class TokenSupplyServiceSpec extends AlephiumFutureSpec with DatabaseFixtureForE
     val block1Locked: Boolean = false
 
     implicit val groupSettings: GroupSetting = GroupSetting(1)
-    implicit val blockCache: BlockCache      = BlockCache()
+    implicit val blockCache: BlockCache      = TestBlockCache()
 
     val genesisAddress = Address.unsafe("122uvHwwcaWoXR1ryub9VK1yh2CZvYCqXxzsYDHRb2jYB")
 

--- a/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
@@ -27,7 +27,7 @@ import org.alephium.explorer.{AlephiumFutureSpec, GroupSetting}
 import org.alephium.explorer.GenApiModel._
 import org.alephium.explorer.Generators._
 import org.alephium.explorer.api.model._
-import org.alephium.explorer.cache.BlockCache
+import org.alephium.explorer.cache.{BlockCache, TestBlockCache}
 import org.alephium.explorer.persistence.DatabaseFixtureForEach
 import org.alephium.explorer.persistence.dao.{BlockDao, UnconfirmedTxDao}
 import org.alephium.explorer.persistence.model._
@@ -454,7 +454,7 @@ class TransactionServiceSpec extends AlephiumFutureSpec with DatabaseFixtureForE
 
   trait Fixture {
     implicit val groupSetting: GroupSetting = groupSettingGen.sample.get
-    implicit val blockCache: BlockCache     = BlockCache()
+    implicit val blockCache: BlockCache     = TestBlockCache()
 
     val groupIndex = GroupIndex.unsafe(0)
 

--- a/app/src/test/scala/org/alephium/explorer/web/InfosServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/InfosServerSpec.scala
@@ -26,7 +26,7 @@ import org.alephium.explorer._
 import org.alephium.explorer.Generators._
 import org.alephium.explorer.HttpFixture._
 import org.alephium.explorer.api.model._
-import org.alephium.explorer.cache.{BlockCache, TransactionCache}
+import org.alephium.explorer.cache.{BlockCache, TestBlockCache, TransactionCache}
 import org.alephium.explorer.config.BootMode
 import org.alephium.explorer.persistence.{Database, DatabaseFixtureForAll}
 import org.alephium.explorer.service._
@@ -80,7 +80,7 @@ class InfosServerSpec()
   }
 
   implicit val groupSetting: GroupSetting = groupSettingGen.sample.get
-  implicit val blockCache: BlockCache     = BlockCache()
+  implicit val blockCache: BlockCache     = TestBlockCache()
   implicit val transactionCache: TransactionCache = TransactionCache(
     new Database(BootMode.ReadWrite))
   val transactionService = new EmptyTransactionService {

--- a/app/src/test/scala/org/alephium/explorer/web/UtilsServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/UtilsServerSpec.scala
@@ -23,7 +23,7 @@ import org.alephium.api.ApiError
 import org.alephium.explorer._
 import org.alephium.explorer.HttpFixture._
 import org.alephium.explorer.api.model.LogbackValue
-import org.alephium.explorer.cache.{BlockCache, TransactionCache}
+import org.alephium.explorer.cache.{BlockCache, TestBlockCache, TransactionCache}
 import org.alephium.explorer.config.BootMode
 import org.alephium.explorer.persistence.{Database, DatabaseFixtureForAll}
 import org.alephium.explorer.service._
@@ -38,7 +38,7 @@ class UtilsServerSpec()
 
   implicit val blockFlowClient: BlockFlowClient = mock[BlockFlowClient]
   implicit val groupSettings: GroupSetting      = Generators.groupSettingGen.sample.get
-  implicit val blockCache: BlockCache           = BlockCache()
+  implicit val blockCache: BlockCache           = TestBlockCache()
   implicit val transactionCache: TransactionCache = TransactionCache(
     new Database(BootMode.ReadWrite))
 

--- a/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/BlockEntityWriteState.scala
+++ b/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/BlockEntityWriteState.scala
@@ -25,7 +25,7 @@ import slick.jdbc.PostgresProfile
 import org.alephium.explorer.GroupSetting
 import org.alephium.explorer.benchmark.db.{DataGenerator, DBConnectionPool, DBExecutor}
 import org.alephium.explorer.benchmark.db.BenchmarkSettings._
-import org.alephium.explorer.cache.BlockCache
+import org.alephium.explorer.cache.{BlockCache, TestBlockCache}
 import org.alephium.explorer.persistence.DBInitializer
 import org.alephium.explorer.persistence.model.BlockEntity
 import org.alephium.util.Duration
@@ -42,7 +42,7 @@ class BlockEntityWriteState(val db: DBExecutor) extends WriteBenchmarkState[Bloc
     GroupSetting(4)
 
   val blockCache: BlockCache =
-    BlockCache()(
+    TestBlockCache()(
       groupSetting = groupSetting,
       ec           = config.db.ioExecutionContext,
       dc           = db.config

--- a/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/ListBlocksReadState.scala
+++ b/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/ListBlocksReadState.scala
@@ -29,7 +29,7 @@ import org.alephium.explorer.api.model._
 import org.alephium.explorer.benchmark.db.{DBConnectionPool, DBExecutor}
 import org.alephium.explorer.benchmark.db.BenchmarkSettings._
 import org.alephium.explorer.benchmark.db.state.ListBlocksReadStateSettings._
-import org.alephium.explorer.cache.BlockCache
+import org.alephium.explorer.cache.{BlockCache, TestBlockCache}
 import org.alephium.explorer.persistence.model.{BlockHeader, TransactionEntity}
 import org.alephium.explorer.persistence.schema.{BlockHeaderSchema, TransactionSchema}
 import org.alephium.protocol.model.{BlockHash, TransactionId}
@@ -49,7 +49,7 @@ class ListBlocksReadState(reverse: Boolean,
   import config.profile.api._
 
   val blockCache: BlockCache =
-    BlockCache()(
+    TestBlockCache()(
       groupSetting = GroupSetting(4),
       ec           = config.db.ioExecutionContext,
       dc           = db.config


### PR DESCRIPTION
- Implements [comment](https://github.com/alephium/explorer-backend/pull/390#discussion_r1026097268)
  - Moved `BlockCache` time reload periods to `application.conf`
  - For test-cases added `TestBlockCache` instead of a config file.
- Resolves #386