### PR TITLE
Use `ExecutionContext.reportFailure` to stop app on sync services error

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/SyncServices.scala
+++ b/app/src/main/scala/org/alephium/explorer/SyncServices.scala
@@ -96,6 +96,7 @@ object SyncServices extends StrictLogging {
           .onComplete {
             case Failure(error) =>
               logger.error(s"Fatal error while syncing: $error")
+              ec.reportFailure(error)
 
             case Success(_) => ()
           }


### PR DESCRIPTION
Hey @polarker I want to discuss this proposition with you.

We try to solve here [this issue](https://github.com/alephium/explorer-backend/issues/395).
Sync services are running in background and on a fatal error, we were not able to gracefully stop the app from there. We need a `Stopper` guy, one way would have been to pass the `ActorSystem` and call `terminate`, but that's super ugly as it's would have been used just for that. We could also go with just a `sys.exit`, but it's not that "graceful".

I just found that that `ExecutionContext` have a [reportFailure](https://www.scala-lang.org/api/2.13.3/scala/concurrent/ExecutionContext.html#reportFailure(cause:Throwable):Unit) which is exactly meant for that.
[the default reporter ](https://www.scala-lang.org/api/2.13.3/scala/concurrent/ExecutionContext$.html#defaultReporter:Throwable=%3EUnit) just log the error, but you can choose what behavior you want by passing your own `reporter`.

That's a nice way to use Vanilla scala.

I tested it by stopping my PG ( in `ReadWrite` and `WriteOnly` mode) and the app correctly stop. 

WDYT? (talking here about the general idea, I haven't polish details nor added tests)