### PR TITLE
Fix missing finalized outputs

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/SyncServices.scala
+++ b/app/src/main/scala/org/alephium/explorer/SyncServices.scala
@@ -50,6 +50,7 @@ object SyncServices extends StrictLogging {
         Future.unit
 
       case BootMode.ReadWrite | BootMode.WriteOnly =>
+        logger.info("Starting sync services")
         getPeers(
           networkId          = config.networkId,
           directCliqueAccess = config.directCliqueAccess,

--- a/app/src/main/scala/org/alephium/explorer/persistence/Migrations.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/Migrations.scala
@@ -28,11 +28,15 @@ import org.alephium.explorer.foldFutures
 import org.alephium.explorer.persistence.model.AppState.MigrationVersion
 import org.alephium.explorer.persistence.queries.AppStateQueries
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
+import org.alephium.explorer.service.FinalizerService
 import org.alephium.explorer.util.TimeUtil
 import org.alephium.protocol.ALPH
 import org.alephium.util.{Duration, TimeStamp}
 
+@SuppressWarnings(Array("org.wartremover.warts.AnyVal"))
 object Migrations extends StrictLogging {
+
+  val latestVersion: MigrationVersion = MigrationVersion(3)
 
   def addInputTxHashRefColumn(): DBActionWT[Int] = {
     sqlu"""
@@ -61,7 +65,7 @@ object Migrations extends StrictLogging {
         output_ref_tx_hash = outputs.tx_hash
       FROM outputs
       WHERE inputs.block_timestamp >= $from
-      AND inputs.block_timestamp < $to
+      AND inputs.block_timestamp <= $to
       AND inputs.output_ref_key = outputs.key
       AND outputs.main_chain = true
       AND inputs.output_ref_tx_hash IS NULL
@@ -70,21 +74,74 @@ object Migrations extends StrictLogging {
     }.map(_ => ())
   }
 
-  def migrations(versionOpt: Option[MigrationVersion])(
-      implicit ec: ExecutionContext): DBActionWT[Option[MigrationVersion]] = {
+  def updateOutputs(finalizationTime: TimeStamp): DBActionW[Int] =
+    sqlu"""
+      UPDATE outputs o
+      SET spent_finalized = i.tx_hash
+      FROM inputs i
+      WHERE i.output_ref_key = o.key
+      AND o.spent_finalized IS NULL
+      AND o.main_chain=true
+      AND i.main_chain=true
+      AND i.block_timestamp <= $finalizationTime
+      """
+
+  def updateTokenOutputs(finalizationTime: TimeStamp): DBActionW[Int] =
+    sqlu"""
+      UPDATE token_outputs o
+      SET spent_finalized = i.tx_hash
+      FROM inputs i
+      WHERE i.output_ref_key = o.key
+      AND o.spent_finalized IS NULL
+      AND o.main_chain=true
+      AND i.main_chain=true
+      AND i.block_timestamp <= $finalizationTime
+      """
+
+  def updateFinalizedValue(implicit ec: ExecutionContext): DBActionWT[Unit] = {
+    logger.info(s"Migrating finalized outputs and tokens")
+    val finalizationTime = FinalizerService.finalizationTime
+    (for {
+      outs <- updateOutputs(finalizationTime)
+      toks <- updateTokenOutputs(finalizationTime)
+    } yield {
+      logger.info(s"$outs outputs finalized")
+      logger.info(s"$toks tokens finalized")
+    }).transactionally
+  }
+
+  private val migration1 =
+    sqlu"""
+      CREATE INDEX IF NOT EXISTS txs_per_address_address_timestamp_idx
+      ON transaction_per_addresses (address, block_timestamp)
+    """
+
+  private def migration2(implicit ec: ExecutionContext) =
+    (for {
+      _ <- addInputTxHashRefColumn()
+      _ <- dropInputOutputRefAddressNullIndex()
+    } yield ()).transactionally
+
+  private def migration3(implicit ec: ExecutionContext) = updateFinalizedValue
+
+  private def migrations(implicit ec: ExecutionContext) =
+    Seq(migration1, migration2, migration3)
+
+  def migrationsQuery(versionOpt: Option[MigrationVersion])(
+      implicit ec: ExecutionContext): DBActionWT[Unit] = {
     logger.info(s"Current migration version: $versionOpt")
     versionOpt match {
-      case Some(MigrationVersion(0)) =>
-        for {
-          _ <- sqlu"""CREATE INDEX IF NOT EXISTS txs_per_address_address_timestamp_idx
-                  ON transaction_per_addresses (address, block_timestamp)"""
-        } yield Some(MigrationVersion(1))
-      case Some(MigrationVersion(1)) =>
-        (for {
-          _ <- addInputTxHashRefColumn()
-          _ <- dropInputOutputRefAddressNullIndex()
-        } yield Some(MigrationVersion(2))).transactionally
-      case _ => DBIOAction.successful(Some(MigrationVersion(2)))
+      //noop
+      case None | Some(MigrationVersion(latestVersion.version)) =>
+        logger.info(s"No migrations needed")
+        DBIOAction.successful(())
+      case Some(MigrationVersion(current)) =>
+        logger.info(s"Applying ${latestVersion.version - current} migrations")
+        val migrationsToPerform = migrations.drop(current)
+        DBIOAction
+          .sequence(migrationsToPerform)
+          .transactionally
+          .map(_ => ())
     }
   }
 
@@ -92,17 +149,17 @@ object Migrations extends StrictLogging {
       implicit ec: ExecutionContext): Future[Unit] = {
     logger.info("Migrating")
     for {
-      (prevVersion, newVersion) <- DBRunner
+      prevVersion <- DBRunner
         .run(databaseConfig)(for {
-          version       <- getVersion()
-          newVersionOpt <- migrations(version)
-        } yield (version, newVersionOpt))
-      _ <- if (prevVersion == Some(MigrationVersion(1))) {
+          version <- getVersion()
+          _       <- migrationsQuery(version)
+        } yield version)
+      _ <- if (prevVersion.map(_.version < 2).getOrElse(false)) {
         updateInputTxHashRef(databaseConfig)
       } else {
         Future.unit
       }
-      _ <- DBRunner.run(databaseConfig)(updateVersion(newVersion))
+      _ <- DBRunner.run(databaseConfig)(updateVersion(Some(latestVersion)))
     } yield ()
   }
 

--- a/app/src/main/scala/org/alephium/explorer/util/TimeUtil.scala
+++ b/app/src/main/scala/org/alephium/explorer/util/TimeUtil.scala
@@ -59,13 +59,13 @@ object TimeUtil {
       if (next.isBefore(remoteTs)) {
         rec(next.plusMillisUnsafe(1), seq :+ ((l, next)))
       } else if (l == remoteTs) {
-        seq :+ ((remoteTs, remoteTs.plusMillisUnsafe(1)))
+        seq :+ ((remoteTs, remoteTs))
       } else {
         seq :+ ((l, remoteTs))
       }
     }
 
-    if (remoteTs.millis <= localTs.millis || step == Duration.zero) {
+    if (remoteTs.millis < localTs.millis || step == Duration.zero) {
       ArraySeq.empty
     } else {
       rec(localTs, ArraySeq.empty)

--- a/app/src/test/scala/org/alephium/explorer/util/TimeUtilSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/util/TimeUtilSpec.scala
@@ -76,13 +76,13 @@ class TimeUtilSpec extends AlephiumSpec with Matchers {
         ArraySeq(r(0, 2), r(3, 5))
 
       buildTimestampRange(t(0), t(6), s(2)) is
-        ArraySeq(r(0, 2), r(3, 5), r(6, 7))
+        ArraySeq(r(0, 2), r(3, 5), r(6, 6))
 
       buildTimestampRange(t(0), t(7), s(2)) is
         ArraySeq(r(0, 2), r(3, 5), r(6, 7))
 
       buildTimestampRange(t(1), t(1), s(1)) is
-        ArraySeq.empty
+        ArraySeq(r(1, 1))
 
       buildTimestampRange(t(1), t(0), s(1)) is
         ArraySeq.empty


### PR DESCRIPTION
[TimeUtil.buildTimeStampRange](https://github.com/alephium/explorer-backend/blob/de891687eaa0fb11b1002bd61b49e77b41c90a90/app/src/main/scala/org/alephium/explorer/util/TimeUtil.scala#L52-L73): From this function, [it implies that our queries have to be inclusive](https://github.com/alephium/explorer-backend/blob/de891687eaa0fb11b1002bd61b49e77b41c90a90/app/src/test/scala/org/alephium/explorer/util/TimeUtilSpec.scala#L81-L82) on both `fromTs` and `toTs`: if our time ranges are: `(0,2), (3,5)`, if our query has `< toTs`, the first range will take only `0 -> 1` timestamps. On the second range it will take `3 -> 4`, So `2` and `5` will be ignored. We were also handling the case where the last time range was supposed to be exactly the same value, we were adding `+1ms` (see [test](https://github.com/alephium/explorer-backend/compare/fix/time-ranges?expand=1#diff-b44f35509058325905b061f74f32809f679f3f4b9698e3b2d40a6a50a14c0d90L79)), which is then wrong then when doing the queries, as we want both inclusive values, `<= toTs` was then taking value `+1ms` too much compared to what we asked for.

We will now see that every functions using this `buildTimeStampRange` is fine using inclusion from both side.

`FinalizerService`: [we need to have <=](https://github.com/alephium/explorer-backend/compare/fix/time-ranges?expand=1#diff-67c243d4b5cf51a0ac4a1913ea8f3ed48a022f151bc7d3a73c4e4e7a3e6ddc36R111) other wise on each round, the `to` will be missed. Also [previously we were not returning any time range if there were only 1 input](https://github.com/alephium/explorer-backend/compare/fix/time-ranges?expand=1#diff-67c243d4b5cf51a0ac4a1913ea8f3ed48a022f151bc7d3a73c4e4e7a3e6ddc36L132), it's really a corner case, but we still need it. If someone run a Devnet and do only one transaction, the output ref needs to marked as `spent`.

[BlockFlowSyncService](https://github.com/alephium/explorer-backend/blob/53f25a344d29555e1810bb53a9de33ceb8dcbe00/app/src/main/scala/org/alephium/explorer/service/BlockFlowSyncService.scala#L188):  all good to have inclusive `from - to` as [it's the case when fetching the node](https://github.com/alephium/alephium/blob/9b103b488d786c8933f41d9b75d43b10e42edb42/flow/src/main/scala/org/alephium/flow/core/BlockChain.scala#L138)

Migrations: [InputUpdateQueries.updateInputs](https://github.com/alephium/explorer-backend/blob/de891687eaa0fb11b1002bd61b49e77b41c90a90/app/src/main/scala/org/alephium/explorer/persistence/queries/InputUpdateQueries.scala#L35-L51) query doesn't care about timestamps, we used timestamp in the migrations to be able to log progress. So those who already ran the migration and might have miss some inputs, they will be eventually updated by the `updateInputs` function.

I ran the migrations with our latest archive, there were around 2300 outupts to update, took around 45s.

For all the test and checkup I did, I pretty sure only this `spent_finalized` was impacted
