### PR TITLE
#388: `BlockEndpoints` and `ChartEndpoints` endpoints as `def`

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/api/BlockEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/BlockEndpoints.scala
@@ -22,33 +22,32 @@ import sttp.tapir._
 import sttp.tapir.generic.auto._
 
 import org.alephium.api.{alphJsonBody => jsonBody}
-import org.alephium.explorer.api.BaseEndpoint
 import org.alephium.explorer.api.model._
 import org.alephium.protocol.model.BlockHash
 
-trait BlockEndpoints extends BaseEndpoint with QueryParams {
+object BlockEndpoints extends BaseEndpoint with QueryParams {
 
-  private val blocksEndpoint =
+  private def blocksEndpoint() =
     baseEndpoint
       .tag("Blocks")
       .in("blocks")
 
-  val getBlockByHash: BaseEndpoint[BlockHash, BlockEntryLite] =
-    blocksEndpoint.get
+  def getBlockByHash(): BaseEndpoint[BlockHash, BlockEntryLite] =
+    blocksEndpoint().get
       .in(path[BlockHash]("block_hash"))
       .out(jsonBody[BlockEntryLite])
       .description("Get a block with hash")
 
-  val getBlockTransactions: BaseEndpoint[(BlockHash, Pagination), ArraySeq[Transaction]] =
-    blocksEndpoint.get
+  def getBlockTransactions(): BaseEndpoint[(BlockHash, Pagination), ArraySeq[Transaction]] =
+    blocksEndpoint().get
       .in(path[BlockHash]("block_hash"))
       .in("transactions")
       .in(pagination)
       .out(jsonBody[ArraySeq[Transaction]])
       .description("Get block's transactions")
 
-  val listBlocks: BaseEndpoint[Pagination, ListBlocks] =
-    blocksEndpoint.get
+  def listBlocks(): BaseEndpoint[Pagination, ListBlocks] =
+    blocksEndpoint().get
       .in(pagination)
       .out(jsonBody[ListBlocks])
       .description("List blocks within time interval")

--- a/app/src/main/scala/org/alephium/explorer/api/BlockEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/BlockEndpoints.scala
@@ -27,27 +27,27 @@ import org.alephium.protocol.model.BlockHash
 
 object BlockEndpoints extends BaseEndpoint with QueryParams {
 
-  private def blocksEndpoint() =
+  private def blocksEndpoint =
     baseEndpoint
       .tag("Blocks")
       .in("blocks")
 
-  def getBlockByHash(): BaseEndpoint[BlockHash, BlockEntryLite] =
-    blocksEndpoint().get
+  def getBlockByHash: BaseEndpoint[BlockHash, BlockEntryLite] =
+    blocksEndpoint.get
       .in(path[BlockHash]("block_hash"))
       .out(jsonBody[BlockEntryLite])
       .description("Get a block with hash")
 
-  def getBlockTransactions(): BaseEndpoint[(BlockHash, Pagination), ArraySeq[Transaction]] =
-    blocksEndpoint().get
+  def getBlockTransactions: BaseEndpoint[(BlockHash, Pagination), ArraySeq[Transaction]] =
+    blocksEndpoint.get
       .in(path[BlockHash]("block_hash"))
       .in("transactions")
       .in(pagination)
       .out(jsonBody[ArraySeq[Transaction]])
       .description("Get block's transactions")
 
-  def listBlocks(): BaseEndpoint[Pagination, ListBlocks] =
-    blocksEndpoint().get
+  def listBlocks: BaseEndpoint[Pagination, ListBlocks] =
+    blocksEndpoint.get
       .in(pagination)
       .out(jsonBody[ListBlocks])
       .description("List blocks within time interval")

--- a/app/src/main/scala/org/alephium/explorer/api/ChartsEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/ChartsEndpoints.scala
@@ -27,38 +27,37 @@ import org.alephium.explorer.api.model.{Hashrate, IntervalType, PerChainTimedCou
 
 object ChartsEndpoints extends BaseEndpoint with QueryParams {
 
-  def intervalTypes(): String = IntervalType.all.map(_.string).mkString(", ")
+  def intervalTypes: String = IntervalType.all.map(_.string).mkString(", ")
 
-  private def chartsEndpoint() =
+  private def chartsEndpoint =
     baseEndpoint
       .tag("Charts")
       .in("charts")
 
-  def getHashrates(): BaseEndpoint[(TimeInterval, IntervalType), ArraySeq[Hashrate]] =
-    chartsEndpoint().get
+  def getHashrates: BaseEndpoint[(TimeInterval, IntervalType), ArraySeq[Hashrate]] =
+    chartsEndpoint.get
       .in("hashrates")
       .in(timeIntervalQuery)
       .in(intervalTypeQuery)
       .out(jsonBody[ArraySeq[Hashrate]])
-      .description(s"`interval-type` query param: ${intervalTypes()}")
+      .description(s"`interval-type` query param: $intervalTypes")
       .summary("Get hashrate chart in H/s")
 
-  def getAllChainsTxCount(): BaseEndpoint[(TimeInterval, IntervalType), ArraySeq[TimedCount]] =
-    chartsEndpoint().get
+  def getAllChainsTxCount: BaseEndpoint[(TimeInterval, IntervalType), ArraySeq[TimedCount]] =
+    chartsEndpoint.get
       .in("transactions-count")
       .in(timeIntervalQuery)
       .in(intervalTypeQuery)
       .out(jsonBody[ArraySeq[TimedCount]])
-      .description(s"`interval-type` query param: ${intervalTypes()}")
+      .description(s"`interval-type` query param: $intervalTypes")
       .summary("Get transaction count history")
 
-  def getPerChainTxCount()
-    : BaseEndpoint[(TimeInterval, IntervalType), ArraySeq[PerChainTimedCount]] =
-    chartsEndpoint().get
+  def getPerChainTxCount: BaseEndpoint[(TimeInterval, IntervalType), ArraySeq[PerChainTimedCount]] =
+    chartsEndpoint.get
       .in("transactions-count-per-chain")
       .in(timeIntervalQuery)
       .in(intervalTypeQuery)
       .out(jsonBody[ArraySeq[PerChainTimedCount]])
-      .description(s"`interval-type` query param: ${intervalTypes()}")
+      .description(s"`interval-type` query param: $intervalTypes")
       .summary("Get transaction count history per chain")
 }

--- a/app/src/main/scala/org/alephium/explorer/api/ChartsEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/ChartsEndpoints.scala
@@ -23,43 +23,42 @@ import sttp.tapir.generic.auto._
 
 import org.alephium.api.{alphJsonBody => jsonBody}
 import org.alephium.api.model.TimeInterval
-import org.alephium.explorer.api.BaseEndpoint
 import org.alephium.explorer.api.model.{Hashrate, IntervalType, PerChainTimedCount, TimedCount}
 
-// scalastyle:off magic.number
-trait ChartsEndpoints extends BaseEndpoint with QueryParams {
+object ChartsEndpoints extends BaseEndpoint with QueryParams {
 
-  val intervalTypes: String = IntervalType.all.map(_.string).mkString(", ")
+  def intervalTypes(): String = IntervalType.all.map(_.string).mkString(", ")
 
-  private val chartsEndpoint =
+  private def chartsEndpoint() =
     baseEndpoint
       .tag("Charts")
       .in("charts")
 
-  val getHashrates: BaseEndpoint[(TimeInterval, IntervalType), ArraySeq[Hashrate]] =
-    chartsEndpoint.get
+  def getHashrates(): BaseEndpoint[(TimeInterval, IntervalType), ArraySeq[Hashrate]] =
+    chartsEndpoint().get
       .in("hashrates")
       .in(timeIntervalQuery)
       .in(intervalTypeQuery)
       .out(jsonBody[ArraySeq[Hashrate]])
-      .description(s"`interval-type` query param: $intervalTypes")
+      .description(s"`interval-type` query param: ${intervalTypes()}")
       .summary("Get hashrate chart in H/s")
 
-  val getAllChainsTxCount: BaseEndpoint[(TimeInterval, IntervalType), ArraySeq[TimedCount]] =
-    chartsEndpoint.get
+  def getAllChainsTxCount(): BaseEndpoint[(TimeInterval, IntervalType), ArraySeq[TimedCount]] =
+    chartsEndpoint().get
       .in("transactions-count")
       .in(timeIntervalQuery)
       .in(intervalTypeQuery)
       .out(jsonBody[ArraySeq[TimedCount]])
-      .description(s"`interval-type` query param: ${intervalTypes}")
+      .description(s"`interval-type` query param: ${intervalTypes()}")
       .summary("Get transaction count history")
 
-  val getPerChainTxCount: BaseEndpoint[(TimeInterval, IntervalType), ArraySeq[PerChainTimedCount]] =
-    chartsEndpoint.get
+  def getPerChainTxCount()
+    : BaseEndpoint[(TimeInterval, IntervalType), ArraySeq[PerChainTimedCount]] =
+    chartsEndpoint().get
       .in("transactions-count-per-chain")
       .in(timeIntervalQuery)
       .in(intervalTypeQuery)
       .out(jsonBody[ArraySeq[PerChainTimedCount]])
-      .description(s"`interval-type` query param: ${intervalTypes}")
+      .description(s"`interval-type` query param: ${intervalTypes()}")
       .summary("Get transaction count history per chain")
 }

--- a/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
+++ b/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
@@ -33,9 +33,9 @@ trait Documentation
     with OpenAPIDocsInterpreter {
   lazy val docs: OpenAPI = toOpenAPI(
     List(
-      listBlocks(),
-      getBlockByHash(),
-      getBlockTransactions(),
+      listBlocks,
+      getBlockByHash,
+      getBlockTransactions,
       getTransactionById,
       getOutputRefTransaction,
       getAddressInfo,
@@ -61,9 +61,9 @@ trait Documentation
       getLockedSupply,
       getTotalTransactions,
       getAverageBlockTime,
-      getHashrates(),
-      getAllChainsTxCount(),
-      getPerChainTxCount(),
+      getHashrates,
+      getAllChainsTxCount,
+      getPerChainTxCount,
       sanityCheck,
       changeGlobalLogLevel,
       changeLogConfig

--- a/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
+++ b/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
@@ -21,12 +21,12 @@ import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
 
 import org.alephium.explorer.api._
 import org.alephium.explorer.api.BlockEndpoints._
+import org.alephium.explorer.api.ChartsEndpoints._
 
 trait Documentation
     extends TransactionEndpoints
     with AddressesEndpoints
     with InfosEndpoints
-    with ChartsEndpoints
     with TokensEndpoints
     with UnconfirmedTransactionEndpoints
     with UtilsEndpoints
@@ -61,9 +61,9 @@ trait Documentation
       getLockedSupply,
       getTotalTransactions,
       getAverageBlockTime,
-      getHashrates,
-      getAllChainsTxCount,
-      getPerChainTxCount,
+      getHashrates(),
+      getAllChainsTxCount(),
+      getPerChainTxCount(),
       sanityCheck,
       changeGlobalLogLevel,
       changeLogConfig

--- a/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
+++ b/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
@@ -20,10 +20,10 @@ import sttp.apispec.openapi.OpenAPI
 import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
 
 import org.alephium.explorer.api._
+import org.alephium.explorer.api.BlockEndpoints._
 
 trait Documentation
-    extends BlockEndpoints
-    with TransactionEndpoints
+    extends TransactionEndpoints
     with AddressesEndpoints
     with InfosEndpoints
     with ChartsEndpoints
@@ -33,9 +33,9 @@ trait Documentation
     with OpenAPIDocsInterpreter {
   lazy val docs: OpenAPI = toOpenAPI(
     List(
-      listBlocks,
-      getBlockByHash,
-      getBlockTransactions,
+      listBlocks(),
+      getBlockByHash(),
+      getBlockTransactions(),
       getTransactionById,
       getOutputRefTransaction,
       getAddressInfo,

--- a/app/src/main/scala/org/alephium/explorer/web/BlockServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/BlockServer.scala
@@ -24,24 +24,23 @@ import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
 
 import org.alephium.api.ApiError
-import org.alephium.explorer.api.BlockEndpoints
+import org.alephium.explorer.api.BlockEndpoints._
 import org.alephium.explorer.cache.BlockCache
 import org.alephium.explorer.service.BlockService
 
 class BlockServer(implicit val executionContext: ExecutionContext,
                   dc: DatabaseConfig[PostgresProfile],
                   blockCache: BlockCache)
-    extends Server
-    with BlockEndpoints {
+    extends Server {
   val routes: ArraySeq[Router => Route] =
     ArraySeq(
-      route(listBlocks.serverLogicSuccess[Future](BlockService.listBlocks(_))),
-      route(getBlockByHash.serverLogic[Future] { hash =>
+      route(listBlocks().serverLogicSuccess[Future](BlockService.listBlocks(_))),
+      route(getBlockByHash().serverLogic[Future] { hash =>
         BlockService
           .getLiteBlockByHash(hash)
           .map(_.toRight(ApiError.NotFound(hash.value.toHexString)))
       }),
-      route(getBlockTransactions.serverLogicSuccess[Future] {
+      route(getBlockTransactions().serverLogicSuccess[Future] {
         case (hash, pagination) => BlockService.getBlockTransactions(hash, pagination)
       })
     )

--- a/app/src/main/scala/org/alephium/explorer/web/BlockServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/BlockServer.scala
@@ -34,13 +34,13 @@ class BlockServer(implicit val executionContext: ExecutionContext,
     extends Server {
   val routes: ArraySeq[Router => Route] =
     ArraySeq(
-      route(listBlocks().serverLogicSuccess[Future](BlockService.listBlocks(_))),
-      route(getBlockByHash().serverLogic[Future] { hash =>
+      route(listBlocks.serverLogicSuccess[Future](BlockService.listBlocks(_))),
+      route(getBlockByHash.serverLogic[Future] { hash =>
         BlockService
           .getLiteBlockByHash(hash)
           .map(_.toRight(ApiError.NotFound(hash.value.toHexString)))
       }),
-      route(getBlockTransactions().serverLogicSuccess[Future] {
+      route(getBlockTransactions.serverLogicSuccess[Future] {
         case (hash, pagination) => BlockService.getBlockTransactions(hash, pagination)
       })
     )

--- a/app/src/main/scala/org/alephium/explorer/web/ChartsServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/ChartsServer.scala
@@ -41,13 +41,13 @@ class ChartsServer()(implicit val executionContext: ExecutionContext,
 
   val routes: ArraySeq[Router => Route] =
     ArraySeq(
-      route(getHashrates().serverLogic[Future] {
+      route(getHashrates.serverLogic[Future] {
         case (timeInterval, interval) =>
           validateTimeInterval(timeInterval, interval) {
             HashrateService.get(timeInterval.from, timeInterval.to, interval)
           }
       }),
-      route(getAllChainsTxCount().serverLogic[Future] {
+      route(getAllChainsTxCount.serverLogic[Future] {
         case (timeInterval, interval) =>
           validateTimeInterval(timeInterval, interval) {
             TransactionHistoryService
@@ -59,7 +59,7 @@ class ChartsServer()(implicit val executionContext: ExecutionContext,
               }
           }
       }),
-      route(getPerChainTxCount().serverLogic[Future] {
+      route(getPerChainTxCount.serverLogic[Future] {
         case (timeInterval, interval) =>
           validateTimeInterval(timeInterval, interval) {
             TransactionHistoryService

--- a/app/src/main/scala/org/alephium/explorer/web/ChartsServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/ChartsServer.scala
@@ -26,15 +26,14 @@ import sttp.model.StatusCode
 
 import org.alephium.api.ApiError
 import org.alephium.api.model.TimeInterval
-import org.alephium.explorer.api.ChartsEndpoints
+import org.alephium.explorer.api.ChartsEndpoints._
 import org.alephium.explorer.api.model.{IntervalType, TimedCount}
 import org.alephium.explorer.service.{HashrateService, TransactionHistoryService}
 import org.alephium.util.Duration
 
 class ChartsServer()(implicit val executionContext: ExecutionContext,
                      dc: DatabaseConfig[PostgresProfile])
-    extends Server
-    with ChartsEndpoints {
+    extends Server {
 
   // scalastyle:off magic.number
   private val maxHourlyTimeSpan = Duration.ofDaysUnsafe(30)
@@ -42,13 +41,13 @@ class ChartsServer()(implicit val executionContext: ExecutionContext,
 
   val routes: ArraySeq[Router => Route] =
     ArraySeq(
-      route(getHashrates.serverLogic[Future] {
+      route(getHashrates().serverLogic[Future] {
         case (timeInterval, interval) =>
           validateTimeInterval(timeInterval, interval) {
             HashrateService.get(timeInterval.from, timeInterval.to, interval)
           }
       }),
-      route(getAllChainsTxCount.serverLogic[Future] {
+      route(getAllChainsTxCount().serverLogic[Future] {
         case (timeInterval, interval) =>
           validateTimeInterval(timeInterval, interval) {
             TransactionHistoryService
@@ -60,7 +59,7 @@ class ChartsServer()(implicit val executionContext: ExecutionContext,
               }
           }
       }),
-      route(getPerChainTxCount.serverLogic[Future] {
+      route(getPerChainTxCount().serverLogic[Future] {
         case (timeInterval, interval) =>
           validateTimeInterval(timeInterval, interval) {
             TransactionHistoryService


### PR DESCRIPTION
- First PR for #388
- Replaces Endpoint classes to be `object`s instead of `trait`s
- Sets endpoints to be defined as functions instead of `val`s