### PR TITLE
ExecutionContext.reportFailure and remove all `sys.exit`

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/SyncServices.scala
+++ b/app/src/main/scala/org/alephium/explorer/SyncServices.scala
@@ -95,7 +95,13 @@ object SyncServices extends StrictLogging {
           )
           .onComplete {
             case Failure(error) =>
+              val failure = error match {
+                case psql: org.postgresql.util.PSQLException =>
+                  DatabaseError(psql)
+                case other => other
+              }
               logger.error(s"Fatal error while syncing: $error")
+              ec.reportFailure(failure)
 
             case Success(_) => ()
           }

--- a/app/src/main/scala/org/alephium/explorer/error/ExplorerError.scala
+++ b/app/src/main/scala/org/alephium/explorer/error/ExplorerError.scala
@@ -18,6 +18,7 @@ package org.alephium.explorer.error
 
 import scala.concurrent.duration.FiniteDuration
 
+import org.postgresql.util.PSQLException
 import sttp.model.Uri
 
 import org.alephium.explorer.api.model.GroupIndex
@@ -71,6 +72,10 @@ object ExplorerError {
   final case class RemoteTimeStampIsBeforeLocal(localTs: TimeStamp, remoteTs: TimeStamp)
       extends Exception(
         s"Max remote timestamp ($remoteTs) cannot be be before local timestamp ($localTs)")
+      with FatalSystemExit
+
+  final case class DatabaseError(cause: PSQLException)
+      extends Exception(s"Database error.", cause)
       with FatalSystemExit
 
   /******** Group: [[ConfigError]] ********/

--- a/app/src/main/scala/org/alephium/explorer/persistence/Migrations.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/Migrations.scala
@@ -26,6 +26,7 @@ import slick.jdbc.PostgresProfile.api._
 
 import org.alephium.explorer.persistence.model.AppState.MigrationVersion
 import org.alephium.explorer.persistence.queries.AppStateQueries
+import org.alephium.explorer.persistence.schema.CustomGetResult._
 
 object Migrations extends StrictLogging {
 
@@ -54,13 +55,7 @@ object Migrations extends StrictLogging {
   }
 
   def getVersion()(implicit ec: ExecutionContext): DBActionR[Option[MigrationVersion]] = {
-    AppStateQueries.get(MigrationVersion).map {
-      case None                            => None
-      case Some(MigrationVersion(version)) => Some(MigrationVersion(version))
-      case _ =>
-        logger.error(s"Invalid migration version, closing app.")
-        sys.exit(1)
-    }
+    AppStateQueries.get(MigrationVersion)
   }
 
   def updateVersion(versionOpt: Option[MigrationVersion])(

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/AppState.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/AppState.scala
@@ -16,8 +16,15 @@
 
 package org.alephium.explorer.persistence.model
 
-import akka.util.ByteString
+import scala.concurrent.ExecutionContext
+import scala.reflect.ClassTag
 
+import akka.util.ByteString
+import slick.jdbc.GetResult
+import slick.jdbc.PostgresProfile.api._
+
+import org.alephium.explorer.persistence.DBActionR
+import org.alephium.explorer.util.SlickUtil._
 import org.alephium.serde._
 import org.alephium.util.TimeStamp
 
@@ -25,31 +32,36 @@ import org.alephium.util.TimeStamp
 sealed trait AppState
 
 /** Keys for AppState */
-sealed trait AppStateKey {
+sealed trait AppStateKey[V <: AppState] {
   def key: String
 
   def apply(bytes: ByteString): Either[SerdeError, AppState]
+
+  final def get()(implicit ct: ClassTag[V],
+                  gr: GetResult[V],
+                  ec: ExecutionContext): DBActionR[Option[V]] =
+    sql"""SELECT value FROM app_state WHERE key = $key""".asAS[V].headOrNone
 }
 
 object AppState {
 
   /** Fetch value for the key and serialised value, or-else, throw error */
-  def applyOrThrow(key: AppStateKey, bytes: ByteString): AppState =
+  def applyOrThrow(key: AppStateKey[_], bytes: ByteString): AppState =
     key(bytes) match {
       case Left(error)     => throw error
       case Right(appState) => appState
     }
 
-  def unapplyOpt(result: AppState): Option[(AppStateKey, ByteString)] =
+  def unapplyOpt(result: AppState): Option[(AppStateKey[_], ByteString)] =
     Some(unapply(result))
 
-  def unapply(result: AppState): (AppStateKey, ByteString) =
+  def unapply(result: AppState): (AppStateKey[_], ByteString) =
     result match {
       case LastFinalizedInputTime(value) => (LastFinalizedInputTime, serialize(value))
       case MigrationVersion(value)       => (MigrationVersion, serialize(value))
     }
 
-  object LastFinalizedInputTime extends AppStateKey {
+  object LastFinalizedInputTime extends AppStateKey[LastFinalizedInputTime] {
     val key = "last_finalized_input_time"
 
     def apply(bytes: ByteString): Either[SerdeError, LastFinalizedInputTime] =
@@ -58,7 +70,7 @@ object AppState {
 
   final case class LastFinalizedInputTime(time: TimeStamp) extends AppState
 
-  object MigrationVersion extends AppStateKey {
+  object MigrationVersion extends AppStateKey[MigrationVersion] {
     val key = "migrations_version"
 
     def apply(bytes: ByteString): Either[SerdeError, MigrationVersion] =
@@ -68,7 +80,7 @@ object AppState {
   final case class MigrationVersion(version: Int) extends AppState
 
   /** All the keys */
-  def keys(): Array[AppStateKey] =
+  def keys(): Array[AppStateKey[_]] =
     Array(LastFinalizedInputTime, MigrationVersion)
 
 }

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/AppStateQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/AppStateQueries.scala
@@ -16,12 +16,15 @@
 
 package org.alephium.explorer.persistence.queries
 
+import scala.concurrent.ExecutionContext
+import scala.reflect.ClassTag
+
+import slick.jdbc.GetResult
 import slick.jdbc.PostgresProfile.api._
 
 import org.alephium.explorer.persistence.{DBActionR, DBActionW}
 import org.alephium.explorer.persistence.model.{AppState, AppStateKey}
 import org.alephium.explorer.persistence.schema.AppStateSchema
-import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 
 /** Queries for table [[org.alephium.explorer.persistence.schema.AppStateSchema.table]] */
 object AppStateQueries {
@@ -32,6 +35,7 @@ object AppStateQueries {
   @inline def insertOrUpdate(appState: AppState): DBActionW[Int] =
     AppStateSchema.table insertOrUpdate appState
 
-  @inline def get(appState: AppStateKey): DBActionR[Option[AppState]] =
-    AppStateSchema.table.filter(_.key === appState).result.headOption
+  @inline def get[V <: AppState: ClassTag: GetResult](appState: AppStateKey[V])(
+      implicit ec: ExecutionContext): DBActionR[Option[V]] =
+    appState.get()
 }

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/AppStateSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/AppStateSchema.scala
@@ -26,8 +26,8 @@ import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 object AppStateSchema extends Schema[AppState]("app_state") {
 
   class AppStates(tag: Tag) extends Table[AppState](tag, name) {
-    def key: Rep[AppStateKey]  = column[AppStateKey]("key", O.PrimaryKey)
-    def value: Rep[ByteString] = column[ByteString]("value")
+    def key: Rep[AppStateKey[_]] = column[AppStateKey[_]]("key", O.PrimaryKey)
+    def value: Rep[ByteString]   = column[ByteString]("value")
 
     def * : ProvenShape[AppState] =
       (key, value).<>((AppState.applyOrThrow _).tupled, AppState.unapplyOpt)

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomGetResult.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomGetResult.scala
@@ -251,4 +251,19 @@ object CustomGetResult {
       val mainChain = result.nextBoolean()
       (chainFrom, chainTo, mainChain)
     }
+
+  implicit val migrationVersionGetResult: GetResult[AppState.MigrationVersion] =
+    (result: PositionedResult) =>
+      AppState.MigrationVersion(ByteString.fromArrayUnsafe(result.nextBytes())) match {
+        case Left(error)  => throw error
+        case Right(value) => value
+    }
+
+  implicit val lastFinalizedInputTimeGetResult: GetResult[AppState.LastFinalizedInputTime] =
+    (result: PositionedResult) =>
+      AppState.LastFinalizedInputTime(ByteString.fromArrayUnsafe(result.nextBytes())) match {
+        case Left(error)  => throw error
+        case Right(value) => value
+    }
+
 }

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomJdbcTypes.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomJdbcTypes.scala
@@ -130,13 +130,13 @@ object CustomJdbcTypes {
       OutputEntity.OutputType.unsafe
     )
 
-  implicit val appStateKey: JdbcType[AppStateKey] =
-    MappedJdbcType.base[AppStateKey, String](
+  implicit val appStateKey: JdbcType[AppStateKey[_]] =
+    MappedJdbcType.base[AppStateKey[_], String](
       state => state.key,
       key =>
         AppState
           .keys()
           .find(_.key == key)
-          .getOrElse(throw new Exception(s"Invalid ${classOf[AppStateKey].getSimpleName}: $key"))
+          .getOrElse(throw new Exception(s"Invalid ${classOf[AppStateKey[_]].getSimpleName}: $key"))
     )
 }

--- a/app/src/main/scala/org/alephium/explorer/service/BlockFlowSyncService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/BlockFlowSyncService.scala
@@ -184,17 +184,13 @@ case object BlockFlowSyncService extends StrictLogging {
     for {
       localTs  <- getLocalMaxTimestamp()
       remoteTs <- getRemoteMaxTimestamp()
-    } yield {
-      TimeUtil.buildTimeStampRangeOrEmpty(step, backStep, localTs, remoteTs) match {
+      result <- TimeUtil.buildTimeStampRangeOrEmpty(step, backStep, localTs, remoteTs) match {
         case Failure(exception) =>
-          logger.error("Failed to get TimeStamp range", exception)
-          //See issue #246. sys.exit need to be removed for graceful termination.
-          sys.exit(0)
-
+          Future.failed(exception)
         case Success(result) =>
-          result
+          Future.successful(result)
       }
-    }
+    } yield result
 
   /** @see [[org.alephium.explorer.persistence.queries.BlockQueries.numOfBlocksAndMaxBlockTimestamp]] */
   def getLocalMaxTimestamp()(implicit ec: ExecutionContext,

--- a/app/src/main/scala/org/alephium/explorer/util/ExecutionContextUtil.scala
+++ b/app/src/main/scala/org/alephium/explorer/util/ExecutionContextUtil.scala
@@ -1,0 +1,42 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.util
+
+import java.util.concurrent.Executor
+
+import scala.concurrent.ExecutionContext
+
+import com.typesafe.scalalogging.StrictLogging
+
+import org.alephium.explorer.error._
+
+object ExecutionContextUtil extends StrictLogging {
+
+  //Currently exiting on every error, we will fined grained this latter
+  //if we see other errors happening that are non-fatal
+  def reporter(exit: => Unit): Throwable => Unit = {
+    case fse: FatalSystemExit =>
+      logger.error(s"Fatal error, closing app", fse)
+      exit
+    case other =>
+      logger.error(s"Unexpected error, closing app", other)
+      exit
+  }
+
+  def fromExecutor(executor: Executor, exit: => Unit): ExecutionContext =
+    ExecutionContext.fromExecutor(executor, reporter(exit))
+}

--- a/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
@@ -142,6 +142,6 @@ class AddressServer(transactionService: TransactionService, exportTxsNumberThres
 
 object AddressServer {
   def exportFileNameHeader(address: Address, timeInterval: TimeInterval): String = {
-    s"""attachment;filename="$address-${timeInterval.from.millis}-${timeInterval.to.millis}""""
+    s"""attachment;filename="$address-${timeInterval.from.millis}-${timeInterval.to.millis}.csv""""
   }
 }

--- a/app/src/test/scala/org/alephium/explorer/service/EmptyBlockFlowClient.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/EmptyBlockFlowClient.scala
@@ -1,0 +1,57 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.service
+
+import scala.collection.immutable.ArraySeq
+import scala.concurrent.{ExecutionContext, Future}
+
+import sttp.model.Uri
+
+import org.alephium.api.model.{ChainInfo, ChainParams, HashesAtHeight, SelfClique}
+import org.alephium.explorer.api.model._
+import org.alephium.explorer.persistence.model._
+import org.alephium.protocol.model.BlockHash
+import org.alephium.util.{Service, TimeStamp}
+
+trait EmptyBlockFlowClient extends BlockFlowClient {
+  implicit val executionContext: ExecutionContext                                      = implicitly
+  override def startSelfOnce(): Future[Unit]                                           = Future.unit
+  override def stopSelfOnce(): Future[Unit]                                            = Future.unit
+  override def subServices: ArraySeq[Service]                                          = ArraySeq.empty
+  override def fetchBlock(fromGroup: GroupIndex, hash: BlockHash): Future[BlockEntity] = ???
+
+  override def fetchChainInfo(fromGroup: GroupIndex, toGroup: GroupIndex): Future[ChainInfo] = ???
+
+  override def fetchHashesAtHeight(fromGroup: GroupIndex,
+                                   toGroup: GroupIndex,
+                                   height: Height): Future[HashesAtHeight] = ???
+
+  override def fetchBlocks(fromTs: TimeStamp,
+                           toTs: TimeStamp,
+                           uri: Uri): Future[ArraySeq[ArraySeq[BlockEntity]]] = ???
+
+  override def fetchSelfClique(): Future[SelfClique] = ???
+
+  override def fetchChainParams(): Future[ChainParams] = ???
+
+  override def fetchUnconfirmedTransactions(uri: Uri): Future[ArraySeq[UnconfirmedTransaction]] =
+    ???
+
+  override def start(): Future[Unit] = ???
+
+  override def close(): Future[Unit] = ???
+}

--- a/app/src/test/scala/org/alephium/explorer/util/ExecutionContextUtilSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/util/ExecutionContextUtilSpec.scala
@@ -1,0 +1,51 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.util
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.concurrent.ExecutionContext
+
+import org.scalatest.concurrent.Eventually
+
+import org.alephium.explorer.AlephiumSpec
+import org.alephium.explorer.error.ExplorerError._
+
+@SuppressWarnings(Array("org.wartremover.warts.ThreadSleep"))
+class ExecutionContextSpec extends AlephiumSpec with Eventually {
+
+  "ExecutionContextUtil" should {
+    val count = new AtomicInteger(0)
+
+    def exit() = {
+      count.incrementAndGet()
+      ()
+    }
+
+    val executionContext = ExecutionContextUtil.fromExecutor(ExecutionContext.global, exit())
+
+    "exit on a fatal explorer error" in {
+      executionContext.reportFailure(new UnreachableNode(new Throwable("error")))
+      eventually(count.get() is 1)
+    }
+
+    "exit on any error" in {
+      executionContext.reportFailure(new Throwable("error"))
+      eventually(count.get() is 2)
+    }
+  }
+}

--- a/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
@@ -191,7 +191,7 @@ class AddressServerSpec()
           )
 
           val header =
-            Header("Content-Disposition", s"""attachment;filename="$address-$fromTs-$toTs"""")
+            Header("Content-Disposition", s"""attachment;filename="$address-$fromTs-$toTs.csv"""")
           response.headers.contains(header) is true
       }
     }
@@ -246,7 +246,7 @@ class AddressServerSpec()
       val from    = 1234L
       val to      = 5678L
 
-      val expected = s"""attachment;filename="$address-$from-$to""""
+      val expected = s"""attachment;filename="$address-$from-$to.csv""""
       AddressServer.exportFileNameHeader(
         Address.unsafe(address),
         TimeInterval(TimeStamp.unsafe(from), TimeStamp.unsafe(to))) is expected


### PR DESCRIPTION
Resolves #395 and #246 

I took the opportunity to tackle the second as it's related.

`ExecutionContext.reportFailure` is now used to warn the top of the application of a failure, currently we stop the app on all event (we use `reportFailure` only once), but later we could choose to have different kind of behavior.

Now that `SyncServices` can warn and stop the app, I could remove the `sys.exit` from `BlockFlowSyncService`, just need to fail the future and it will be catch by `SyncServices` and trigger the `reportFailure`.

The latest `sys.exit` was in migration, but it was actually a dead branch that couldn't be reach.

following the code, `AppStateQuery.get(MigrationVersion)` couldn't return anything else than `None` or `Some(MigrationVersion(x))`, but from the compiler side, it thought it could return any `AppState`. So I rework a bit the `AppState` thing so the compiler understand and the `sys.exit` was automatically removed.