### PR TITLE
#413: multi-column timestamp indexes

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/persistence/DBInitializer.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/DBInitializer.scala
@@ -97,10 +97,11 @@ object DBInitializer extends StrictLogging {
       _ <- TransactionSchema.createMainChainIndex()
       _ <- InputSchema.createMainChainIndex()
       _ <- OutputSchema.createMainChainIndex()
-      _ <- TransactionPerAddressSchema.createMainChainIndex()
+      _ <- TransactionPerAddressSchema.createSQLIndexes()
       _ <- OutputSchema.createNonSpentIndex()
       _ <- InputSchema.createOutputRefAddressNullIndex()
       _ <- TransactionPerTokenSchema.createSQLIndexes()
+      _ <- TokenPerAddressSchema.createSQLIndexes()
     } yield ())
   }
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/CommonIndex.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/CommonIndex.scala
@@ -30,9 +30,9 @@ object CommonIndex {
     * Postgres uses this index for queries that order by `block_timestamp desc, tx_order asc`
     * and have large number of resulting rows.
     */
-  def blockTimestampTxnOrderIndex(table: Schema[_]): SqlAction[Int, NoStream, Effect] =
+  def blockTimestampTxOrderIndex(table: Schema[_]): SqlAction[Int, NoStream, Effect] =
     sqlu"""
-        create index if not exists #${table.name}_block_timestamp_txn_order_idx
+        create index if not exists #${table.name}_block_timestamp_tx_order_idx
                 on #${table.name} (block_timestamp desc, tx_order asc);
         """
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/CommonIndex.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/CommonIndex.scala
@@ -1,0 +1,45 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.persistence.schema
+
+import slick.jdbc.PostgresProfile.api._
+import slick.sql.SqlAction
+
+/**
+  * Common table indexes.
+  */
+object CommonIndex {
+
+  /**
+    * Need for this multi-column index?
+    *
+    * Postgres uses this index for queries that order by `block_timestamp desc, tx_order asc`
+    * and have large number of resulting rows.
+    */
+  def blockTimestampTxnOrderIndex(table: Schema[_]): SqlAction[Int, NoStream, Effect] =
+    sqlu"""
+        create index if not exists #${table.name}_block_timestamp_txn_order_idx
+                on #${table.name} (block_timestamp desc, tx_order asc);
+        """
+
+  def timestampIndex(table: Schema[_]): SqlAction[Int, NoStream, Effect] =
+    sqlu"""
+        create index if not exists #${table.name}_timestamp_idx
+                on #${table.name} (block_timestamp desc);
+        """
+
+}

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenTxPerAddressSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenTxPerAddressSchema.scala
@@ -52,7 +52,7 @@ object TokenPerAddressSchema
 
   def createSQLIndexes(): DBIO[Unit] =
     DBIO.seq(
-      CommonIndex.blockTimestampTxnOrderIndex(this),
+      CommonIndex.blockTimestampTxOrderIndex(this),
       CommonIndex.timestampIndex(this)
     )
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenTxPerAddressSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenTxPerAddressSchema.scala
@@ -40,7 +40,6 @@ object TokenPerAddressSchema
     def pk: PrimaryKey = primaryKey("token_tx_per_address_pk", (txHash, blockHash, address, token))
 
     def hashIdx: Index         = index("token_tx_per_address_hash_idx", txHash)
-    def timestampIdx: Index    = index("token_tx_per_address_timestamp_idx", timestamp)
     def blockHashIdx: Index    = index("token_tx_per_address_block_hash_idx", blockHash)
     def addressIdx: Index      = index("token_tx_per_address_address_idx", address)
     def tokenIdx: Index        = index("token_tx_per_address_token_idx", token)
@@ -50,6 +49,12 @@ object TokenPerAddressSchema
       (address, txHash, blockHash, timestamp, txOrder, mainChain, token)
         .<>((TokenTxPerAddressEntity.apply _).tupled, TokenTxPerAddressEntity.unapply)
   }
