### PR TITLE
Convert `UnlockScript.SameAsPrevious` to the correct value + Bump common to 1.6.x

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/service/BlockFlowClient.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/BlockFlowClient.scala
@@ -186,7 +186,9 @@ object BlockFlowClient extends StrictLogging {
         .map { utxs =>
           utxs.flatMap { utx =>
             utx.unconfirmedTransactions.map { tx =>
-              val inputs  = tx.unsigned.inputs.map(protocolInputToInput).toArraySeq
+              val inputs = InputAddressUtil
+                .convertSameAsPrevious(tx.unsigned.inputs.toArraySeq)
+                .map(protocolInputToInput)
               val outputs = tx.unsigned.fixedOutputs.map(protocolOutputToAssetOutput).toArraySeq
               txToUTx(tx, utx.fromGroup, utx.toGroup, inputs, outputs, TimeStamp.now())
             }
@@ -227,7 +229,7 @@ object BlockFlowClient extends StrictLogging {
     val inputs =
       transactions.flatMap {
         case (tx, txOrder) =>
-          tx.unsigned.inputs.toArraySeq.zipWithIndex.map {
+          InputAddressUtil.convertSameAsPrevious(tx.unsigned.inputs.toArraySeq).zipWithIndex.map {
             case (in, index) =>
               inputToEntity(in, hash, tx.unsigned.txId, block.timestamp, mainChain, index, txOrder)
           }

--- a/app/src/main/scala/org/alephium/explorer/util/InputAddressUtil.scala
+++ b/app/src/main/scala/org/alephium/explorer/util/InputAddressUtil.scala
@@ -82,17 +82,19 @@ object InputAddressUtil extends StrictLogging {
   @SuppressWarnings(Array("org.wartremover.warts.IterableOps"))
   def convertSameAsPrevious(
       inputs: ArraySeq[api.model.AssetInput]): ArraySeq[api.model.AssetInput] = {
-    if (inputs.sizeIs <= 1) {
+    if (inputs.length <= 1) {
       inputs
     } else {
-      inputs.tail.foldLeft(ArraySeq(inputs.head)) {
-        case (result, input) =>
-          if (input.unlockScript === sameAsPrevious) {
-            result :+ input.copy(unlockScript = result.last.unlockScript)
-          } else {
-            result :+ input
-          }
+      var lastUncompressedScript: Int = -1
+      val converted = inputs.view.zipWithIndex.map { case (input, index) =>
+        if (input.unlockScript === sameAsPrevious) {
+          input.copy(unlockScript = inputs(lastUncompressedScript).unlockScript)
+        } else {
+          lastUncompressedScript = index
+          input
+        }
       }
+      ArraySeq.from(converted)
     }
   }
 }

--- a/app/src/main/scala/org/alephium/explorer/util/InputAddressUtil.scala
+++ b/app/src/main/scala/org/alephium/explorer/util/InputAddressUtil.scala
@@ -82,7 +82,7 @@ object InputAddressUtil extends StrictLogging {
   @SuppressWarnings(Array("org.wartremover.warts.IterableOps"))
   def convertSameAsPrevious(
       inputs: ArraySeq[api.model.AssetInput]): ArraySeq[api.model.AssetInput] = {
-    if (inputs.length <= 1) {
+    if (inputs.sizeIs <= 1) {
       inputs
     } else {
       var lastUncompressedScript: Int = -1

--- a/app/src/main/scala/org/alephium/explorer/util/InputAddressUtil.scala
+++ b/app/src/main/scala/org/alephium/explorer/util/InputAddressUtil.scala
@@ -86,13 +86,14 @@ object InputAddressUtil extends StrictLogging {
       inputs
     } else {
       var lastUncompressedScript: Int = -1
-      val converted = inputs.view.zipWithIndex.map { case (input, index) =>
-        if (input.unlockScript === sameAsPrevious) {
-          input.copy(unlockScript = inputs(lastUncompressedScript).unlockScript)
-        } else {
-          lastUncompressedScript = index
-          input
-        }
+      val converted = inputs.view.zipWithIndex.map {
+        case (input, index) =>
+          if (input.unlockScript === sameAsPrevious) {
+            input.copy(unlockScript = inputs(lastUncompressedScript).unlockScript)
+          } else {
+            lastUncompressedScript = index
+            input
+          }
       }
       ArraySeq.from(converted)
     }

--- a/app/src/main/scala/org/alephium/explorer/util/InputAddressUtil.scala
+++ b/app/src/main/scala/org/alephium/explorer/util/InputAddressUtil.scala
@@ -21,10 +21,14 @@ import scala.collection.immutable.ArraySeq
 import com.typesafe.scalalogging.StrictLogging
 
 import org.alephium.api
+import org.alephium.explorer.AnyOps
 import org.alephium.explorer.api.model.Address
 import org.alephium.protocol
+import org.alephium.serde._
 
 object InputAddressUtil extends StrictLogging {
+  private val sameAsPrevious = serialize(
+    protocol.vm.UnlockScript.SameAsPrevious: protocol.vm.UnlockScript)
   /*
    * Extract address from an [[org.alephium.api.model.AssetInput]]
    * Addresses can only be extracted from P2PKH and P2SH.
@@ -65,8 +69,8 @@ object InputAddressUtil extends StrictLogging {
         case None => None
         case Some(_) =>
           if (inputs.tail.forall(input =>
-                input.unlockScript == protocol.vm.UnlockScript.SameAsPrevious || InputAddressUtil
-                  .addressFromProtocolInput(input) == addressOpt)) {
+                input.unlockScript === sameAsPrevious || InputAddressUtil
+                  .addressFromProtocolInput(input) === addressOpt)) {
             addressOpt
           } else {
             None
@@ -83,7 +87,7 @@ object InputAddressUtil extends StrictLogging {
     } else {
       inputs.tail.foldLeft(ArraySeq(inputs.head)) {
         case (result, input) =>
-          if (input.unlockScript == protocol.vm.UnlockScript.SameAsPrevious) {
+          if (input.unlockScript === sameAsPrevious) {
             result :+ input.copy(unlockScript = result.last.unlockScript)
           } else {
             result :+ input

--- a/app/src/test/scala/org/alephium/explorer/util/InputAddressUtilSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/util/InputAddressUtilSpec.scala
@@ -120,6 +120,53 @@ class InputAddressUtilSpec extends AlephiumSpec with Matchers {
     }
   }
 
+  "convertSameAsPrevious" should {
+    "return empty list if list is empty" in {
+      InputAddressUtil.convertSameAsPrevious(ArraySeq.empty) is ArraySeq.empty
+    }
+
+    "return same list if list as only one element" in {
+      forAll(inputProtocolGen) { input =>
+        InputAddressUtil.convertSameAsPrevious(ArraySeq(input)) is ArraySeq(input)
+      }
+    }
+
+    "correcly convert simple SameAsPrevious case" in {
+      val sameAsPrevious =
+        serialize(protocol.vm.UnlockScript.SameAsPrevious: protocol.vm.UnlockScript)
+      forAll(inputProtocolGen, inputProtocolGen, inputProtocolGen) {
+        case (input1, in2, in3) =>
+          val input2 = in2.copy(unlockScript = sameAsPrevious)
+          val input3 = in3.copy(unlockScript = sameAsPrevious)
+
+          val result = InputAddressUtil.convertSameAsPrevious(ArraySeq(input1, input2, input3))
+
+          val newInput2 = input2.copy(unlockScript = input1.unlockScript)
+          val newInput3 = input3.copy(unlockScript = input1.unlockScript)
+
+          result is ArraySeq(input1, newInput2, newInput3)
+      }
+    }
+
+    "correcly convert slightly more complex SameAsPrevious case" in {
+      val sameAsPrevious =
+        serialize(protocol.vm.UnlockScript.SameAsPrevious: protocol.vm.UnlockScript)
+      forAll(inputProtocolGen, inputProtocolGen, inputProtocolGen, inputProtocolGen) {
+        case (input1, in2, input3, in4) =>
+          val input2 = in2.copy(unlockScript = sameAsPrevious)
+          val input4 = in4.copy(unlockScript = sameAsPrevious)
+
+          val result =
+            InputAddressUtil.convertSameAsPrevious(ArraySeq(input1, input2, input3, input4))
+
+          val newInput2 = input2.copy(unlockScript = input1.unlockScript)
+          val newInput4 = input4.copy(unlockScript = input3.unlockScript)
+
+          result is ArraySeq(input1, newInput2, input3, newInput4)
+      }
+    }
+  }
+
   def buildAssetInput(outputRef: api.model.OutputRef, unlockScript: protocol.vm.UnlockScript) = {
     api.model.AssetInput(
       outputRef,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@
 import sbt._
 
 object Version {
-  lazy val common = "1.5.5"
+  lazy val common = "1.6.1"
 
   lazy val akka       = "2.6.20"
   lazy val tapir      = "1.2.2"


### PR DESCRIPTION
The  idea is to convert directly the protocol inputs as soon as we access them (only twice in the code) to be sure we have the correct unlock scripts latter.