### PR TITLE
#388: `AddressesEndpoints` as `def`

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
@@ -27,34 +27,33 @@ import org.alephium.explorer.api.model._
 import org.alephium.protocol.model.TokenId
 
 // scalastyle:off magic.number
-trait AddressesEndpoints extends BaseEndpoint with QueryParams {
-
-  def groupNum: Int
+object AddressesEndpoints extends BaseEndpoint with QueryParams {
 
   //As defined in https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki#address-gap-limit
   private val gapLimit = 20
 
-  private lazy val activeAddressesMaxSize: Int = groupNum * gapLimit
+  private def activeAddressesMaxSize(groupNum: Int): Int =
+    groupNum * gapLimit
 
-  private val addressesEndpoint =
+  private def addressesEndpoint =
     baseEndpoint
       .tag("Addresses")
       .in("addresses")
 
-  private val addressesTokensEndpoint =
+  private def addressesTokensEndpoint =
     baseEndpoint
       .tag("Addresses")
       .in("addresses")
       .in(path[Address]("address")(Codecs.explorerAddressTapirCodec))
       .in("tokens")
 
-  val getAddressInfo: BaseEndpoint[Address, AddressInfo] =
+  def getAddressInfo: BaseEndpoint[Address, AddressInfo] =
     addressesEndpoint.get
       .in(path[Address]("address")(Codecs.explorerAddressTapirCodec))
       .out(jsonBody[AddressInfo])
       .description("Get address information")
 
-  val getTransactionsByAddressDEPRECATED
+  def getTransactionsByAddressDEPRECATED
     : BaseEndpoint[(Address, Pagination), ArraySeq[Transaction]] =
     addressesEndpoint.get
       .in(path[Address]("address")(Codecs.explorerAddressTapirCodec))
@@ -63,7 +62,7 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
       .out(jsonBody[ArraySeq[Transaction]])
       .description("List transactions of a given address")
 
-  val getTransactionsByAddress: BaseEndpoint[(Address, Pagination), ArraySeq[Transaction]] =
+  def getTransactionsByAddress: BaseEndpoint[(Address, Pagination), ArraySeq[Transaction]] =
     addressesEndpoint.get
       .in(path[Address]("address")(Codecs.explorerAddressTapirCodec))
       .in("transactions")
@@ -71,16 +70,16 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
       .out(jsonBody[ArraySeq[Transaction]])
       .description("List transactions of a given address")
 
-  lazy val getTransactionsByAddresses
-    : BaseEndpoint[(ArraySeq[Address], Pagination), ArraySeq[Transaction]] =
+  def getTransactionsByAddresses(
+      groupNum: Int): BaseEndpoint[(ArraySeq[Address], Pagination), ArraySeq[Transaction]] =
     addressesEndpoint.post
-      .in(jsonBody[ArraySeq[Address]].validate(Validator.maxSize(activeAddressesMaxSize)))
+      .in(jsonBody[ArraySeq[Address]].validate(Validator.maxSize(activeAddressesMaxSize(groupNum))))
       .in("transactions")
       .in(pagination)
       .out(jsonBody[ArraySeq[Transaction]])
       .description("List transactions for given addresses")
 
-  val getTransactionsByAddressTimeRanged
+  def getTransactionsByAddressTimeRanged
     : BaseEndpoint[(Address, TimeInterval, Pagination), ArraySeq[Transaction]] =
     addressesEndpoint.get
       .in(path[Address]("address")(Codecs.explorerAddressTapirCodec))
@@ -90,40 +89,40 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
       .out(jsonBody[ArraySeq[Transaction]])
       .description("List transactions of a given address within a time-range")
 
-  val getTotalTransactionsByAddress: BaseEndpoint[Address, Int] =
+  def getTotalTransactionsByAddress: BaseEndpoint[Address, Int] =
     addressesEndpoint.get
       .in(path[Address]("address")(Codecs.explorerAddressTapirCodec))
       .in("total-transactions")
       .out(jsonBody[Int])
       .description("Get total transactions of a given address")
 
-  val addressUnconfirmedTransactions: BaseEndpoint[Address, ArraySeq[TransactionLike]] =
+  def addressUnconfirmedTransactions: BaseEndpoint[Address, ArraySeq[TransactionLike]] =
     addressesEndpoint.get
       .in(path[Address]("address")(Codecs.explorerAddressTapirCodec))
       .in("unconfirmed-transactions")
       .out(jsonBody[ArraySeq[TransactionLike]])
       .description("List unconfirmed transactions of a given address")
 
-  val getAddressBalance: BaseEndpoint[Address, AddressBalance] =
+  def getAddressBalance: BaseEndpoint[Address, AddressBalance] =
     addressesEndpoint.get
       .in(path[Address]("address")(Codecs.explorerAddressTapirCodec))
       .in("balance")
       .out(jsonBody[AddressBalance])
       .description("Get address balance")
 
-  val listAddressTokens: BaseEndpoint[Address, ArraySeq[TokenId]] =
+  def listAddressTokens: BaseEndpoint[Address, ArraySeq[TokenId]] =
     addressesTokensEndpoint.get
       .out(jsonBody[ArraySeq[TokenId]])
       .description("List address tokens")
 
-  val getAddressTokenBalance: BaseEndpoint[(Address, TokenId), AddressBalance] =
+  def getAddressTokenBalance: BaseEndpoint[(Address, TokenId), AddressBalance] =
     addressesTokensEndpoint.get
       .in(path[TokenId]("token_id"))
       .in("balance")
       .out(jsonBody[AddressBalance])
       .description("Get address balance of given token")
 
-  val listAddressTokenTransactions
+  def listAddressTokenTransactions
     : BaseEndpoint[(Address, TokenId, Pagination), ArraySeq[Transaction]] =
     addressesTokensEndpoint.get
       .in(path[TokenId]("token_id"))
@@ -132,12 +131,12 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
       .out(jsonBody[ArraySeq[Transaction]])
       .description("List address tokens")
 
-  lazy val areAddressesActive: BaseEndpoint[ArraySeq[Address], ArraySeq[Boolean]] =
+  def areAddressesActive(groupNum: Int): BaseEndpoint[ArraySeq[Address], ArraySeq[Boolean]] =
     baseEndpoint
       .tag("Addresses")
       .in("addresses-active")
       .post
-      .in(jsonBody[ArraySeq[Address]].validate(Validator.maxSize(activeAddressesMaxSize)))
+      .in(jsonBody[ArraySeq[Address]].validate(Validator.maxSize(activeAddressesMaxSize(groupNum))))
       .out(jsonBody[ArraySeq[Boolean]])
       .description("Are the addresses active (at least 1 transaction)")
 }

--- a/app/src/main/scala/org/alephium/explorer/api/BlockEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/BlockEndpoints.scala
@@ -22,33 +22,32 @@ import sttp.tapir._
 import sttp.tapir.generic.auto._
 
 import org.alephium.api.{alphJsonBody => jsonBody}
-import org.alephium.explorer.api.BaseEndpoint
 import org.alephium.explorer.api.model._
 import org.alephium.protocol.model.BlockHash
 
-trait BlockEndpoints extends BaseEndpoint with QueryParams {
+object BlockEndpoints extends BaseEndpoint with QueryParams {
 
-  private val blocksEndpoint =
+  private def blocksEndpoint() =
     baseEndpoint
       .tag("Blocks")
       .in("blocks")
 
-  val getBlockByHash: BaseEndpoint[BlockHash, BlockEntryLite] =
-    blocksEndpoint.get
+  def getBlockByHash(): BaseEndpoint[BlockHash, BlockEntryLite] =
+    blocksEndpoint().get
       .in(path[BlockHash]("block_hash"))
       .out(jsonBody[BlockEntryLite])
       .description("Get a block with hash")
 
-  val getBlockTransactions: BaseEndpoint[(BlockHash, Pagination), ArraySeq[Transaction]] =
-    blocksEndpoint.get
+  def getBlockTransactions(): BaseEndpoint[(BlockHash, Pagination), ArraySeq[Transaction]] =
+    blocksEndpoint().get
       .in(path[BlockHash]("block_hash"))
       .in("transactions")
       .in(pagination)
       .out(jsonBody[ArraySeq[Transaction]])
       .description("Get block's transactions")
 
-  val listBlocks: BaseEndpoint[Pagination, ListBlocks] =
-    blocksEndpoint.get
+  def listBlocks(): BaseEndpoint[Pagination, ListBlocks] =
+    blocksEndpoint().get
       .in(pagination)
       .out(jsonBody[ListBlocks])
       .description("List blocks within time interval")

--- a/app/src/main/scala/org/alephium/explorer/api/BlockEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/BlockEndpoints.scala
@@ -27,27 +27,27 @@ import org.alephium.protocol.model.BlockHash
 
 object BlockEndpoints extends BaseEndpoint with QueryParams {
 
-  private def blocksEndpoint() =
+  private def blocksEndpoint =
     baseEndpoint
       .tag("Blocks")
       .in("blocks")
 
-  def getBlockByHash(): BaseEndpoint[BlockHash, BlockEntryLite] =
-    blocksEndpoint().get
+  def getBlockByHash: BaseEndpoint[BlockHash, BlockEntryLite] =
+    blocksEndpoint.get
       .in(path[BlockHash]("block_hash"))
       .out(jsonBody[BlockEntryLite])
       .description("Get a block with hash")
 
-  def getBlockTransactions(): BaseEndpoint[(BlockHash, Pagination), ArraySeq[Transaction]] =
-    blocksEndpoint().get
+  def getBlockTransactions: BaseEndpoint[(BlockHash, Pagination), ArraySeq[Transaction]] =
+    blocksEndpoint.get
       .in(path[BlockHash]("block_hash"))
       .in("transactions")
       .in(pagination)
       .out(jsonBody[ArraySeq[Transaction]])
       .description("Get block's transactions")
 
-  def listBlocks(): BaseEndpoint[Pagination, ListBlocks] =
-    blocksEndpoint().get
+  def listBlocks: BaseEndpoint[Pagination, ListBlocks] =
+    blocksEndpoint.get
       .in(pagination)
       .out(jsonBody[ListBlocks])
       .description("List blocks within time interval")

--- a/app/src/main/scala/org/alephium/explorer/api/ChartsEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/ChartsEndpoints.scala
@@ -27,38 +27,37 @@ import org.alephium.explorer.api.model.{Hashrate, IntervalType, PerChainTimedCou
 
 object ChartsEndpoints extends BaseEndpoint with QueryParams {
 
-  def intervalTypes(): String = IntervalType.all.map(_.string).mkString(", ")
+  def intervalTypes: String = IntervalType.all.map(_.string).mkString(", ")
 
-  private def chartsEndpoint() =
+  private def chartsEndpoint =
     baseEndpoint
       .tag("Charts")
       .in("charts")
 
-  def getHashrates(): BaseEndpoint[(TimeInterval, IntervalType), ArraySeq[Hashrate]] =
-    chartsEndpoint().get
+  def getHashrates: BaseEndpoint[(TimeInterval, IntervalType), ArraySeq[Hashrate]] =
+    chartsEndpoint.get
       .in("hashrates")
       .in(timeIntervalQuery)
       .in(intervalTypeQuery)
       .out(jsonBody[ArraySeq[Hashrate]])
-      .description(s"`interval-type` query param: ${intervalTypes()}")
+      .description(s"`interval-type` query param: $intervalTypes")
       .summary("Get hashrate chart in H/s")
 
-  def getAllChainsTxCount(): BaseEndpoint[(TimeInterval, IntervalType), ArraySeq[TimedCount]] =
-    chartsEndpoint().get
+  def getAllChainsTxCount: BaseEndpoint[(TimeInterval, IntervalType), ArraySeq[TimedCount]] =
+    chartsEndpoint.get
       .in("transactions-count")
       .in(timeIntervalQuery)
       .in(intervalTypeQuery)
       .out(jsonBody[ArraySeq[TimedCount]])
-      .description(s"`interval-type` query param: ${intervalTypes()}")
+      .description(s"`interval-type` query param: $intervalTypes")
       .summary("Get transaction count history")
 
-  def getPerChainTxCount()
-    : BaseEndpoint[(TimeInterval, IntervalType), ArraySeq[PerChainTimedCount]] =
-    chartsEndpoint().get
+  def getPerChainTxCount: BaseEndpoint[(TimeInterval, IntervalType), ArraySeq[PerChainTimedCount]] =
+    chartsEndpoint.get
       .in("transactions-count-per-chain")
       .in(timeIntervalQuery)
       .in(intervalTypeQuery)
       .out(jsonBody[ArraySeq[PerChainTimedCount]])
-      .description(s"`interval-type` query param: ${intervalTypes()}")
+      .description(s"`interval-type` query param: $intervalTypes")
       .summary("Get transaction count history per chain")
 }

--- a/app/src/main/scala/org/alephium/explorer/api/ChartsEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/ChartsEndpoints.scala
@@ -23,43 +23,42 @@ import sttp.tapir.generic.auto._
 
 import org.alephium.api.{alphJsonBody => jsonBody}
 import org.alephium.api.model.TimeInterval
-import org.alephium.explorer.api.BaseEndpoint
 import org.alephium.explorer.api.model.{Hashrate, IntervalType, PerChainTimedCount, TimedCount}
 
-// scalastyle:off magic.number
-trait ChartsEndpoints extends BaseEndpoint with QueryParams {
+object ChartsEndpoints extends BaseEndpoint with QueryParams {
 
-  val intervalTypes: String = IntervalType.all.map(_.string).mkString(", ")
+  def intervalTypes(): String = IntervalType.all.map(_.string).mkString(", ")
 
-  private val chartsEndpoint =
+  private def chartsEndpoint() =
     baseEndpoint
       .tag("Charts")
       .in("charts")
 
-  val getHashrates: BaseEndpoint[(TimeInterval, IntervalType), ArraySeq[Hashrate]] =
-    chartsEndpoint.get
+  def getHashrates(): BaseEndpoint[(TimeInterval, IntervalType), ArraySeq[Hashrate]] =
+    chartsEndpoint().get
       .in("hashrates")
       .in(timeIntervalQuery)
       .in(intervalTypeQuery)
       .out(jsonBody[ArraySeq[Hashrate]])
-      .description(s"`interval-type` query param: $intervalTypes")
+      .description(s"`interval-type` query param: ${intervalTypes()}")
       .summary("Get hashrate chart in H/s")
 
-  val getAllChainsTxCount: BaseEndpoint[(TimeInterval, IntervalType), ArraySeq[TimedCount]] =
-    chartsEndpoint.get
+  def getAllChainsTxCount(): BaseEndpoint[(TimeInterval, IntervalType), ArraySeq[TimedCount]] =
+    chartsEndpoint().get
       .in("transactions-count")
       .in(timeIntervalQuery)
       .in(intervalTypeQuery)
       .out(jsonBody[ArraySeq[TimedCount]])
-      .description(s"`interval-type` query param: ${intervalTypes}")
+      .description(s"`interval-type` query param: ${intervalTypes()}")
       .summary("Get transaction count history")
 
-  val getPerChainTxCount: BaseEndpoint[(TimeInterval, IntervalType), ArraySeq[PerChainTimedCount]] =
-    chartsEndpoint.get
+  def getPerChainTxCount()
+    : BaseEndpoint[(TimeInterval, IntervalType), ArraySeq[PerChainTimedCount]] =
+    chartsEndpoint().get
       .in("transactions-count-per-chain")
       .in(timeIntervalQuery)
       .in(intervalTypeQuery)
       .out(jsonBody[ArraySeq[PerChainTimedCount]])
-      .description(s"`interval-type` query param: ${intervalTypes}")
+      .description(s"`interval-type` query param: ${intervalTypes()}")
       .summary("Get transaction count history per chain")
 }

--- a/app/src/main/scala/org/alephium/explorer/api/InfosEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/InfosEndpoints.scala
@@ -24,69 +24,68 @@ import sttp.tapir._
 import sttp.tapir.generic.auto._
 
 import org.alephium.api.{alphJsonBody => jsonBody}
-import org.alephium.explorer.api.BaseEndpoint
 import org.alephium.explorer.api.model._
 
 // scalastyle:off magic.number
-trait InfosEndpoints extends BaseEndpoint with QueryParams {
+object InfosEndpoints extends BaseEndpoint with QueryParams {
 
-  private val infosEndpoint =
+  private def infosEndpoint =
     baseEndpoint
       .tag("Infos")
       .in("infos")
 
-  private val supplyEndpoint =
+  private def supplyEndpoint =
     infosEndpoint
       .in("supply")
 
-  val getInfos: BaseEndpoint[Unit, ExplorerInfo] =
+  def getInfos: BaseEndpoint[Unit, ExplorerInfo] =
     infosEndpoint.get
       .out(jsonBody[ExplorerInfo])
       .description("Get explorer informations")
 
-  val listTokenSupply: BaseEndpoint[Pagination, ArraySeq[TokenSupply]] =
+  def listTokenSupply: BaseEndpoint[Pagination, ArraySeq[TokenSupply]] =
     supplyEndpoint.get
       .in(pagination)
       .out(jsonBody[ArraySeq[TokenSupply]])
       .description("Get token supply list")
 
-  val getCirculatingSupply: BaseEndpoint[Unit, BigDecimal] =
+  def getCirculatingSupply: BaseEndpoint[Unit, BigDecimal] =
     supplyEndpoint.get
       .in("circulating-alph")
       .out(plainBody[BigDecimal])
       .description("Get the ALPH circulating supply")
 
-  val getTotalSupply: BaseEndpoint[Unit, BigDecimal] =
+  def getTotalSupply: BaseEndpoint[Unit, BigDecimal] =
     supplyEndpoint.get
       .in("total-alph")
       .out(plainBody[BigDecimal])
       .description("Get the ALPH total supply")
 
-  val getReservedSupply: BaseEndpoint[Unit, BigDecimal] =
+  def getReservedSupply: BaseEndpoint[Unit, BigDecimal] =
     supplyEndpoint.get
       .in("reserved-alph")
       .out(plainBody[BigDecimal])
       .description("Get the ALPH reserved supply")
 
-  val getLockedSupply: BaseEndpoint[Unit, BigDecimal] =
+  def getLockedSupply: BaseEndpoint[Unit, BigDecimal] =
     supplyEndpoint.get
       .in("locked-alph")
       .out(plainBody[BigDecimal])
       .description("Get the ALPH locked supply")
 
-  val getHeights: BaseEndpoint[Unit, ArraySeq[PerChainHeight]] =
+  def getHeights: BaseEndpoint[Unit, ArraySeq[PerChainHeight]] =
     infosEndpoint.get
       .in("heights")
       .out(jsonBody[ArraySeq[PerChainHeight]])
       .description("List latest height for each chain")
 
-  val getTotalTransactions: BaseEndpoint[Unit, Int] =
+  def getTotalTransactions: BaseEndpoint[Unit, Int] =
     infosEndpoint.get
       .in("total-transactions")
       .out(plainBody[Int])
       .description("Get the total number of transactions")
 
-  val getAverageBlockTime: BaseEndpoint[Unit, ArraySeq[PerChainDuration]] =
+  def getAverageBlockTime: BaseEndpoint[Unit, ArraySeq[PerChainDuration]] =
     infosEndpoint.get
       .in("average-block-times")
       .out(jsonBody[ArraySeq[PerChainDuration]])

--- a/app/src/main/scala/org/alephium/explorer/api/TokensEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/TokensEndpoints.scala
@@ -22,25 +22,23 @@ import sttp.tapir._
 import sttp.tapir.generic.auto._
 
 import org.alephium.api.{alphJsonBody => jsonBody}
-import org.alephium.explorer.api.BaseEndpoint
 import org.alephium.explorer.api.model._
 import org.alephium.protocol.model.TokenId
 
-// scalastyle:off magic.number
-trait TokensEndpoints extends BaseEndpoint with QueryParams {
+object TokensEndpoints extends BaseEndpoint with QueryParams {
 
-  private val tokensEndpoint =
+  private def tokensEndpoint =
     baseEndpoint
       .tag("Tokens")
       .in("tokens")
 
-  val listTokens: BaseEndpoint[Pagination, ArraySeq[TokenId]] =
+  def listTokens: BaseEndpoint[Pagination, ArraySeq[TokenId]] =
     tokensEndpoint.get
       .in(pagination)
       .out(jsonBody[ArraySeq[TokenId]])
       .description("List tokens")
 
-  val listTokenTransactions: BaseEndpoint[(TokenId, Pagination), ArraySeq[Transaction]] =
+  def listTokenTransactions: BaseEndpoint[(TokenId, Pagination), ArraySeq[Transaction]] =
     tokensEndpoint.get
       .in(path[TokenId]("token_id"))
       .in("transactions")
@@ -48,7 +46,7 @@ trait TokensEndpoints extends BaseEndpoint with QueryParams {
       .out(jsonBody[ArraySeq[Transaction]])
       .description("List token transactions")
 
-  val listTokenAddresses: BaseEndpoint[(TokenId, Pagination), ArraySeq[Address]] =
+  def listTokenAddresses: BaseEndpoint[(TokenId, Pagination), ArraySeq[Address]] =
     tokensEndpoint.get
       .in(path[TokenId]("token_id"))
       .in("addresses")

--- a/app/src/main/scala/org/alephium/explorer/api/TransactionEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/TransactionEndpoints.scala
@@ -21,24 +21,23 @@ import sttp.tapir.generic.auto._
 
 import org.alephium.api.{alphJsonBody => jsonBody}
 import org.alephium.explorer.Hash
-import org.alephium.explorer.api.BaseEndpoint
 import org.alephium.explorer.api.model.{Transaction, TransactionLike}
 import org.alephium.protocol.model.TransactionId
 
-trait TransactionEndpoints extends BaseEndpoint {
+object TransactionEndpoints extends BaseEndpoint {
 
-  private val transactionsEndpoint =
+  private def transactionsEndpoint =
     baseEndpoint
       .tag("Transactions")
       .in("transactions")
 
-  val getTransactionById: BaseEndpoint[TransactionId, TransactionLike] =
+  def getTransactionById: BaseEndpoint[TransactionId, TransactionLike] =
     transactionsEndpoint.get
       .in(path[TransactionId]("transaction_hash"))
       .out(jsonBody[TransactionLike])
       .description("Get a transaction with hash")
 
-  val getOutputRefTransaction: BaseEndpoint[Hash, Transaction] =
+  def getOutputRefTransaction: BaseEndpoint[Hash, Transaction] =
     baseEndpoint
       .tag("Transactions")
       .in("transactions")

--- a/app/src/main/scala/org/alephium/explorer/api/UnconfirmedTransactionEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/UnconfirmedTransactionEndpoints.scala
@@ -22,17 +22,16 @@ import sttp.tapir._
 import sttp.tapir.generic.auto._
 
 import org.alephium.api.{alphJsonBody => jsonBody}
-import org.alephium.explorer.api.BaseEndpoint
 import org.alephium.explorer.api.model.{Pagination, TransactionLike}
 
-trait UnconfirmedTransactionEndpoints extends BaseEndpoint with QueryParams {
+object UnconfirmedTransactionEndpoints extends BaseEndpoint with QueryParams {
 
-  private val unconfirmedTransactionsEndpoint =
+  private def unconfirmedTransactionsEndpoint =
     baseEndpoint
       .tag("Transactions")
       .in("unconfirmed-transactions")
 
-  val listUnconfirmedTransactions: BaseEndpoint[Pagination, ArraySeq[TransactionLike]] =
+  def listUnconfirmedTransactions: BaseEndpoint[Pagination, ArraySeq[TransactionLike]] =
     unconfirmedTransactionsEndpoint.get
       .in(pagination)
       .out(jsonBody[ArraySeq[TransactionLike]])

--- a/app/src/main/scala/org/alephium/explorer/api/UtilsEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/UtilsEndpoints.scala
@@ -25,35 +25,34 @@ import org.alephium.api.{alphJsonBody => jsonBody}
 import org.alephium.explorer.api.model.LogbackValue
 import org.alephium.explorer.persistence.queries.ExplainResult
 
-// scalastyle:off magic.number
-trait UtilsEndpoints extends BaseEndpoint with QueryParams {
+object UtilsEndpoints extends BaseEndpoint with QueryParams {
 
-  private val utilsEndpoint =
+  private def utilsEndpoint =
     baseEndpoint
       .tag("Utils")
       .in("utils")
 
-  private val logLevels    = List("TRACE", "DEBUG", "INFO", "WARN", "ERROR")
-  private val logLevelsStr = logLevels.mkString(", ")
+  private def logLevels    = List("TRACE", "DEBUG", "INFO", "WARN", "ERROR")
+  private def logLevelsStr = logLevels.mkString(", ")
 
-  val sanityCheck: BaseEndpoint[Unit, Unit] =
+  def sanityCheck: BaseEndpoint[Unit, Unit] =
     utilsEndpoint.put
       .in("sanity-check")
       .description("Perform a sanity check")
 
-  val indexCheck: BaseEndpoint[Unit, ArraySeq[ExplainResult]] =
+  def indexCheck: BaseEndpoint[Unit, ArraySeq[ExplainResult]] =
     utilsEndpoint.get
       .in("index-check")
       .out(jsonBody[ArraySeq[ExplainResult]])
       .description("Perform index check")
 
-  val changeGlobalLogLevel: BaseEndpoint[String, Unit] =
+  def changeGlobalLogLevel: BaseEndpoint[String, Unit] =
     utilsEndpoint.put
       .in("update-global-loglevel")
       .in(plainBody[String].validate(Validator.enumeration(logLevels)))
       .description(s"Update global log level, accepted: $logLevelsStr")
 
-  val changeLogConfig: BaseEndpoint[ArraySeq[LogbackValue], Unit] =
+  def changeLogConfig: BaseEndpoint[ArraySeq[LogbackValue], Unit] =
     utilsEndpoint.put
       .in("update-log-config")
       .in(jsonBody[ArraySeq[LogbackValue]])

--- a/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
+++ b/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
@@ -19,7 +19,7 @@ package org.alephium.explorer.docs
 import sttp.apispec.openapi.OpenAPI
 import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
 
-import org.alephium.explorer.api._
+import org.alephium.explorer.api.AddressesEndpoints._
 import org.alephium.explorer.api.BlockEndpoints._
 import org.alephium.explorer.api.ChartsEndpoints._
 import org.alephium.explorer.api.InfosEndpoints._
@@ -28,8 +28,8 @@ import org.alephium.explorer.api.TransactionEndpoints._
 import org.alephium.explorer.api.UnconfirmedTransactionEndpoints._
 import org.alephium.explorer.api.UtilsEndpoints._
 
-trait Documentation extends AddressesEndpoints with OpenAPIDocsInterpreter {
-  lazy val docs: OpenAPI = toOpenAPI(
+object Documentation extends OpenAPIDocsInterpreter {
+  def docs(groupNum: Int): OpenAPI = toOpenAPI(
     List(
       listBlocks,
       getBlockByHash,
@@ -38,7 +38,7 @@ trait Documentation extends AddressesEndpoints with OpenAPIDocsInterpreter {
       getOutputRefTransaction,
       getAddressInfo,
       getTransactionsByAddress,
-      getTransactionsByAddresses,
+      getTransactionsByAddresses(groupNum),
       getTransactionsByAddressTimeRanged,
       getTotalTransactionsByAddress,
       addressUnconfirmedTransactions,
@@ -46,7 +46,7 @@ trait Documentation extends AddressesEndpoints with OpenAPIDocsInterpreter {
       listAddressTokens,
       listAddressTokenTransactions,
       getAddressTokenBalance,
-      areAddressesActive,
+      areAddressesActive(groupNum),
       getInfos,
       getHeights,
       listUnconfirmedTransactions,

--- a/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
+++ b/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
@@ -33,9 +33,9 @@ trait Documentation
     with OpenAPIDocsInterpreter {
   lazy val docs: OpenAPI = toOpenAPI(
     List(
-      listBlocks(),
-      getBlockByHash(),
-      getBlockTransactions(),
+      listBlocks,
+      getBlockByHash,
+      getBlockTransactions,
       getTransactionById,
       getOutputRefTransaction,
       getAddressInfo,
@@ -61,9 +61,9 @@ trait Documentation
       getLockedSupply,
       getTotalTransactions,
       getAverageBlockTime,
-      getHashrates(),
-      getAllChainsTxCount(),
-      getPerChainTxCount(),
+      getHashrates,
+      getAllChainsTxCount,
+      getPerChainTxCount,
       sanityCheck,
       changeGlobalLogLevel,
       changeLogConfig

--- a/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
+++ b/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
@@ -21,12 +21,12 @@ import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
 
 import org.alephium.explorer.api._
 import org.alephium.explorer.api.BlockEndpoints._
+import org.alephium.explorer.api.ChartsEndpoints._
 
 trait Documentation
     extends TransactionEndpoints
     with AddressesEndpoints
     with InfosEndpoints
-    with ChartsEndpoints
     with TokensEndpoints
     with UnconfirmedTransactionEndpoints
     with UtilsEndpoints
@@ -61,9 +61,9 @@ trait Documentation
       getLockedSupply,
       getTotalTransactions,
       getAverageBlockTime,
-      getHashrates,
-      getAllChainsTxCount,
-      getPerChainTxCount,
+      getHashrates(),
+      getAllChainsTxCount(),
+      getPerChainTxCount(),
       sanityCheck,
       changeGlobalLogLevel,
       changeLogConfig

--- a/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
+++ b/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
@@ -20,10 +20,10 @@ import sttp.apispec.openapi.OpenAPI
 import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
 
 import org.alephium.explorer.api._
+import org.alephium.explorer.api.BlockEndpoints._
 
 trait Documentation
-    extends BlockEndpoints
-    with TransactionEndpoints
+    extends TransactionEndpoints
     with AddressesEndpoints
     with InfosEndpoints
     with ChartsEndpoints
@@ -33,9 +33,9 @@ trait Documentation
     with OpenAPIDocsInterpreter {
   lazy val docs: OpenAPI = toOpenAPI(
     List(
-      listBlocks,
-      getBlockByHash,
-      getBlockTransactions,
+      listBlocks(),
+      getBlockByHash(),
+      getBlockTransactions(),
       getTransactionById,
       getOutputRefTransaction,
       getAddressInfo,

--- a/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
+++ b/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
@@ -22,15 +22,13 @@ import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
 import org.alephium.explorer.api._
 import org.alephium.explorer.api.BlockEndpoints._
 import org.alephium.explorer.api.ChartsEndpoints._
+import org.alephium.explorer.api.InfosEndpoints._
+import org.alephium.explorer.api.TokensEndpoints._
+import org.alephium.explorer.api.TransactionEndpoints._
+import org.alephium.explorer.api.UnconfirmedTransactionEndpoints._
+import org.alephium.explorer.api.UtilsEndpoints._
 
-trait Documentation
-    extends TransactionEndpoints
-    with AddressesEndpoints
-    with InfosEndpoints
-    with TokensEndpoints
-    with UnconfirmedTransactionEndpoints
-    with UtilsEndpoints
-    with OpenAPIDocsInterpreter {
+trait Documentation extends AddressesEndpoints with OpenAPIDocsInterpreter {
   lazy val docs: OpenAPI = toOpenAPI(
     List(
       listBlocks,

--- a/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
@@ -24,7 +24,7 @@ import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
 
 import org.alephium.explorer.GroupSetting
-import org.alephium.explorer.api.AddressesEndpoints
+import org.alephium.explorer.api.AddressesEndpoints._
 import org.alephium.explorer.api.model.{AddressBalance, AddressInfo}
 import org.alephium.explorer.service.TransactionService
 
@@ -32,10 +32,7 @@ class AddressServer(transactionService: TransactionService)(
     implicit val executionContext: ExecutionContext,
     groupSetting: GroupSetting,
     dc: DatabaseConfig[PostgresProfile])
-    extends Server
-    with AddressesEndpoints {
-
-  val groupNum = groupSetting.groupNum
+    extends Server {
 
   val routes: ArraySeq[Router => Route] =
     ArraySeq(
@@ -44,7 +41,7 @@ class AddressServer(transactionService: TransactionService)(
           transactionService
             .getTransactionsByAddress(address, pagination)
       }),
-      route(getTransactionsByAddresses.serverLogicSuccess[Future] {
+      route(getTransactionsByAddresses(groupSetting.groupNum).serverLogicSuccess[Future] {
         case (addresses, pagination) =>
           transactionService
             .getTransactionsByAddresses(addresses, pagination)
@@ -97,7 +94,7 @@ class AddressServer(transactionService: TransactionService)(
             tokens <- transactionService.listAddressTokenTransactions(address, token, pagination)
           } yield tokens
       }),
-      route(areAddressesActive.serverLogicSuccess[Future] { addresses =>
+      route(areAddressesActive(groupSetting.groupNum).serverLogicSuccess[Future] { addresses =>
         transactionService.areAddressesActive(addresses)
       })
     )

--- a/app/src/main/scala/org/alephium/explorer/web/BlockServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/BlockServer.scala
@@ -24,24 +24,23 @@ import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
 
 import org.alephium.api.ApiError
-import org.alephium.explorer.api.BlockEndpoints
+import org.alephium.explorer.api.BlockEndpoints._
 import org.alephium.explorer.cache.BlockCache
 import org.alephium.explorer.service.BlockService
 
 class BlockServer(implicit val executionContext: ExecutionContext,
                   dc: DatabaseConfig[PostgresProfile],
                   blockCache: BlockCache)
-    extends Server
-    with BlockEndpoints {
+    extends Server {
   val routes: ArraySeq[Router => Route] =
     ArraySeq(
-      route(listBlocks.serverLogicSuccess[Future](BlockService.listBlocks(_))),
-      route(getBlockByHash.serverLogic[Future] { hash =>
+      route(listBlocks().serverLogicSuccess[Future](BlockService.listBlocks(_))),
+      route(getBlockByHash().serverLogic[Future] { hash =>
         BlockService
           .getLiteBlockByHash(hash)
           .map(_.toRight(ApiError.NotFound(hash.value.toHexString)))
       }),
-      route(getBlockTransactions.serverLogicSuccess[Future] {
+      route(getBlockTransactions().serverLogicSuccess[Future] {
         case (hash, pagination) => BlockService.getBlockTransactions(hash, pagination)
       })
     )

--- a/app/src/main/scala/org/alephium/explorer/web/BlockServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/BlockServer.scala
@@ -34,13 +34,13 @@ class BlockServer(implicit val executionContext: ExecutionContext,
     extends Server {
   val routes: ArraySeq[Router => Route] =
     ArraySeq(
-      route(listBlocks().serverLogicSuccess[Future](BlockService.listBlocks(_))),
-      route(getBlockByHash().serverLogic[Future] { hash =>
+      route(listBlocks.serverLogicSuccess[Future](BlockService.listBlocks(_))),
+      route(getBlockByHash.serverLogic[Future] { hash =>
         BlockService
           .getLiteBlockByHash(hash)
           .map(_.toRight(ApiError.NotFound(hash.value.toHexString)))
       }),
-      route(getBlockTransactions().serverLogicSuccess[Future] {
+      route(getBlockTransactions.serverLogicSuccess[Future] {
         case (hash, pagination) => BlockService.getBlockTransactions(hash, pagination)
       })
     )

--- a/app/src/main/scala/org/alephium/explorer/web/ChartsServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/ChartsServer.scala
@@ -41,13 +41,13 @@ class ChartsServer()(implicit val executionContext: ExecutionContext,
 
   val routes: ArraySeq[Router => Route] =
     ArraySeq(
-      route(getHashrates().serverLogic[Future] {
+      route(getHashrates.serverLogic[Future] {
         case (timeInterval, interval) =>
           validateTimeInterval(timeInterval, interval) {
             HashrateService.get(timeInterval.from, timeInterval.to, interval)
           }
       }),
-      route(getAllChainsTxCount().serverLogic[Future] {
+      route(getAllChainsTxCount.serverLogic[Future] {
         case (timeInterval, interval) =>
           validateTimeInterval(timeInterval, interval) {
             TransactionHistoryService
@@ -59,7 +59,7 @@ class ChartsServer()(implicit val executionContext: ExecutionContext,
               }
           }
       }),
-      route(getPerChainTxCount().serverLogic[Future] {
+      route(getPerChainTxCount.serverLogic[Future] {
         case (timeInterval, interval) =>
           validateTimeInterval(timeInterval, interval) {
             TransactionHistoryService

--- a/app/src/main/scala/org/alephium/explorer/web/ChartsServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/ChartsServer.scala
@@ -26,15 +26,14 @@ import sttp.model.StatusCode
 
 import org.alephium.api.ApiError
 import org.alephium.api.model.TimeInterval
-import org.alephium.explorer.api.ChartsEndpoints
+import org.alephium.explorer.api.ChartsEndpoints._
 import org.alephium.explorer.api.model.{IntervalType, TimedCount}
 import org.alephium.explorer.service.{HashrateService, TransactionHistoryService}
 import org.alephium.util.Duration
 
 class ChartsServer()(implicit val executionContext: ExecutionContext,
                      dc: DatabaseConfig[PostgresProfile])
-    extends Server
-    with ChartsEndpoints {
+    extends Server {
 
   // scalastyle:off magic.number
   private val maxHourlyTimeSpan = Duration.ofDaysUnsafe(30)
@@ -42,13 +41,13 @@ class ChartsServer()(implicit val executionContext: ExecutionContext,
 
   val routes: ArraySeq[Router => Route] =
     ArraySeq(
-      route(getHashrates.serverLogic[Future] {
+      route(getHashrates().serverLogic[Future] {
         case (timeInterval, interval) =>
           validateTimeInterval(timeInterval, interval) {
             HashrateService.get(timeInterval.from, timeInterval.to, interval)
           }
       }),
-      route(getAllChainsTxCount.serverLogic[Future] {
+      route(getAllChainsTxCount().serverLogic[Future] {
         case (timeInterval, interval) =>
           validateTimeInterval(timeInterval, interval) {
             TransactionHistoryService
@@ -60,7 +59,7 @@ class ChartsServer()(implicit val executionContext: ExecutionContext,
               }
           }
       }),
-      route(getPerChainTxCount.serverLogic[Future] {
+      route(getPerChainTxCount().serverLogic[Future] {
         case (timeInterval, interval) =>
           validateTimeInterval(timeInterval, interval) {
             TransactionHistoryService

--- a/app/src/main/scala/org/alephium/explorer/web/DocumentationServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/DocumentationServer.scala
@@ -24,15 +24,13 @@ import sttp.tapir.swagger.{SwaggerUI, SwaggerUIOptions}
 
 import org.alephium.api.OpenAPIWriters.openApiJson
 import org.alephium.explorer.GroupSetting
-import org.alephium.explorer.docs.Documentation
+import org.alephium.explorer.docs.Documentation._
 
-class DocumentationServer()(implicit groupSetting: GroupSetting) extends Server with Documentation {
-
-  val groupNum = groupSetting.groupNum
+class DocumentationServer()(implicit groupSetting: GroupSetting) extends Server {
 
   val routes: ArraySeq[Router => Route] =
     ArraySeq.from(
       SwaggerUI[Future](
-        openApiJson(docs, dropAuth             = false),
-        SwaggerUIOptions.default.copy(yamlName = "explorer-backend-openapi.json")).map(route(_)))
+        openApiJson(docs(groupSetting.groupNum), dropAuth = false),
+        SwaggerUIOptions.default.copy(yamlName            = "explorer-backend-openapi.json")).map(route(_)))
 }

--- a/app/src/main/scala/org/alephium/explorer/web/InfosServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/InfosServer.scala
@@ -27,7 +27,7 @@ import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
 
 import org.alephium.explorer.{BuildInfo, GroupSetting}
-import org.alephium.explorer.api.InfosEndpoints
+import org.alephium.explorer.api.InfosEndpoints._
 import org.alephium.explorer.api.model.{ExplorerInfo, TokenSupply}
 import org.alephium.explorer.cache.{AsyncReloadingCache, BlockCache, TransactionCache}
 import org.alephium.explorer.service.{BlockService, TokenSupplyService, TransactionService}
@@ -42,8 +42,7 @@ class InfosServer(tokenSupplyService: TokenSupplyService,
     blockCache: BlockCache,
     transactionCache: TransactionCache,
     groupSettings: GroupSetting)
-    extends Server
-    with InfosEndpoints {
+    extends Server {
 
   // scalafmt is struggling on this one, maybe latest version wil work.
   // format: off

--- a/app/src/main/scala/org/alephium/explorer/web/TokenServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/TokenServer.scala
@@ -23,13 +23,12 @@ import io.vertx.ext.web._
 import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
 
-import org.alephium.explorer.api.TokensEndpoints
+import org.alephium.explorer.api.TokensEndpoints._
 import org.alephium.explorer.service.TransactionService
 
 class TokenServer()(implicit val executionContext: ExecutionContext,
                     dc: DatabaseConfig[PostgresProfile])
-    extends Server
-    with TokensEndpoints {
+    extends Server {
 
   val routes: ArraySeq[Router => Route] =
     ArraySeq(

--- a/app/src/main/scala/org/alephium/explorer/web/TransactionServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/TransactionServer.scala
@@ -24,13 +24,12 @@ import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
 
 import org.alephium.api.ApiError
-import org.alephium.explorer.api.TransactionEndpoints
+import org.alephium.explorer.api.TransactionEndpoints._
 import org.alephium.explorer.service.TransactionService
 
 class TransactionServer(implicit val executionContext: ExecutionContext,
                         dc: DatabaseConfig[PostgresProfile])
-    extends Server
-    with TransactionEndpoints {
+    extends Server {
   val routes: ArraySeq[Router => Route] = ArraySeq(
     route(getTransactionById.serverLogic[Future] { hash =>
       TransactionService

--- a/app/src/main/scala/org/alephium/explorer/web/UnconfirmedTransactionServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/UnconfirmedTransactionServer.scala
@@ -23,13 +23,12 @@ import io.vertx.ext.web._
 import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
 
-import org.alephium.explorer.api.UnconfirmedTransactionEndpoints
+import org.alephium.explorer.api.UnconfirmedTransactionEndpoints._
 import org.alephium.explorer.service.TransactionService
 
 class UnconfirmedTransactionServer(implicit val executionContext: ExecutionContext,
                                    dc: DatabaseConfig[PostgresProfile])
-    extends Server
-    with UnconfirmedTransactionEndpoints {
+    extends Server {
   val routes: ArraySeq[Router => Route] = ArraySeq(
     route(listUnconfirmedTransactions.serverLogicSuccess[Future] { pagination =>
       TransactionService

--- a/app/src/main/scala/org/alephium/explorer/web/UtilsServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/UtilsServer.scala
@@ -21,6 +21,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util._
 
 import ch.qos.logback.classic.{Level, Logger, LoggerContext}
+import com.typesafe.scalalogging.StrictLogging
 import io.vertx.ext.web._
 import org.slf4j.LoggerFactory
 import slick.basic.DatabaseConfig
@@ -29,7 +30,7 @@ import sttp.model.StatusCode
 
 import org.alephium.api.ApiError
 import org.alephium.explorer.{sideEffect, GroupSetting}
-import org.alephium.explorer.api.UtilsEndpoints
+import org.alephium.explorer.api.UtilsEndpoints._
 import org.alephium.explorer.api.model.LogbackValue
 import org.alephium.explorer.cache.BlockCache
 import org.alephium.explorer.service.{BlockFlowClient, IndexChecker, SanityChecker}
@@ -40,7 +41,7 @@ class UtilsServer()(implicit val executionContext: ExecutionContext,
                     blockCache: BlockCache,
                     groupSetting: GroupSetting)
     extends Server
-    with UtilsEndpoints {
+    with StrictLogging {
 
   val routes: ArraySeq[Router => Route] =
     ArraySeq(

--- a/tools/src/main/scala/org/alephium/tools/OpenApiUpdate.scala
+++ b/tools/src/main/scala/org/alephium/tools/OpenApiUpdate.scala
@@ -23,18 +23,16 @@ import org.alephium.explorer.sideEffect
 object OpenApiUpdate {
   def main(args: Array[String]): Unit = {
     sideEffect {
-      new Documentation {
 
-        val groupNum = 4
+      val groupNum = 4
 
-        private val json = openApiJson(docs, dropAuth = false)
+      val json = openApiJson(Documentation.docs(groupNum), dropAuth = false)
 
-        import java.io.PrintWriter
-        new PrintWriter("../app/src/main/resources/explorer-backend-openapi.json") {
-          write(json)
-          write('\n')
-          close
-        }
+      import java.io.PrintWriter
+      new PrintWriter("../app/src/main/resources/explorer-backend-openapi.json") {
+        write(json)
+        write('\n')
+        close
       }
     }
   }


### PR DESCRIPTION
- Third PR for #388
- This PR is stacked on #396
- Replaces `AddressesEndpoints` & `Documentation` to be `object`s instead of `trait`s
- Sets endpoints to be defined as functions instead of `val`s

FYI: I've manually checked the APIs I'm familiar with to make sure they are running as usual. Hoping the tests will ensure that all the rest of the APIs are ok (too many to check manually anyway).