### PR TITLE
Add parallelism to stream

### DIFF
--- a/app/src/main/resources/application.conf
+++ b/app/src/main/resources/application.conf
@@ -41,6 +41,10 @@ explorer {
 
     #How many transaction can be exported at max
     export-txs-number-threshold = 10000
+
+    #Number of allowed parallelism when using `mapAsync` on streams.
+    stream-parallelism = 8
+    stream-parallelism = ${?EXPLORER_STREAM_PARALLELISM}
 }
 
 blockflow {

--- a/app/src/main/scala/org/alephium/explorer/AppServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/AppServer.scala
@@ -31,7 +31,7 @@ import org.alephium.explorer.web._
 // scalastyle:off magic.number
 object AppServer {
 
-  def routes(exportTxsNumberThreshold: Int)(
+  def routes(exportTxsNumberThreshold: Int, streamParallelism: Int)(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile],
       blockFlowClient: BlockFlowClient,
@@ -40,8 +40,9 @@ object AppServer {
       actorSystem: ActorSystem,
       groupSetting: GroupSetting): ArraySeq[Router => Route] = {
 
-    val blockServer                = new BlockServer()
-    val addressServer              = new AddressServer(TransactionService, exportTxsNumberThreshold)
+    val blockServer = new BlockServer()
+    val addressServer =
+      new AddressServer(TransactionService, exportTxsNumberThreshold, streamParallelism)
     val transactionServer          = new TransactionServer()
     val infosServer                = new InfosServer(TokenSupplyService, BlockService, TransactionService)
     val utilsServer: UtilsServer   = new UtilsServer()

--- a/app/src/main/scala/org/alephium/explorer/ExplorerState.scala
+++ b/app/src/main/scala/org/alephium/explorer/ExplorerState.scala
@@ -93,13 +93,14 @@ sealed trait ExplorerStateRead extends ExplorerState {
     new ExplorerHttpServer(
       config.host,
       config.port,
-      AppServer.routes(config.exportTxsNumberThreshold)(executionContext,
-                                                        database.databaseConfig,
-                                                        blockFlowClient,
-                                                        blockCache,
-                                                        transactionCache,
-                                                        actorSystem,
-                                                        groupSettings)
+      AppServer.routes(config.exportTxsNumberThreshold, config.streamParallelism)(
+        executionContext,
+        database.databaseConfig,
+        blockFlowClient,
+        blockCache,
+        transactionCache,
+        actorSystem,
+        groupSettings)
     )
 
   override lazy val customServices: ArraySeq[Service] = ArraySeq(httpServer)

--- a/app/src/main/scala/org/alephium/explorer/config/ExplorerConfig.scala
+++ b/app/src/main/scala/org/alephium/explorer/config/ExplorerConfig.scala
@@ -136,7 +136,8 @@ object ExplorerConfig {
           explorer.cacheRowCountReloadPeriod,
           explorer.cacheBlockTimesReloadPeriod,
           explorer.cacheLatestBlocksReloadPeriod,
-          explorer.exportTxsNumberThreshold
+          explorer.exportTxsNumberThreshold,
+          explorer.streamParallelism
         )
       }).get
     }
@@ -162,7 +163,9 @@ object ExplorerConfig {
                                     cacheRowCountReloadPeriod: FiniteDuration,
                                     cacheBlockTimesReloadPeriod: FiniteDuration,
                                     cacheLatestBlocksReloadPeriod: FiniteDuration,
-                                    exportTxsNumberThreshold: Int)
+                                    exportTxsNumberThreshold: Int,
+                                    streamParallelism: Int)
+
 }
 
 /**
@@ -187,4 +190,5 @@ final case class ExplorerConfig private (groupNum: Int,
                                          cacheRowCountReloadPeriod: FiniteDuration,
                                          cacheBlockTimesReloadPeriod: FiniteDuration,
                                          cacheLatestBlocksReloadPeriod: FiniteDuration,
-                                         exportTxsNumberThreshold: Int)
+                                         exportTxsNumberThreshold: Int,
+                                         streamParallelism: Int)

--- a/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
@@ -36,11 +36,12 @@ import org.alephium.explorer.api.model._
 import org.alephium.explorer.service.TransactionService
 import org.alephium.protocol.model.Address
 
-class AddressServer(transactionService: TransactionService, exportTxsNumberThreshold: Int)(
-    implicit val executionContext: ExecutionContext,
-    ac: ActorSystem,
-    groupSetting: GroupSetting,
-    dc: DatabaseConfig[PostgresProfile])
+class AddressServer(transactionService: TransactionService,
+                    exportTxsNumberThreshold: Int,
+                    streamParallelism: Int)(implicit val executionContext: ExecutionContext,
+                                            ac: ActorSystem,
+                                            groupSetting: GroupSetting,
+                                            dc: DatabaseConfig[PostgresProfile])
     extends Server
     with AddressesEndpoints {
 
@@ -134,7 +135,8 @@ class AddressServer(transactionService: TransactionService, exportTxsNumberThres
                                                                    timeInterval.from,
                                                                    timeInterval.to,
                                                                    exportType,
-                                                                   1)
+                                                                   1,
+                                                                   streamParallelism)
           pub.subscribe(readStream)
           Right(readStream)
         }

--- a/app/src/test/scala/org/alephium/explorer/service/EmptyTransactionService.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/EmptyTransactionService.scala
@@ -113,7 +113,8 @@ trait EmptyTransactionService extends TransactionService {
                                   from: TimeStamp,
                                   to: TimeStamp,
                                   exportType: ExportType,
-                                  batchSize: Int)(
+                                  batchSize: Int,
+                                  streamParallelism: Int)(
       implicit ec: ExecutionContext,
       ac: ActorSystem,
       dc: DatabaseConfig[PostgresProfile]): Publisher[Buffer] = ???

--- a/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
@@ -448,7 +448,7 @@ class TransactionServiceSpec extends AlephiumActorSpecLike with DatabaseFixtureF
   "export transactions by address" in new TxsByAddressFixture {
     forAll(Gen.choose(1, 4)) { batchSize =>
       val publisher = TransactionService
-        .exportTransactionsByAddress(address, fromTs, toTs, ExportType.CSV, batchSize)
+        .exportTransactionsByAddress(address, fromTs, toTs, ExportType.CSV, batchSize, 8)
 
       val result: Seq[Buffer] =
         Source.fromPublisher(publisher).runWith(Sink.seq).futureValue

--- a/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
@@ -84,7 +84,8 @@ class AddressServerSpec()
                                              from: TimeStamp,
                                              to: TimeStamp,
                                              exportType: ExportType,
-                                             batchSize: Int)(
+                                             batchSize: Int,
+                                             streamParallelism: Int)(
         implicit ec: ExecutionContext,
         ac: ActorSystem,
         dc: DatabaseConfig[PostgresProfile]): Publisher[Buffer] = {
@@ -96,7 +97,8 @@ class AddressServerSpec()
     }
   }
 
-  val server = new AddressServer(transactionService, exportTxsNumberThreshold = 1000)
+  val server =
+    new AddressServer(transactionService, exportTxsNumberThreshold = 1000, streamParallelism = 8)
 
   val routes = server.routes
 

--- a/docker/release/Dockerfile.release
+++ b/docker/release/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:jre-11.0.11_9
+FROM eclipse-temurin:17-jre
 
 ARG RELEASE=0.0.0
 

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -38,7 +38,7 @@
     </check>
     <check level="error" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
         <parameters>
-            <parameter name="maxParameters"><![CDATA[8]]></parameter>
+            <parameter name="maxParameters"><![CDATA[9]]></parameter>
         </parameters>
     </check>
     <check level="error" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true">

--- a/scalastyle-test-config.xml
+++ b/scalastyle-test-config.xml
@@ -42,7 +42,7 @@
     </check>
     <check level="error" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
         <parameters>
-            <parameter name="maxParameters"><![CDATA[8]]></parameter>
+            <parameter name="maxParameters"><![CDATA[9]]></parameter>
         </parameters>
     </check>
     <check level="error" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="false">


### PR DESCRIPTION
I initially thought that [mapAsync](https://doc.akka.io/api/akka/2.7/akka/stream/scaladsl/Source.html#mapAsync[T](parallelism:Int)(f:Out=%3Escala.concurrent.Future[T]):FlowOps.this.Repr[T]) was not preserving order, while it actually does. There is a specific [mapAsyncUnordered](https://doc.akka.io/api/akka/2.7/akka/stream/scaladsl/Source.html#mapAsyncUnordered[T](parallelism:Int)(f:Out=%3Escala.concurrent.Future[T]):FlowOps.this.Repr[T]) if you don't want to preserve.

This improved a lot the performance, 8 seems a good value while doing my test, going above didn't improved.
I added a config value so we can easily play with it if we want.