+
+  def createSQLIndexes(): DBIO[Unit] =
+    DBIO.seq(
+      CommonIndex.blockTimestampTxnOrderIndex(this),
+      CommonIndex.timestampIndex(this)
+    )
 
   val table: TableQuery[TokenPerAddresses] = TableQuery[TokenPerAddresses]
 }

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionPerAddressSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionPerAddressSchema.scala
@@ -40,7 +40,6 @@ object TransactionPerAddressSchema
     def pk: PrimaryKey = primaryKey("txs_per_address_pk", (txHash, blockHash, address))
 
     def hashIdx: Index      = index("txs_per_address_tx_hash_idx", txHash)
-    def timestampIdx: Index = index("txs_per_address_timestamp_idx", timestamp)
     def blockHashIdx: Index = index("txs_per_address_block_hash_idx", blockHash)
     def addressIdx: Index   = index("txs_per_address_address_idx", address)
     def addressTimestampIdx: Index =
@@ -50,6 +49,13 @@ object TransactionPerAddressSchema
       (address, txHash, blockHash, timestamp, txOrder, mainChain, coinbase)
         .<>((TransactionPerAddressEntity.apply _).tupled, TransactionPerAddressEntity.unapply)
   }
+
+  def createSQLIndexes(): DBIO[Unit] =
+    DBIO.seq(
+      createMainChainIndex(),
+      CommonIndex.blockTimestampTxnOrderIndex(this),
+      CommonIndex.timestampIndex(this)
+    )
 
   val table: TableQuery[TransactionPerAddresses] = TableQuery[TransactionPerAddresses]
 }

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionPerAddressSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionPerAddressSchema.scala
@@ -53,7 +53,7 @@ object TransactionPerAddressSchema
   def createSQLIndexes(): DBIO[Unit] =
     DBIO.seq(
       createMainChainIndex(),
-      CommonIndex.blockTimestampTxnOrderIndex(this),
+      CommonIndex.blockTimestampTxOrderIndex(this),
       CommonIndex.timestampIndex(this)
     )
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionPerTokenSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionPerTokenSchema.scala
@@ -48,7 +48,7 @@ object TransactionPerTokenSchema
 
   def createSQLIndexes(): DBIO[Unit] =
     DBIO.seq(
-      CommonIndex.blockTimestampTxnOrderIndex(this),
+      CommonIndex.blockTimestampTxOrderIndex(this),
       CommonIndex.timestampIndex(this)
     )
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionPerTokenSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionPerTokenSchema.scala
@@ -18,7 +18,6 @@ package org.alephium.explorer.persistence.schema
 
 import slick.jdbc.PostgresProfile.api._
 import slick.lifted.{Index, PrimaryKey, ProvenShape}
-import slick.sql.SqlAction
 
 import org.alephium.explorer.persistence.model.TransactionPerTokenEntity
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
@@ -47,26 +46,11 @@ object TransactionPerTokenSchema
         .<>((TransactionPerTokenEntity.apply _).tupled, TransactionPerTokenEntity.unapply)
   }
 
-  /**
-    * Need for multi-column index `block_timestamp_txn_order_idx`?
-    *
-    * Postgres uses this index for queries that order by `block_timestamp desc, tx_order asc`
-    * and have large number of resulting rows.
-    */
-  private def timestampTxnOrderIndex(): SqlAction[Int, NoStream, Effect] =
-    sqlu"""
-        create index if not exists #${name}_block_timestamp_txn_order_idx
-                on #$name (block_timestamp desc, tx_order asc);
-        """
-
-  private def timestampIndex(): SqlAction[Int, NoStream, Effect] =
-    sqlu"""
-        create index if not exists #${name}_timestamp_idx
-                on #$name (block_timestamp desc);
-        """
-
   def createSQLIndexes(): DBIO[Unit] =
-    DBIO.seq(timestampTxnOrderIndex(), timestampIndex())
+    DBIO.seq(
+      CommonIndex.blockTimestampTxnOrderIndex(this),
+      CommonIndex.timestampIndex(this)
+    )
 
   val table: TableQuery[TransactionPerTokens] = TableQuery[TransactionPerTokens]
 }


### PR DESCRIPTION
Towards #413.

Is there a need to maintain the index names as before?

- Table named `token_tx_per_addresses` has indexes prefixed as `token_tx_per_address_*`
- Table named `transaction_per_addresses` has indexes prefixed as `txs_per_address_*`

This PR use the same prefix as table name. 
