### PR TITLE
Fix console logging level

### DIFF
--- a/app/src/main/resources/logback.xml
+++ b/app/src/main/resources/logback.xml
@@ -69,10 +69,6 @@
     </if>
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>${EXPLORER_LOG_LEVEL:-INFO}</level>
-        </filter>
-
         <encoder>
             <pattern>${consolePattern}</pattern>
         </encoder>
@@ -84,7 +80,7 @@
     <logger name="io.netty" level="WARN"/>
     <logger name="org.asynchttpclient" level="WARN"/>
 
-    <root>
+    <root level="${EXPLORER_LOG_LEVEL:-INFO}">
         <appender-ref ref="CONSOLE"/>
         <appender-ref ref="ERRFILE"/>
         <appender-ref ref="INFOFILE"/>

--- a/app/src/test/resources/logback-test.xml
+++ b/app/src/test/resources/logback-test.xml
@@ -4,22 +4,19 @@
               value="%-63(%yellow(%date{ISO8601}) %green([%.13thread])) %highlight(%-5level) %-50(%cyan(%logger{20})) - %msg%n"/>
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
-        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-            <level>DEBUG</level>
-        </filter>
-
         <encoder>
             <pattern>${defaultPattern}</pattern>
         </encoder>
     </appender>
 
+    <logger name="ROOT" level="DEBUG"/>
     <logger name="akka.http.impl.engine.client" level="WARN"/>
     <logger name="slick" level="INFO"/>
     <logger name="com.zaxxer.hikari" level="INFO"/>
     <logger name="io.netty" level="WARN"/>
     <logger name="org.asynchttpclient" level="WARN"/>
 
-    <root>
+    <root level="DEBUG" >
         <appender-ref ref="CONSOLE"/>
     </root>
 </configuration>


### PR DESCRIPTION
We were not configuring the log level at the right place, the threshold is a fixed limit that cannot be passed, it makes sense for the various `FileAppender`, but not for console (in our case).

Resolves: https://github.com/alephium/explorer-backend/issues/391

Calling the update-log-level endpoint now works as expected, I manually tested it.

I tried to add a Unit test, but using mocking is a nightmare and nothing is working or it's ugly as hell.

 @polarker let me know if you want me  to do the same in the full node.