### PR TITLE
Clean tables rather than drop/re-create them in `DatabaseFixtureForEach`

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/persistence/DBInitializer.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/DBInitializer.scala
@@ -35,8 +35,9 @@ object DBInitializer extends StrictLogging {
   @SuppressWarnings(
     Array("org.wartremover.warts.JavaSerializable",
           "org.wartremover.warts.Product",
-          "org.wartremover.warts.Serializable"))
-  private val allTables =
+          "org.wartremover.warts.Serializable",
+          "org.wartremover.warts.PublicInference"))
+  val allTables =
     ArraySeq(
       BlockHeaderSchema.table,
       BlockDepsSchema.table,

--- a/app/src/test/scala/org/alephium/explorer/persistence/DatabaseFixtureForAll.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/DatabaseFixtureForAll.scala
@@ -38,7 +38,7 @@ trait DatabaseFixtureForAll extends BeforeAndAfterAll with AlephiumFutures with 
   override def beforeAll(): Unit = {
     super.beforeAll()
     DatabaseFixture.createDb(dbName)
-    DatabaseFixture.dropCreateTables()
+    DatabaseFixture.createTables()
     logger.debug(s"Test database $dbName created")
   }
 

--- a/app/src/test/scala/org/alephium/explorer/persistence/DatabaseFixtureForEach.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/DatabaseFixtureForEach.scala
@@ -41,11 +41,12 @@ trait DatabaseFixtureForEach
   override def beforeAll(): Unit = {
     super.beforeAll()
     DatabaseFixture.createDb(dbName)
+    DatabaseFixture.createTables()
     logger.debug(s"Test database $dbName created")
   }
   override def beforeEach(): Unit = {
     super.beforeEach()
-    DatabaseFixture.dropCreateTables()
+    DatabaseFixture.cleanTables()
   }
 
   override def afterEach(): Unit = {


### PR DESCRIPTION
Performance are improved a bit  and it seems to make more sense like this, rather than re-creating tables and index every time.