### PR TITLE
#253: OpenAPI `Endpoint` examples for Block APIs

### DIFF
--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -49,6 +49,31 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ListBlocks"
+                },
+                "example": {
+                  "total": 2,
+                  "blocks": [
+                    {
+                      "hash": "bdaf9dc514ce7d34b6474b8ca10a3dfb93ba997cb9d5ff1ea724ebe2af48abe5",
+                      "timestamp": 1611041396892,
+                      "chainFrom": 1,
+                      "chainTo": 2,
+                      "height": 42,
+                      "txNumber": 1,
+                      "mainChain": true,
+                      "hashRate": "100"
+                    },
+                    {
+                      "hash": "bdaf9dc514ce7d34b6474b8ca10a3dfb93ba997cb9d5ff1ea724ebe2af48abe5",
+                      "timestamp": 1611041396892,
+                      "chainFrom": 1,
+                      "chainTo": 2,
+                      "height": 42,
+                      "txNumber": 1,
+                      "mainChain": true,
+                      "hashRate": "100"
+                    }
+                  ]
                 }
               }
             }
@@ -145,6 +170,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/BlockEntryLite"
+                },
+                "example": {
+                  "hash": "bdaf9dc514ce7d34b6474b8ca10a3dfb93ba997cb9d5ff1ea724ebe2af48abe5",
+                  "timestamp": 1611041396892,
+                  "chainFrom": 1,
+                  "chainTo": 2,
+                  "height": 42,
+                  "txNumber": 1,
+                  "mainChain": true,
+                  "hashRate": "100"
                 }
               }
             }
@@ -273,7 +308,143 @@
                   "items": {
                     "$ref": "#/components/schemas/Transaction"
                   }
