### PR TITLE
Coverage 2: `UInputQueriesSpec` & `UOutputQueriesSpec`

### DIFF
--- a/app/src/test/scala/org/alephium/explorer/GenCommon.scala
+++ b/app/src/test/scala/org/alephium/explorer/GenCommon.scala
@@ -72,4 +72,15 @@ object GenCommon {
       genStringOfLength(length, charGen)
     }
 
+  /**
+    * Randomly pick one from the list.
+    *
+    * If the list is empty generate new from the `Gen[T]`.
+    */
+  def pickOneOrGen[T](pickFrom: Iterable[T])(orElseGen: Gen[T]): Gen[T] =
+    if (pickFrom.isEmpty) {
+      orElseGen
+    } else {
+      Gen.oneOf(pickFrom)
+    }
 }

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/UInputQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/UInputQueriesSpec.scala
@@ -1,0 +1,131 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.persistence.queries
+
+import org.scalacheck.Gen
+import slick.jdbc.PostgresProfile.api._
+
+import org.alephium.explorer.{AlephiumFutureSpec, GenCommon}
+import org.alephium.explorer.GenApiModel._
+import org.alephium.explorer.Generators._
+import org.alephium.explorer.persistence.{DatabaseFixtureForAll, DBRunner}
+import org.alephium.explorer.persistence.model._
+import org.alephium.explorer.persistence.schema._
+
+class UInputQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForAll with DBRunner {
+
+  /**
+    * Clear [[UInputSchema]] table and persist new test data.
+    */
+  def createTestData(uinputs: Iterable[UInputEntity]): Unit = {
+    run(UInputSchema.table.delete).futureValue
+    val persistCount = run(UInputSchema.table ++= uinputs).futureValue
+    persistCount should contain(uinputs.size)
+    ()
+  }
+
+  "listUTXHashesByAddress" should {
+    "return distinct hashes for address" in {
+      forAll(uinputEntityWithDuplicateTxIdsAndAddressesGen()) { uinputs =>
+        createTestData(uinputs)
+
+        val addressAndExpectedUInputs =
+          uinputs
+            .groupBy(_.address)
+            .map {
+              case (Some(address), entities) =>
+                //collect entities with addresses
+                (address, entities)
+
+              case (None, _) =>
+                //The entity didn't generate an address.
+                //So generate one and expect empty query result
+                (addressGen.sample.get, List.empty)
+            }
+
+        addressAndExpectedUInputs foreach {
+          case (address, expectedUInputs) =>
+            val actual =
+              run(UnconfirmedTransactionQueries.listUTXHashesByAddress(address)).futureValue
+
+            //expect distinct transaction hashes
+            val expected = expectedUInputs.map(_.txHash).distinct
+
+            actual should contain theSameElementsAs expected
+        }
+      }
+    }
+  }
+
+  "uinputsFromTxs" should {
+    "return distinct hashes for address" in {
+      forAll(uinputEntityWithDuplicateTxIdsAndAddressesGen()) { uinputs =>
+        createTestData(uinputs)
+
+        //randomly select some of the persisted test data
+        //and expect only these to be returned by the query
+        val generator =
+          Gen.someOf(uinputs.map(_.txHash))
+
+        forAll(generator) { txIds =>
+          //For each iteration expect entities with txHashes to be the same as txIds
+          val expected = uinputs.filter(uinput => txIds.contains(uinput.txHash))
+
+          val actual =
+            run(UnconfirmedTransactionQueries.uinputsFromTxs(txIds)).futureValue
+
+          actual should contain theSameElementsAs expected
+        }
+      }
+    }
+  }
+
+  "uinputsFromTx" should {
+    "return uinput entities ordered by uinput_order" in {
+      forAll(uinputEntityWithDuplicateTxIdsAndAddressesGen()) { _uinputs =>
+        //update uinputs to have incremental order so it's easier to test
+        val uinputs =
+          _uinputs.zipWithIndex map {
+            case (uinput, index) =>
+              uinput.copy(uinputOrder = index)
+          }
+
+        createTestData(uinputs)
+
+        val txIds =
+          uinputs.map(_.txHash)
+
+        val txIdGen = //randomly pick a txId or generate a new one if the list is empty.
+          GenCommon.pickOneOrGen(txIds)(transactionHashGen)
+
+        forAll(txIdGen) { txId =>
+          //expect only the uinputs with this txId.
+          val expected =
+            uinputs
+              .filter(_.txHash == txId)
+              .sortBy(_.uinputOrder)
+
+          val actual =
+            run(UnconfirmedTransactionQueries.uinputsFromTx(txId)).futureValue
+
+          //the result should be in expected order.
+          actual should contain theSameElementsInOrderAs expected
+        }
+      }
+    }
+  }
+}

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/UOutputQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/UOutputQueriesSpec.scala
@@ -1,0 +1,91 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.persistence.queries
+
+import org.scalacheck.Gen
+import slick.jdbc.PostgresProfile.api._
+
+import org.alephium.explorer.{AlephiumFutureSpec, GenCommon}
+import org.alephium.explorer.GenApiModel._
+import org.alephium.explorer.Generators._
+import org.alephium.explorer.persistence.{DatabaseFixtureForAll, DBRunner}
+import org.alephium.explorer.persistence.model._
+import org.alephium.explorer.persistence.schema._
+
+class UOutputQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForAll with DBRunner {
+
+  /**
+    * Clear [[UOutputSchema]] table and persist new test data.
+    */
+  def createTestData(uoutput: Iterable[UOutputEntity]): Unit = {
+    run(UOutputSchema.table.delete).futureValue
+    val persistCount = run(UOutputSchema.table ++= uoutput).futureValue
+    persistCount should contain(uoutput.size)
+    ()
+  }
+
+  "uoutputsFromTxs" should {
+    "return distinct hashes for address" in {
+      forAll(uoutputEntityWithDuplicateTxIdsAndAddressesGen()) { uoutput =>
+        createTestData(uoutput)
+
+        //randomly select some of the TransactionIds from the
+        //persisted test data and expect only these to be returned
+        val txIdsGen =
+          Gen.someOf(uoutput.map(_.txHash))
+
+        forAll(txIdsGen) { txIds =>
+          //For each iteration expect entities with txHashes to be the same as txIds
+          val expected = uoutput.filter(uoutput => txIds.contains(uoutput.txHash))
+
+          val actual =
+            run(UnconfirmedTransactionQueries.uoutputsFromTxs(txIds)).futureValue
+
+          actual should contain theSameElementsAs expected
+        }
+      }
+    }
+  }
+
+  "uoutputsFromTx" should {
+    "return uoutput entities ordered by uoutput_order" in {
+      forAll(uoutputEntityWithDuplicateTxIdsAndAddressesGen()) { uoutputs =>
+        createTestData(uoutputs)
+
+        val txIds =
+          uoutputs.map(_.txHash)
+
+        val txIdGen = //randomly pick a txId or generate a new one if the list is empty.
+          GenCommon.pickOneOrGen(txIds)(transactionHashGen)
+
+        forAll(txIdGen) { txId =>
+          //expect only the uoutput with this txId.
+          val expected =
+            uoutputs
+              .filter(_.txHash == txId)
+              .sortBy(_.uoutputOrder)
+
+          val actual =
+            run(UnconfirmedTransactionQueries.uoutputsFromTx(txId)).futureValue
+
+          //the result should be in expected order.
+          actual should contain theSameElementsInOrderAs expected
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Test cases for tables `uinputs` and `uoutputs`.

## Coverage 

| Package: `org.alephium.explorer.persistence.queries` | Class | Method | Line |
|------------------------------------------------------|----------------|-----------------|---------------|
| Initial  coverage                                         | 72% (29/40)    | 59% (203/343)  | 67% (640/950) | 
| Updated coverage 1                                  | 77% (31/40)    | 61% (212/343)   | 70% (665/950) | 
| Updated coverage 2 (this PR)                  | 82% (33/40)   | 66% (228/343)  | 74% (704/950) | 

`UnconfirmedTransactionQueries` coverage  = `100%`.