### PR TITLE
Fix `java.util.NoSuchElementException: None.get`

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/cache/BlockCache.scala
+++ b/app/src/main/scala/org/alephium/explorer/cache/BlockCache.scala
@@ -60,6 +60,14 @@ object BlockCache {
       dc: DatabaseConfig[PostgresProfile]): BlockCache = {
     val groupConfig: GroupConfig = groupSetting.groupConfig
 
+    /*
+     * `Option.get` is used to avoid unnecessary memory allocations.
+     * This cache is guaranteed to have data available for
+     * all chain-indexes after a single run of sync so `.get` would
+     * never fail after first few seconds after boot-up.
+     *
+     * @see Comments in PR <a href="https://github.com/alephium/explorer-backend/pull/393">#393</a>
+     */
     @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
     val latestBlockAsyncLoader: AsyncCacheLoader[ChainIndex, LatestBlock] = {
       case (key, _) =>


### PR DESCRIPTION
Calls to `BlockCache.getAllLatestBlocks` throw the following `NoSuchElementException` when the cache is empty or partially populated.

> java.util.NoSuchElementException: None.get
	at scala.None$.get(Option.scala:627)
	at scala.None$.get(Option.scala:626)
	at org.alephium.explorer.cache.BlockCache$.$anonfun$apply$2(BlockCache.scala:69)

This PR removes [this](https://github.com/alephium/explorer-backend/blob/09b30e9e7be13dd737da6036ac67fd56b7ee871e/app/src/main/scala/org/alephium/explorer/cache/BlockCache.scala#L69) call to `Option.get`.