-                }
+                },
+                "example": [
+                  {
+                    "hash": "503bfb16230888af4924aa8f8250d7d348b862e267d75d3147f1998050b6da69",
+                    "blockHash": "bdaf9dc514ce7d34b6474b8ca10a3dfb93ba997cb9d5ff1ea724ebe2af48abe5",
+                    "timestamp": 1611041396892,
+                    "inputs": [
+                      {
+                        "outputRef": {
+                          "hint": 23412,
+                          "key": "798e9e137aec7c2d59d9655b4ffa640f301f628bf7c365083bb255f6aa5f89ef"
+                        },
+                        "unlockScript": "d1b70d2226308b46da297486adb6b4f1a8c1842cb159ac5ec04f384fe2d6f5da28",
+                        "txHashRef": "503bfb16230888af4924aa8f8250d7d348b862e267d75d3147f1998050b6da69",
+                        "address": "1AujpupFP4KWeZvqA7itsHY9cLJmx4qTzojVZrg8W9y",
+                        "attoAlphAmount": "2",
+                        "tokens": [
+                          {
+                            "id": "2d11fd6c12435ffb07aaed4d190a505b621b927a5f6e51b61ce0ebe186397bdd",
+                            "amount": "42000000000000000000"
+                          },
+                          {
+                            "id": "bd165d20bd063c7a023d22232a1e75bf46e904067f92b49323fe89fa0fd586bf",
+                            "amount": "1000000000000000000000"
+                          }
+                        ]
+                      }
+                    ],
+                    "outputs": [
+                      {
+                        "type": "AssetOutput",
+                        "hint": 1,
+                        "key": "798e9e137aec7c2d59d9655b4ffa640f301f628bf7c365083bb255f6aa5f89ef",
+                        "attoAlphAmount": "2",
+                        "address": "1AujpupFP4KWeZvqA7itsHY9cLJmx4qTzojVZrg8W9y",
+                        "tokens": [
+                          {
+                            "id": "2d11fd6c12435ffb07aaed4d190a505b621b927a5f6e51b61ce0ebe186397bdd",
+                            "amount": "42000000000000000000"
+                          },
+                          {
+                            "id": "bd165d20bd063c7a023d22232a1e75bf46e904067f92b49323fe89fa0fd586bf",
+                            "amount": "1000000000000000000000"
+                          }
+                        ],
+                        "lockTime": 1611041396892,
+                        "message": "798e9e137aec7c2d59d9655b4ffa640f301f628bf7c365083bb255f6aa5f89ef"
+                      },
+                      {
+                        "type": "ContractOutput",
+                        "hint": 1,
+                        "key": "798e9e137aec7c2d59d9655b4ffa640f301f628bf7c365083bb255f6aa5f89ef",
+                        "attoAlphAmount": "2",
+                        "address": "1AujpupFP4KWeZvqA7itsHY9cLJmx4qTzojVZrg8W9y",
+                        "tokens": [
+                          {
+                            "id": "2d11fd6c12435ffb07aaed4d190a505b621b927a5f6e51b61ce0ebe186397bdd",
+                            "amount": "42000000000000000000"
+                          },
+                          {
+                            "id": "bd165d20bd063c7a023d22232a1e75bf46e904067f92b49323fe89fa0fd586bf",
+                            "amount": "1000000000000000000000"
+                          }
+                        ]
+                      }
+                    ],
+                    "gasAmount": 20000,
+                    "gasPrice": "100000000000"
+                  },
+                  {
+                    "hash": "503bfb16230888af4924aa8f8250d7d348b862e267d75d3147f1998050b6da69",
+                    "blockHash": "bdaf9dc514ce7d34b6474b8ca10a3dfb93ba997cb9d5ff1ea724ebe2af48abe5",
+                    "timestamp": 1611041396892,
+                    "inputs": [
+                      {
+                        "outputRef": {
+                          "hint": 23412,
+                          "key": "798e9e137aec7c2d59d9655b4ffa640f301f628bf7c365083bb255f6aa5f89ef"
+                        },
+                        "unlockScript": "d1b70d2226308b46da297486adb6b4f1a8c1842cb159ac5ec04f384fe2d6f5da28",
+                        "txHashRef": "503bfb16230888af4924aa8f8250d7d348b862e267d75d3147f1998050b6da69",
+                        "address": "1AujpupFP4KWeZvqA7itsHY9cLJmx4qTzojVZrg8W9y",
+                        "attoAlphAmount": "2",
+                        "tokens": [
+                          {
+                            "id": "2d11fd6c12435ffb07aaed4d190a505b621b927a5f6e51b61ce0ebe186397bdd",
+                            "amount": "42000000000000000000"
+                          },
+                          {
+                            "id": "bd165d20bd063c7a023d22232a1e75bf46e904067f92b49323fe89fa0fd586bf",
+                            "amount": "1000000000000000000000"
+                          }
+                        ]
+                      }
+                    ],
+                    "outputs": [
+                      {
+                        "type": "AssetOutput",
+                        "hint": 1,
+                        "key": "798e9e137aec7c2d59d9655b4ffa640f301f628bf7c365083bb255f6aa5f89ef",
+                        "attoAlphAmount": "2",
+                        "address": "1AujpupFP4KWeZvqA7itsHY9cLJmx4qTzojVZrg8W9y",
+                        "tokens": [
+                          {
+                            "id": "2d11fd6c12435ffb07aaed4d190a505b621b927a5f6e51b61ce0ebe186397bdd",
+                            "amount": "42000000000000000000"
+                          },
+                          {
+                            "id": "bd165d20bd063c7a023d22232a1e75bf46e904067f92b49323fe89fa0fd586bf",
+                            "amount": "1000000000000000000000"
+                          }
+                        ],
+                        "lockTime": 1611041396892,
+                        "message": "798e9e137aec7c2d59d9655b4ffa640f301f628bf7c365083bb255f6aa5f89ef"
+                      },
+                      {
+                        "type": "ContractOutput",
+                        "hint": 1,
+                        "key": "798e9e137aec7c2d59d9655b4ffa640f301f628bf7c365083bb255f6aa5f89ef",
+                        "attoAlphAmount": "2",
+                        "address": "1AujpupFP4KWeZvqA7itsHY9cLJmx4qTzojVZrg8W9y",
+                        "tokens": [
+                          {
+                            "id": "2d11fd6c12435ffb07aaed4d190a505b621b927a5f6e51b61ce0ebe186397bdd",
+                            "amount": "42000000000000000000"
+                          },
+                          {
+                            "id": "bd165d20bd063c7a023d22232a1e75bf46e904067f92b49323fe89fa0fd586bf",
+                            "amount": "1000000000000000000000"
+                          }
+                        ]
+                      }
+                    ],
+                    "gasAmount": 20000,
+                    "gasPrice": "100000000000"
+                  }
+                ]
               }
             }
           },

--- a/app/src/main/scala/org/alephium/explorer/api/BlockEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/BlockEndpoints.scala
@@ -21,8 +21,8 @@ import scala.collection.immutable.ArraySeq
 import sttp.tapir._
 import sttp.tapir.generic.auto._
 
