### PR TITLE
Add `/addresses/<address>/tokens-balance` endpoint

### DIFF
--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -2467,6 +2467,146 @@
         }
       }
     },
+    "/addresses/{address}/tokens-balance": {
+      "get": {
+        "tags": [
+          "Addresses"
+        ],
+        "description": "List tokens with their balance",
+        "operationId": "getAddressesAddressTokens-balance",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number of items per page",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "reverse",
+            "in": "query",
+            "description": "Reverse pagination",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TokenBalance"
+                  }
+                },
+                "example": [
+                  {
+                    "tokenId": "2d11fd6c12435ffb07aaed4d190a505b621b927a5f6e51b61ce0ebe186397bdd",
+                    "balance": "10",
+                    "lockedBalance": "2"
+                  },
+                  {
+                    "tokenId": "bd165d20bd063c7a023d22232a1e75bf46e904067f92b49323fe89fa0fd586bf",
+                    "balance": "10",
+                    "lockedBalance": "2"
+                  }
+                ]
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequest"
+                },
+                "example": {
+                  "detail": "Something bad in the request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unauthorized"
+                },
+                "example": {
+                  "detail": "You shall not pass"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFound"
+                },
+                "example": {
+                  "resource": "wallet-name",
+                  "detail": "wallet-name not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                },
+                "example": {
+                  "detail": "Ouch"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailable"
+                },
+                "example": {
+                  "detail": "Self clique unsynced"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/addresses/{address}/tokens/{token_id}/balance": {
       "get": {
         "tags": [
@@ -6308,6 +6448,28 @@
             "format": "32-byte-hash"
           },
           "amount": {
+            "type": "string",
+            "format": "uint256"
+          }
+        }
+      },
+      "TokenBalance": {
+        "required": [
+          "tokenId",
+          "balance",
+          "lockedBalance"
+        ],
+        "type": "object",
+        "properties": {
+          "tokenId": {
+            "type": "string",
+            "format": "32-byte-hash"
+          },
+          "balance": {
+            "type": "string",
+            "format": "uint256"
+          },
+          "lockedBalance": {
             "type": "string",
             "format": "uint256"
           }

--- a/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
@@ -123,6 +123,13 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
       .in(paginator(defaultLimit = 100))
       .description("List address tokens")
 
+  val listAddressTokensBalance: BaseEndpoint[(Address, Pagination), ArraySeq[TokenBalance]] =
+    addressesEndpoint.get
+      .in("tokens-balance")
+      .in(paginator(defaultLimit = 100))
+      .out(jsonBody[ArraySeq[TokenBalance]])
+      .description("List tokens with their balance")
+
   val getAddressTokenBalance: BaseEndpoint[(Address, TokenId), AddressBalance] =
     addressesTokensEndpoint.get
       .in(path[TokenId]("token_id"))

--- a/app/src/main/scala/org/alephium/explorer/api/EndpointExamples.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/EndpointExamples.scala
@@ -171,6 +171,15 @@ object EndpointExamples extends EndpointsExamples {
       lockedBalance = U256.Two
     )
 
+  private val tokensBalance =
+    tokens.map { token =>
+      TokenBalance(
+        tokenId       = token.id,
+        balance       = U256.Ten,
+        lockedBalance = U256.Two
+      )
+    }
+
   private val contractParent =
     ContractParent(Some(address1))
 
@@ -293,6 +302,9 @@ object EndpointExamples extends EndpointsExamples {
 
   implicit val addressBalanceExample: List[Example[AddressBalance]] =
     simpleExample(addressBalance)
+
+  implicit val tokensBalanceExample: List[Example[ArraySeq[TokenBalance]]] =
+    simpleExample(tokensBalance)
 
   implicit val contractParentExample: List[Example[ContractParent]] =
     simpleExample(contractParent)

--- a/app/src/main/scala/org/alephium/explorer/api/model/TokenBalance.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/TokenBalance.scala
@@ -1,0 +1,28 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.api.model
+
+import org.alephium.explorer.api.Json._
+import org.alephium.json.Json._
+import org.alephium.protocol.model.TokenId
+import org.alephium.util.U256
+
+final case class TokenBalance(tokenId: TokenId, balance: U256, lockedBalance: U256)
+
+object TokenBalance {
+  implicit val readWriter: ReadWriter[TokenBalance] = macroRW
+}

--- a/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
+++ b/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
@@ -48,6 +48,7 @@ trait Documentation
       getAddressBalance,
       listAddressTokens,
       listAddressTokenTransactions,
+      listAddressTokensBalance,
       getAddressTokenBalance,
       areAddressesActive,
       exportTransactionsCsvByAddress,

--- a/app/src/main/scala/org/alephium/explorer/persistence/dao/TransactionDao.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/dao/TransactionDao.scala
@@ -94,6 +94,11 @@ object TransactionDao {
       implicit dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[TokenId]] =
     run(listAddressTokensAction(address, pagination))
 
+  def listAddressTokensBalance(address: Address, pagination: Pagination)(
+      implicit ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[TokenBalance]] =
+    run(listAddressTokensBalanceAction(address, pagination))
+
   def listAddressTokenTransactions(address: Address, token: TokenId, pagination: Pagination)(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]] =

--- a/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
@@ -102,6 +102,10 @@ trait TransactionService {
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[TokenId]]
 
+  def listAddressTokensBalance(address: Address, pagination: Pagination)(
+      implicit ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[TokenBalance]]
+
   def listAddressTokenTransactions(address: Address, token: TokenId, pagination: Pagination)(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]]
@@ -194,6 +198,11 @@ object TransactionService extends TransactionService {
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[TokenId]] =
     TransactionDao.listAddressTokens(address, pagination)
+
+  def listAddressTokensBalance(address: Address, pagination: Pagination)(
+      implicit ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[TokenBalance]] =
+    TransactionDao.listAddressTokensBalance(address, pagination)
 
   def listTokenAddresses(token: TokenId, pagination: Pagination)(
       implicit ec: ExecutionContext,

--- a/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
@@ -101,6 +101,10 @@ class AddressServer(transactionService: TransactionService, exportTxsNumberThres
             tokens <- transactionService.listAddressTokens(address, pagination)
           } yield tokens
       }),
+      route(listAddressTokensBalance.serverLogicSuccess[Future] {
+        case (address, pagination) =>
+          transactionService.listAddressTokensBalance(address, pagination)
+      }),
       route(listAddressTokenTransactions.serverLogicSuccess[Future] {
         case (address, token, pagination) =>
           for {

--- a/app/src/test/scala/org/alephium/explorer/service/EmptyTransactionService.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/EmptyTransactionService.scala
@@ -100,6 +100,9 @@ trait EmptyTransactionService extends TransactionService {
   def listTokens(pagination: Pagination)(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[TokenId]] = ???
+  def listAddressTokensBalance(address: Address, pagination: Pagination)(
+      implicit ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[TokenBalance]] = ???
   def areAddressesActive(addresses: ArraySeq[Address])(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Boolean]] = {


### PR DESCRIPTION
On the explorer front-end, we start to have `too many request` on address page with lots of tokens, as currently it needs to loop and call the balance endpoint for each token.

This endpoint allows to do only one call to get all tokens info needed.

This is currently quite a naive approach, also we need to handle the case where balance is 0, we shouldn't return the tokens in those case. But this requires some work to do things in an efficient way.