### PR TITLE
Feature/add input tx hash ref

### DIFF
--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -3991,6 +3991,10 @@
             "type": "string",
             "format": "hex-string"
           },
+          "txHashRef": {
+            "type": "string",
+            "format": "32-byte-hash"
+          },
           "address": {
             "type": "string"
           },

--- a/app/src/main/scala/org/alephium/explorer/api/model/Input.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/Input.scala
@@ -23,12 +23,14 @@ import akka.util.ByteString
 import org.alephium.api.UtilJson._
 import org.alephium.explorer.api.Json._
 import org.alephium.json.Json._
+import org.alephium.protocol.model.TransactionId
 import org.alephium.util.U256
 
 @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
 final case class Input(
     outputRef: OutputRef,
     unlockScript: Option[ByteString] = None,
+    txHashRef: Option[TransactionId] = None,
     address: Option[Address]         = None,
     attoAlphAmount: Option[U256]     = None,
     tokens: Option[ArraySeq[Token]]  = None

--- a/app/src/main/scala/org/alephium/explorer/persistence/Migrations.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/Migrations.scala
@@ -83,7 +83,7 @@ object Migrations extends StrictLogging {
         (for {
           _ <- addInputTxHashRefColumn()
           _ <- dropInputOutputRefAddressNullIndex()
-        } yield Some(MigrationVersion(1))).transactionally
+        } yield Some(MigrationVersion(2))).transactionally
       case _ => DBIOAction.successful(Some(MigrationVersion(2)))
     }
   }

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/InputEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/InputEntity.scala
@@ -35,6 +35,7 @@ final case class InputEntity(
     mainChain: Boolean,
     inputOrder: Int,
     txOrder: Int,
+    outputRefTxHash: Option[TransactionId],
     outputRefAddress: Option[Address],
     outputRefAmount: Option[U256],
     outputRefTokens: Option[ArraySeq[Token]] //None if empty list
@@ -43,6 +44,7 @@ final case class InputEntity(
     Input(
       OutputRef(hint, outputRefKey),
       unlockScript,
+      Some(outputRef.txHash),
       Some(outputRef.address),
       Some(outputRef.amount),
       outputRef.tokens

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/UInputEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/UInputEntity.scala
@@ -33,6 +33,7 @@ final case class UInputEntity(
   val toApi: Input = Input(
     OutputRef(hint, outputRefKey),
     unlockScript,
+    None,
     address,
     None,
     None

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/InputQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/InputQueries.scala
@@ -37,7 +37,7 @@ object InputQueries {
   /** Inserts inputs or ignore rows with primary key conflict */
   // scalastyle:off magic.number
   def insertInputs(inputs: Iterable[InputEntity]): DBActionW[Int] =
-    QuerySplitter.splitUpdates(rows = inputs, columnsPerRow = 11) { (inputs, placeholder) =>
+    QuerySplitter.splitUpdates(rows = inputs, columnsPerRow = 12) { (inputs, placeholder) =>
       val query =
         s"""
            |INSERT INTO inputs ("block_hash",
@@ -49,6 +49,7 @@ object InputQueries {
            |                    "main_chain",
            |                    "input_order",
            |                    "tx_order",
+           |                    "output_ref_tx_hash",
            |                    "output_ref_address",
            |                    "output_ref_amount")
            |VALUES $placeholder
@@ -69,6 +70,7 @@ object InputQueries {
             params >> input.mainChain
             params >> input.inputOrder
             params >> input.txOrder
+            params >> input.outputRefTxHash
             params >> input.outputRefAddress
             params >> input.outputRefAmount
         }
@@ -88,6 +90,7 @@ object InputQueries {
                  inputs.hint,
                  inputs.output_ref_key,
                  inputs.unlock_script,
+                 outputs.tx_hash,
                  outputs.address,
                  outputs.amount,
                  outputs.tokens
@@ -111,6 +114,7 @@ object InputQueries {
                  inputs.hint,
                  inputs.output_ref_key,
                  inputs.unlock_script,
+                 outputs.tx_hash,
                  outputs.address,
                  outputs.amount,
                  outputs.tokens
@@ -144,6 +148,7 @@ object InputQueries {
            |       hint,
            |       output_ref_key,
            |       unlock_script,
+           |       output_ref_tx_hash,
            |       output_ref_address,
            |       output_ref_amount,
            |       output_ref_tokens
@@ -171,6 +176,7 @@ object InputQueries {
         SELECT hint,
                output_ref_key,
                unlock_script,
+               output_ref_tx_hash,
                output_ref_address,
                output_ref_amount,
                output_ref_tokens
@@ -192,6 +198,7 @@ object InputQueries {
           main_chain,
           input_order,
           tx_order,
+          output_ref_tx_hash,
           output_ref_address,
           output_ref_amount,
           output_ref_tokens

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/InputUpdateQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/InputUpdateQueries.scala
@@ -36,6 +36,7 @@ object InputUpdateQueries {
     sql"""
       UPDATE inputs
       SET
+        output_ref_tx_hash = outputs.tx_hash,
         output_ref_address = outputs.address,
         output_ref_amount = outputs.amount,
         output_ref_tokens = outputs.tokens

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/result/InputsFromTxQR.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/result/InputsFromTxQR.scala
@@ -36,6 +36,7 @@ object InputsFromTxQR {
         hint         = result.<<,
         outputRefKey = result.<<,
         unlockScript = result.<<?,
+        txHashRef    = result.<<?,
         address      = result.<<?,
         amount       = result.<<?,
         token        = result.<<?
@@ -48,6 +49,7 @@ final case class InputsFromTxQR(txHash: TransactionId,
                                 hint: Int,
                                 outputRefKey: Hash,
                                 unlockScript: Option[ByteString],
+                                txHashRef: Option[TransactionId],
                                 address: Option[Address],
                                 amount: Option[U256],
                                 token: Option[ArraySeq[Token]]) {
@@ -55,6 +57,7 @@ final case class InputsFromTxQR(txHash: TransactionId,
   def toApiInput(): Input =
     Input(outputRef      = OutputRef(hint, outputRefKey),
           unlockScript   = unlockScript,
+          txHashRef      = txHashRef,
           address        = address,
           attoAlphAmount = amount,
           tokens         = token)

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/result/InputsQR.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/result/InputsQR.scala
@@ -24,6 +24,7 @@ import slick.jdbc.{GetResult, PositionedResult}
 import org.alephium.explorer.Hash
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.persistence.schema.CustomGetResult._
+import org.alephium.protocol.model.TransactionId
 import org.alephium.util.U256
 
 object InputsQR {
@@ -33,6 +34,7 @@ object InputsQR {
         hint             = result.<<,
         outputRefKey     = result.<<,
         unlockScript     = result.<<?,
+        outputRefTxHash  = result.<<?,
         outputRefAddress = result.<<?,
         outputRefAmount  = result.<<?,
         outputRefTokens  = result.<<?
@@ -43,14 +45,18 @@ object InputsQR {
 final case class InputsQR(hint: Int,
                           outputRefKey: Hash,
                           unlockScript: Option[ByteString],
+                          outputRefTxHash: Option[TransactionId],
                           outputRefAddress: Option[Address],
                           outputRefAmount: Option[U256],
                           outputRefTokens: Option[ArraySeq[Token]]) {
 
   def toApiInput(): Input =
-    Input(outputRef      = OutputRef(hint, outputRefKey),
-          unlockScript   = unlockScript,
-          address        = outputRefAddress,
-          attoAlphAmount = outputRefAmount,
-          tokens         = outputRefTokens)
+    Input(
+      outputRef      = OutputRef(hint, outputRefKey),
+      unlockScript   = unlockScript,
+      txHashRef      = outputRefTxHash,
+      address        = outputRefAddress,
+      attoAlphAmount = outputRefAmount,
+      tokens         = outputRefTokens
+    )
 }

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomGetResult.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomGetResult.scala
@@ -152,6 +152,7 @@ object CustomGetResult {
         mainChain        = result.<<,
         inputOrder       = result.<<,
         txOrder          = result.<<,
+        outputRefTxHash  = result.<<?,
         outputRefAddress = result.<<?,
         outputRefAmount  = result.<<?,
         outputRefTokens  = result.<<?

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/InputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/InputSchema.scala
@@ -33,15 +33,17 @@ import org.alephium.util.{TimeStamp, U256}
 object InputSchema extends SchemaMainChain[InputEntity]("inputs") {
 
   class Inputs(tag: Tag) extends Table[InputEntity](tag, name) {
-    def blockHash: Rep[BlockHash]              = column[BlockHash]("block_hash", O.SqlType("BYTEA"))
-    def txHash: Rep[TransactionId]             = column[TransactionId]("tx_hash", O.SqlType("BYTEA"))
-    def timestamp: Rep[TimeStamp]              = column[TimeStamp]("block_timestamp")
-    def hint: Rep[Int]                         = column[Int]("hint")
-    def outputRefKey: Rep[Hash]                = column[Hash]("output_ref_key", O.SqlType("BYTEA"))
-    def unlockScript: Rep[Option[ByteString]]  = column[Option[ByteString]]("unlock_script")
-    def mainChain: Rep[Boolean]                = column[Boolean]("main_chain")
-    def inputOrder: Rep[Int]                   = column[Int]("input_order")
-    def txOrder: Rep[Int]                      = column[Int]("tx_order")
+    def blockHash: Rep[BlockHash]             = column[BlockHash]("block_hash", O.SqlType("BYTEA"))
+    def txHash: Rep[TransactionId]            = column[TransactionId]("tx_hash", O.SqlType("BYTEA"))
+    def timestamp: Rep[TimeStamp]             = column[TimeStamp]("block_timestamp")
+    def hint: Rep[Int]                        = column[Int]("hint")
+    def outputRefKey: Rep[Hash]               = column[Hash]("output_ref_key", O.SqlType("BYTEA"))
+    def unlockScript: Rep[Option[ByteString]] = column[Option[ByteString]]("unlock_script")
+    def mainChain: Rep[Boolean]               = column[Boolean]("main_chain")
+    def inputOrder: Rep[Int]                  = column[Int]("input_order")
+    def txOrder: Rep[Int]                     = column[Int]("tx_order")
+    def outputRefTxHash: Rep[Option[TransactionId]] =
+      column[Option[TransactionId]]("output_ref_tx_hash")
     def outputRefAddress: Rep[Option[Address]] = column[Option[Address]]("output_ref_address")
     def outputRefAmount: Rep[Option[U256]] =
       column[Option[U256]]("output_ref_amount", O.SqlType("DECIMAL(80,0)")) //U256.MaxValue has 78 digits
@@ -66,6 +68,7 @@ object InputSchema extends SchemaMainChain[InputEntity]("inputs") {
        mainChain,
        inputOrder,
        txOrder,
+       outputRefTxHash,
        outputRefAddress,
        outputRefAmount,
        outputRefTokens)
@@ -74,7 +77,7 @@ object InputSchema extends SchemaMainChain[InputEntity]("inputs") {
 
   def createOutputRefAddressNullIndex(): DBActionW[Int] =
     sqlu"""CREATE INDEX IF NOT EXISTS inputs_output_ref_amount_null_idx
-      ON #${name} (output_ref_address, output_ref_amount, output_ref_tokens)
+      ON #${name} (output_ref_tx_hash, output_ref_address, output_ref_amount, output_ref_tokens)
       WHERE output_ref_amount IS NULL"""
 
   val table: TableQuery[Inputs] = TableQuery[Inputs]

--- a/app/src/main/scala/org/alephium/explorer/service/BlockFlowClient.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/BlockFlowClient.scala
@@ -348,6 +348,7 @@ object BlockFlowClient extends StrictLogging {
     Input(
       OutputRef(input.outputRef.hint, input.outputRef.key),
       Some(input.unlockScript),
+      None,
       addressFromProtocolInput(input),
       None,
       None
@@ -371,6 +372,7 @@ object BlockFlowClient extends StrictLogging {
       mainChain,
       index,
       txOrder,
+      None,
       addressFromProtocolInput(input),
       None,
       None
@@ -394,6 +396,7 @@ object BlockFlowClient extends StrictLogging {
       mainChain,
       index,
       txOrder,
+      None,
       None,
       None,
       None

--- a/app/src/test/scala/org/alephium/explorer/GenApiModel.scala
+++ b/app/src/test/scala/org/alephium/explorer/GenApiModel.scala
@@ -59,9 +59,10 @@ object GenApiModel extends ImplicitConversions {
   val inputGen: Gen[Input] = for {
     outputRef    <- outputRefGen
     unlockScript <- Gen.option(unlockScriptGen)
+    txHashRef    <- Gen.option(transactionHashGen)
     address      <- Gen.option(addressGen)
     amount       <- Gen.option(amountGen)
-  } yield Input(outputRef, unlockScript, address, amount)
+  } yield Input(outputRef, unlockScript, txHashRef, address, amount)
 
   val tokenGen: Gen[Token] = for {
     id     <- tokenIdGen
@@ -110,7 +111,7 @@ object GenApiModel extends ImplicitConversions {
       hash      <- transactionHashGen
       chainFrom <- groupIndexGen
       chainTo   <- groupIndexGen
-      inputs    <- Gen.listOfN(3, inputGen.map(_.copy(attoAlphAmount = None)))
+      inputs    <- Gen.listOfN(3, inputGen.map(_.copy(attoAlphAmount = None, txHashRef = None)))
       outputs   <- Gen.listOfN(3, assetOutputGen.map(_.copy(spent = None)))
       gasAmount <- Gen.posNum[Int]
       gasPrice  <- u256Gen

--- a/app/src/test/scala/org/alephium/explorer/Generators.scala
+++ b/app/src/test/scala/org/alephium/explorer/Generators.scala
@@ -501,6 +501,7 @@ object Generators {
         txOrder      = txOrder,
         None,
         None,
+        None,
         None
       )
     }

--- a/app/src/test/scala/org/alephium/explorer/api/model/ApiModelSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/api/model/ApiModelSpec.scala
@@ -208,7 +208,9 @@ class ApiModelSpec() extends AlephiumSpec {
      |{
      |  "outputRef": ${write(input.outputRef)}
      |  ${input.unlockScript.map(script => s""","unlockScript": ${write(script)}""").getOrElse("")}
-     |  ${input.address.map(address => s""","address": "${address}"""").getOrElse("")}
+     |  ${input.txHashRef.map(txHashRef      => s""","txHashRef": "${txHashRef.toHexString}"""")
+                          .getOrElse("")}
+     |  ${input.address.map(address           => s""","address": "${address}"""").getOrElse("")}
      |  ${input.attoAlphAmount
                           .map(attoAlphAmount => s""","attoAlphAmount": "${attoAlphAmount}"""")
                           .getOrElse("")}

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/InputQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/InputQueriesSpec.scala
@@ -106,6 +106,7 @@ class InputQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForEach wi
                 hint         = entity.hint,
                 outputRefKey = entity.outputRefKey,
                 unlockScript = entity.unlockScript,
+                txHashRef    = entity.outputRefTxHash,
                 address      = entity.outputRefAddress,
                 amount       = entity.outputRefAmount,
                 token        = entity.outputRefTokens
@@ -151,6 +152,7 @@ class InputQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForEach wi
               hint             = input.hint,
               outputRefKey     = input.outputRefKey,
               unlockScript     = input.unlockScript,
+              outputRefTxHash  = input.outputRefTxHash,
               outputRefAddress = input.outputRefAddress,
               outputRefAmount  = input.outputRefAmount,
               outputRefTokens  = input.outputRefTokens

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/TransactionQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/TransactionQueriesSpec.scala
@@ -239,6 +239,7 @@ class TransactionQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForE
           hint         = input.hint,
           outputRefKey = input.outputRefKey,
           unlockScript = input.unlockScript,
+          txHashRef    = Some(output.txHash),
           address      = Some(output.address),
           amount       = Some(output.amount),
           token        = output.tokens
@@ -622,6 +623,7 @@ class TransactionQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForE
                   true,
                   0,
                   0,
+                  None,
                   None,
                   None,
                   None)

--- a/app/src/test/scala/org/alephium/explorer/service/TokenSupplyServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TokenSupplyServiceSpec.scala
@@ -198,6 +198,7 @@ class TokenSupplyServiceSpec extends AlephiumFutureSpec with DatabaseFixtureForE
                         0,
                         None,
                         None,
+                        None,
                         None)
 
         },

--- a/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
@@ -182,6 +182,7 @@ class TransactionServiceSpec extends AlephiumActorSpecLike with DatabaseFixtureF
                              0,
                              None,
                              None,
+                             None,
                              None)
     val output1 = OutputEntity(blockHash1,
                                tx1.hash,
@@ -237,7 +238,12 @@ class TransactionServiceSpec extends AlephiumActorSpecLike with DatabaseFixtureF
       tx1.hash,
       blockHash1,
       ts1,
-      ArraySeq(Input(OutputRef(0, output0.key), None, Some(address0), Some(U256.One))),
+      ArraySeq(
+        Input(OutputRef(0, output0.key),
+              None,
+              Some(output0.txHash),
+              Some(address0),
+              Some(U256.One))),
       ArraySeq(AssetOutput(output1.hint, output1.key, U256.One, address1, None, None, None, None)),
       gasAmount1,
       gasPrice1

--- a/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/DataGenerator.scala
+++ b/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/DataGenerator.scala
@@ -99,6 +99,7 @@ object DataGenerator {
           txOrder      = order,
           None,
           None,
+          None,
           None
         )
     }

--- a/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/AddressReadState.scala
+++ b/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/AddressReadState.scala
@@ -95,6 +95,7 @@ class AddressReadState(val db: DBExecutor)
       txOrder      = 0,
       None,
       None,
+      None,
       None
     )
   }


### PR DESCRIPTION
I'm still running the migration, but we can already start to review it.

In the second commit I change the migration to update inputs day by day, otherwise we can't really see the progress and we can think it stucks. 

EDIT: Migration done in around 1:30h, I checked multiple Inputs, data seems all correct. I also checked and all inputs where updated, (no inputs with `output_tx_hash_ref = nulll` in DB