-import org.alephium.api.{alphJsonBody => jsonBody}
-import org.alephium.explorer.api.BaseEndpoint
+import org.alephium.api.Endpoints.jsonBody
+import org.alephium.explorer.api.EndpointExamples._
 import org.alephium.explorer.api.model._
 import org.alephium.protocol.model.BlockHash
 

--- a/app/src/main/scala/org/alephium/explorer/api/EndpointExamples.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/EndpointExamples.scala
@@ -1,0 +1,131 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.api
+
+import java.math.BigInteger
+
+import scala.collection.immutable.ArraySeq
+
+import akka.util.ByteString
+import sttp.tapir.EndpointIO.Example
+
+import org.alephium.api.EndpointsExamples
+import org.alephium.api.model.Amount
+import org.alephium.explorer.api.model._
+import org.alephium.protocol.ALPH
+import org.alephium.protocol.model.{BlockHash, TokenId}
+import org.alephium.util.{Hex, U256}
+
+/**
+  * Contains OpenAPI Examples.
+  */
+// scalastyle:off magic.number
+@SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
+object EndpointExamples extends EndpointsExamples {
+
+  private def alph(value: Int): Amount =
+    Amount(ALPH.oneAlph.mulUnsafe(U256.unsafe(value)))
+
+  private val blockHash: BlockHash =
+    BlockHash
+      .from(Hex.unsafe("bdaf9dc514ce7d34b6474b8ca10a3dfb93ba997cb9d5ff1ea724ebe2af48abe5"))
+      .get
+
+  private val outputRef: OutputRef =
+    OutputRef(hint = 23412, key = hash)
+
+  private val unlockScript: ByteString =
+    Hex.unsafe("d1b70d2226308b46da297486adb6b4f1a8c1842cb159ac5ec04f384fe2d6f5da28")
+
+  private val addressExplorer: Address =
+    Address.unsafe("1AujpupFP4KWeZvqA7itsHY9cLJmx4qTzojVZrg8W9y9n")
+
+  private val tokens: ArraySeq[Token] =
+    ArraySeq(
+      Token(TokenId.hash("token1"), alph(42).value),
+      Token(TokenId.hash("token2"), alph(1000).value)
+    )
+
+  private val input: Input =
+    Input(
+      outputRef      = outputRef,
+      unlockScript   = Some(unlockScript),
+      txHashRef      = Some(txId),
+      address        = Some(addressExplorer),
+      attoAlphAmount = Some(U256.Two),
+      tokens         = Some(tokens)
+    )
+
+  private val outputAsset: AssetOutput =
+    AssetOutput(
+      hint           = 1,
+      key            = hash,
+      attoAlphAmount = U256.Two,
+      address        = addressExplorer,
+      tokens         = Some(tokens),
+      lockTime       = Some(ts),
+      message        = Some(hash.bytes)
+    )
+
+  private val outputContract: Output =
+    ContractOutput(
+      hint           = 1,
+      key            = hash,
+      attoAlphAmount = U256.Two,
+      address        = addressExplorer,
+      tokens         = Some(tokens)
+    )
+
+  /**
+    * Main API objects
+    */
+  private val blockEntryLite: BlockEntryLite =
+    BlockEntryLite(
+      hash      = blockHash,
+      timestamp = ts,
+      chainFrom = GroupIndex.unsafe(1),
+      chainTo   = GroupIndex.unsafe(2),
+      height    = Height.unsafe(42),
+      txNumber  = 1,
+      mainChain = true,
+      hashRate  = BigInteger.valueOf(100L)
+    )
+
+  private val transaction: Transaction =
+    Transaction(
+      hash      = txId,
+      blockHash = blockHash,
+      timestamp = ts,
+      inputs    = ArraySeq(input),
+      outputs   = ArraySeq(outputAsset, outputContract),
+      gasAmount = org.alephium.protocol.model.defaultGas.value,
+      gasPrice  = org.alephium.protocol.model.defaultGasPrice.value
+    )
+
+  /**
+    * Examples
+    */
+  implicit val blockEntryLiteExample: List[Example[BlockEntryLite]] =
+    simpleExample(blockEntryLite)
+
+  implicit val transactionsExample: List[Example[ArraySeq[Transaction]]] =
+    simpleExample(ArraySeq(transaction, transaction))
+
+  implicit val listOfBlocksExample: List[Example[ListBlocks]] =
+    simpleExample(ListBlocks(2, ArraySeq(blockEntryLite, blockEntryLite)))
+
+}


### PR DESCRIPTION
- Towards #253.
- Added `Example`s for `BlockEndpoints`.
- Everything is declared as `val` in `EndpointExamples` following the node. Assuming that's preferred.