### PR TITLE
Feature/java rx

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/AppServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/AppServer.scala
@@ -19,7 +19,6 @@ package org.alephium.explorer
 import scala.collection.immutable.ArraySeq
 import scala.concurrent.ExecutionContext
 
-import akka.actor.ActorSystem
 import io.vertx.ext.web._
 import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
@@ -37,7 +36,6 @@ object AppServer {
       blockFlowClient: BlockFlowClient,
       blockCache: BlockCache,
       transactionCache: TransactionCache,
-      actorSystem: ActorSystem,
       groupSetting: GroupSetting): ArraySeq[Router => Route] = {
 
     val blockServer = new BlockServer()

--- a/app/src/main/scala/org/alephium/explorer/ExploreHttpServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/ExploreHttpServer.scala
@@ -79,7 +79,6 @@ class ExplorerHttpServer(host: String, port: Int, val routes: ArraySeq[Router =>
     }
   }
 
-  /** Stop AkkaHttp server and terminates ActorSystem */
   def stopSelfOnce(): Future[Unit] = {
     for {
       binding <- httpBindingPromise.future

--- a/app/src/main/scala/org/alephium/explorer/ExplorerState.scala
+++ b/app/src/main/scala/org/alephium/explorer/ExplorerState.scala
@@ -19,7 +19,6 @@ package org.alephium.explorer
 import scala.collection.immutable.ArraySeq
 import scala.concurrent.{ExecutionContext, Future}
 
-import akka.actor.ActorSystem
 import com.typesafe.scalalogging.StrictLogging
 import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
@@ -88,7 +87,6 @@ sealed trait ExplorerState extends Service with StrictLogging {
 }
 
 sealed trait ExplorerStateRead extends ExplorerState {
-  implicit def actorSystem: ActorSystem
   lazy val httpServer: ExplorerHttpServer =
     new ExplorerHttpServer(
       config.host,
@@ -99,7 +97,6 @@ sealed trait ExplorerStateRead extends ExplorerState {
         blockFlowClient,
         blockCache,
         transactionCache,
-        actorSystem,
         groupSettings)
     )
 
@@ -109,15 +106,13 @@ sealed trait ExplorerStateRead extends ExplorerState {
 object ExplorerState {
 
   /** State of Explorer is started in read-only mode */
-  final case class ReadOnly()(implicit val actorSystem: ActorSystem,
-                              val config: ExplorerConfig,
+  final case class ReadOnly()(implicit val config: ExplorerConfig,
                               val databaseConfig: DatabaseConfig[PostgresProfile],
                               val executionContext: ExecutionContext)
       extends ExplorerStateRead
 
   /** State of Explorer is started in read-write mode */
-  final case class ReadWrite()(implicit val actorSystem: ActorSystem,
-                               val config: ExplorerConfig,
+  final case class ReadWrite()(implicit val config: ExplorerConfig,
                                val databaseConfig: DatabaseConfig[PostgresProfile],
                                val executionContext: ExecutionContext)
       extends ExplorerStateRead {

--- a/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
@@ -18,10 +18,10 @@ package org.alephium.explorer.service
 
 import scala.collection.immutable.ArraySeq
 import scala.concurrent.{ExecutionContext, Future}
+import scala.jdk.CollectionConverters._
+import scala.jdk.FutureConverters._
 
-import akka.NotUsed
-import akka.actor.ActorSystem
-import akka.stream.scaladsl._
+import io.reactivex.rxjava3.core.Flowable
 import io.vertx.core.buffer.Buffer
 import org.reactivestreams.Publisher
 import slick.basic.DatabaseConfig
@@ -32,7 +32,6 @@ import org.alephium.explorer.cache.TransactionCache
 import org.alephium.explorer.persistence.DBRunner._
 import org.alephium.explorer.persistence.dao.{MempoolDao, TransactionDao}
 import org.alephium.explorer.persistence.queries.TransactionQueries._
-import org.alephium.json.Json.write
 import org.alephium.protocol.model.{Address, TokenId, TransactionId}
 import org.alephium.util.{TimeStamp, U256}
 
@@ -108,17 +107,14 @@ trait TransactionService {
 
   def hasAddressMoreTxsThan(address: Address, from: TimeStamp, to: TimeStamp, threshold: Int)(
       implicit ec: ExecutionContext,
-      ac: ActorSystem,
       dc: DatabaseConfig[PostgresProfile]): Future[Boolean]
 
   def exportTransactionsByAddress(address: Address,
                                   fromTime: TimeStamp,
                                   toTime: TimeStamp,
-                                  exportType: ExportType,
                                   batchSize: Int,
                                   paralellism: Int)(
       implicit ec: ExecutionContext,
-      ac: ActorSystem,
       dc: DatabaseConfig[PostgresProfile]): Publisher[Buffer]
 }
 
@@ -216,23 +212,19 @@ object TransactionService extends TransactionService {
 
   def hasAddressMoreTxsThan(address: Address, from: TimeStamp, to: TimeStamp, threshold: Int)(
       implicit ec: ExecutionContext,
-      ac: ActorSystem,
       dc: DatabaseConfig[PostgresProfile]): Future[Boolean] = {
     run(hasAddressMoreTxsThanQuery(address, from, to, threshold))
   }
   def exportTransactionsByAddress(address: Address,
                                   fromTime: TimeStamp,
                                   toTime: TimeStamp,
-                                  exportType: ExportType,
                                   batchSize: Int,
                                   paralellism: Int)(
       implicit ec: ExecutionContext,
-      ac: ActorSystem,
       dc: DatabaseConfig[PostgresProfile]): Publisher[Buffer] = {
 
     transactionsPublisher(
       address,
-      exportType,
       transactionSource(address, fromTime, toTime, batchSize, paralellism)
     )
 
@@ -244,39 +236,34 @@ object TransactionService extends TransactionService {
                                 batchSize: Int,
                                 paralellism: Int)(
       implicit ec: ExecutionContext,
-      dc: DatabaseConfig[PostgresProfile]): Source[ArraySeq[Transaction], NotUsed] = {
-    Source
+      dc: DatabaseConfig[PostgresProfile]): Flowable[ArraySeq[Transaction]] = {
+    Flowable
       .fromPublisher(stream(streamTxByAddressQR(address, from, to)))
-      .grouped(batchSize)
-      .mapAsync(paralellism) { hashes =>
-        run(getTransactionsNoJoin(ArraySeq.from(hashes)))
+      .buffer(batchSize)
+      .concatMap { hashes =>
+        Flowable.fromFuture(
+          run(getTransactionsNoJoin(ArraySeq.from(hashes.asScala))).asJava.toCompletableFuture
+        )
       }
   }
 
-  private def bufferPublisher(source: Source[String, NotUsed])(
-      implicit ac: ActorSystem): Publisher[Buffer] = {
+  private def bufferPublisher(source: Flowable[String]): Publisher[Buffer] = {
     source
       .map(Buffer.buffer)
-      .toMat(Sink.asPublisher[Buffer](false))(Keep.right)
-      .run()
   }
 
   def transactionsPublisher(address: Address,
-                            exportType: ExportType,
-                            source: Source[ArraySeq[Transaction], NotUsed])(
-      implicit actorSystem: ActorSystem
-  ): Publisher[Buffer] = {
+                            source: Flowable[ArraySeq[Transaction]]): Publisher[Buffer] = {
     bufferPublisher {
-      exportType match {
-        case ExportType.CSV =>
-          val headerSource = Source(ArraySeq(Transaction.csvHeader))
-          val csvSource    = source.map(_.map(_.toCsv(address)).mkString)
-          headerSource ++ csvSource
-        case ExportType.JSON =>
-          source
-            .map(write(_))
-            .intersperse("[", ",\n", "]")
-      }
+      val headerSource = Flowable.just(Transaction.csvHeader)
+      val csvSource    = source.map(_.map(_.toCsv(address)).mkString)
+      headerSource.mergeWith(csvSource)
+    }
+  }
+
+  def outputsPublisher(source: Flowable[ArraySeq[Output]]): Publisher[Buffer] = {
+    bufferPublisher {
+      source.map(_.map(_.toString()).mkString)
     }
   }
 }

--- a/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
@@ -240,8 +240,8 @@ object TransactionService extends TransactionService {
       .fromPublisher(stream(streamTxByAddressQR(address, from, to)))
       .buffer(batchSize)
       .concatMapEager(({ hashes =>
-        Flowable.fromFuture(
-          run(getTransactionsNoJoin(ArraySeq.from(hashes.asScala))).asJava.toCompletableFuture
+        Flowable.fromCompletionStage(
+          run(getTransactionsNoJoin(ArraySeq.from(hashes.asScala))).asJava
         )
       }), paralellism, 1)
   }

--- a/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
@@ -21,8 +21,8 @@ import scala.concurrent.{ExecutionContext, Future}
 
 import io.vertx.core.buffer.Buffer
 import io.vertx.core.streams.ReadStream
-import io.vertx.ext.reactivestreams.ReactiveReadStream
 import io.vertx.ext.web._
+import io.vertx.rxjava3.FlowableHelper
 import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
 import sttp.model.StatusCode
@@ -128,14 +128,12 @@ class AddressServer(transactionService: TransactionService,
           Left(ApiError.BadRequest(
             s"Too many transactions for that address in this time range, limit is $exportTxsNumberThreshold"))
         } else {
-          val readStream: ReactiveReadStream[Buffer] = ReactiveReadStream.readStream();
-          val pub = transactionService.exportTransactionsByAddress(address,
-                                                                   timeInterval.from,
-                                                                   timeInterval.to,
-                                                                   1,
-                                                                   streamParallelism)
-          pub.subscribe(readStream)
-          Right(readStream)
+          val flowable = transactionService.exportTransactionsByAddress(address,
+                                                                        timeInterval.from,
+                                                                        timeInterval.to,
+                                                                        1,
+                                                                        streamParallelism)
+          Right(FlowableHelper.toReadStream(flowable))
         }
       }
   }

--- a/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
@@ -19,7 +19,6 @@ package org.alephium.explorer.web
 import scala.collection.immutable.ArraySeq
 import scala.concurrent.{ExecutionContext, Future}
 
-import akka.actor.ActorSystem
 import io.vertx.core.buffer.Buffer
 import io.vertx.core.streams.ReadStream
 import io.vertx.ext.reactivestreams.ReactiveReadStream
@@ -39,7 +38,6 @@ import org.alephium.protocol.model.Address
 class AddressServer(transactionService: TransactionService,
                     exportTxsNumberThreshold: Int,
                     streamParallelism: Int)(implicit val executionContext: ExecutionContext,
-                                            ac: ActorSystem,
                                             groupSetting: GroupSetting,
                                             dc: DatabaseConfig[PostgresProfile])
     extends Server
@@ -113,7 +111,7 @@ class AddressServer(transactionService: TransactionService,
       }),
       route(exportTransactionsCsvByAddress.serverLogic[Future] {
         case (address, timeInterval) =>
-          exportTransactions(address, timeInterval, ExportType.CSV).map(_.map { stream =>
+          exportTransactions(address, timeInterval).map(_.map { stream =>
             (AddressServer.exportFileNameHeader(address, timeInterval), stream)
           })
       })
@@ -121,8 +119,8 @@ class AddressServer(transactionService: TransactionService,
 
   private def exportTransactions(
       address: Address,
-      timeInterval: TimeInterval,
-      exportType: ExportType): Future[Either[ApiError[_ <: StatusCode], ReadStream[Buffer]]] = {
+      timeInterval: TimeInterval
+  ): Future[Either[ApiError[_ <: StatusCode], ReadStream[Buffer]]] = {
     transactionService
       .hasAddressMoreTxsThan(address, timeInterval.from, timeInterval.to, exportTxsNumberThreshold)
       .map { hasMore =>
@@ -134,7 +132,6 @@ class AddressServer(transactionService: TransactionService,
           val pub = transactionService.exportTransactionsByAddress(address,
                                                                    timeInterval.from,
                                                                    timeInterval.to,
-                                                                   exportType,
                                                                    1,
                                                                    streamParallelism)
           pub.subscribe(readStream)

--- a/app/src/test/scala/org/alephium/explorer/service/EmptyTransactionService.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/EmptyTransactionService.scala
@@ -19,7 +19,6 @@ package org.alephium.explorer.service
 import scala.collection.immutable.ArraySeq
 import scala.concurrent.{ExecutionContext, Future}
 
-import akka.actor.ActorSystem
 import io.vertx.core.buffer.Buffer
 import org.reactivestreams.Publisher
 import slick.basic.DatabaseConfig
@@ -107,15 +106,12 @@ trait EmptyTransactionService extends TransactionService {
   }
   def hasAddressMoreTxsThan(address: Address, from: TimeStamp, to: TimeStamp, threshold: Int)(
       implicit ec: ExecutionContext,
-      ac: ActorSystem,
       dc: DatabaseConfig[PostgresProfile]): Future[Boolean] = ???
   def exportTransactionsByAddress(address: Address,
                                   from: TimeStamp,
                                   to: TimeStamp,
-                                  exportType: ExportType,
                                   batchSize: Int,
                                   streamParallelism: Int)(
       implicit ec: ExecutionContext,
-      ac: ActorSystem,
       dc: DatabaseConfig[PostgresProfile]): Publisher[Buffer] = ???
 }

--- a/app/src/test/scala/org/alephium/explorer/service/EmptyTransactionService.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/EmptyTransactionService.scala
@@ -19,8 +19,8 @@ package org.alephium.explorer.service
 import scala.collection.immutable.ArraySeq
 import scala.concurrent.{ExecutionContext, Future}
 
+import io.reactivex.rxjava3.core.Flowable
 import io.vertx.core.buffer.Buffer
-import org.reactivestreams.Publisher
 import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
 
@@ -113,5 +113,5 @@ trait EmptyTransactionService extends TransactionService {
                                   batchSize: Int,
                                   streamParallelism: Int)(
       implicit ec: ExecutionContext,
-      dc: DatabaseConfig[PostgresProfile]): Publisher[Buffer] = ???
+      dc: DatabaseConfig[PostgresProfile]): Flowable[Buffer] = ???
 }

--- a/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
@@ -20,8 +20,9 @@ import java.math.BigInteger
 
 import scala.collection.immutable.ArraySeq
 import scala.concurrent.Future
+import scala.jdk.CollectionConverters._
 
-import akka.stream.scaladsl._
+import io.reactivex.rxjava3.core.Flowable
 import io.vertx.core.buffer.Buffer
 import org.scalacheck.Gen
 
@@ -448,10 +449,10 @@ class TransactionServiceSpec extends AlephiumActorSpecLike with DatabaseFixtureF
   "export transactions by address" in new TxsByAddressFixture {
     forAll(Gen.choose(1, 4)) { batchSize =>
       val publisher = TransactionService
-        .exportTransactionsByAddress(address, fromTs, toTs, ExportType.CSV, batchSize, 8)
+        .exportTransactionsByAddress(address, fromTs, toTs, batchSize, 8)
 
       val result: Seq[Buffer] =
-        Source.fromPublisher(publisher).runWith(Sink.seq).futureValue
+        Flowable.fromPublisher(publisher).toList().blockingGet().asScala
 
       //TODO Check data format and not only the size
 

--- a/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
@@ -22,7 +22,6 @@ import scala.jdk.CollectionConverters._
 
 import io.reactivex.rxjava3.core.Flowable
 import io.vertx.core.buffer.Buffer
-import org.reactivestreams.Publisher
 import org.scalacheck.Gen
 import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
@@ -85,8 +84,8 @@ class AddressServerSpec()
                                              batchSize: Int,
                                              streamParallelism: Int)(
         implicit ec: ExecutionContext,
-        dc: DatabaseConfig[PostgresProfile]): Publisher[Buffer] = {
-      TransactionService.transactionsPublisher(
+        dc: DatabaseConfig[PostgresProfile]): Flowable[Buffer] = {
+      TransactionService.transactionsFlowable(
         address,
         Flowable
           .fromIterable(transactions.asJava)

--- a/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
@@ -175,9 +175,8 @@ class AddressServerSpec()
     }
   }
 
-  //FIXME See: https://github.com/alephium/explorer-backend/issues/401
   "/addresses/<address>/export-transactions/" should {
-    "handle csv format" ignore {
+    "handle csv format" in {
       val address    = addressGen.sample.get
       val timestamps = transactions.map(_.timestamp.millis).sorted
       val fromTs     = timestamps.head
@@ -194,7 +193,7 @@ class AddressServerSpec()
           response.headers.contains(header) is true
       }
     }
-    "restrict time range to 1 year" ignore {
+    "restrict time range to 1 year" in {
       val address = addressGen.sample.get
       val long    = Gen.posNum[Long].sample.get
       val fromTs  = TimeStamp.now().millis
@@ -213,7 +212,7 @@ class AddressServerSpec()
     }
   }
 
-  "fail if address has more txs than the threshold" ignore {
+  "fail if address has more txs than the threshold" in {
     addressHasMoreTxs = true
     val address = addressGen.sample.get
     Get(s"/addresses/${address}/export-transactions/csv?fromTs=0&toTs=1") check { response =>
@@ -237,8 +236,6 @@ class AddressServerSpec()
     }
   }
 
-  //Test could be removed once : https://github.com/alephium/explorer-backend/issues/401 is fixed
-  //and ignored test in this file are un-ignored.
   "AddressServer companion object" should {
     "create correct export filename" in {
       val address = "12jK2jHyyJTJyuRMRya7QJSojgVnb5yh4HVzNNw6BTBDF"

--- a/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
@@ -18,9 +18,9 @@ package org.alephium.explorer.web
 
 import scala.collection.immutable.ArraySeq
 import scala.concurrent.{ExecutionContext, Future}
+import scala.jdk.CollectionConverters._
 
-import akka.actor.ActorSystem
-import akka.stream.scaladsl._
+import io.reactivex.rxjava3.core.Flowable
 import io.vertx.core.buffer.Buffer
 import org.reactivestreams.Publisher
 import org.scalacheck.Gen
@@ -77,23 +77,22 @@ class AddressServerSpec()
                                        to: TimeStamp,
                                        threshold: Int)(
         implicit ec: ExecutionContext,
-        ac: ActorSystem,
         dc: DatabaseConfig[PostgresProfile]): Future[Boolean] = Future.successful(addressHasMoreTxs)
 
     override def exportTransactionsByAddress(address: Address,
                                              from: TimeStamp,
                                              to: TimeStamp,
-                                             exportType: ExportType,
                                              batchSize: Int,
                                              streamParallelism: Int)(
         implicit ec: ExecutionContext,
-        ac: ActorSystem,
         dc: DatabaseConfig[PostgresProfile]): Publisher[Buffer] = {
       TransactionService.transactionsPublisher(
         address,
-        exportType,
-        Source(transactions).grouped(batchSize).map(ArraySeq.from)
-      )(system)
+        Flowable
+          .fromIterable(transactions.asJava)
+          .buffer(batchSize)
+          .map(l => ArraySeq.from(l.asScala))
+      )
     }
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -170,7 +170,7 @@ lazy val app = mainProject("app")
     tapirCore,
     tapirServer,
     tapirVertx,
-    vertxReactiveStreams,
+    vertxRxJava,
     tapirOpenapi,
     tapirOpenapiModel,
     tapirSwaggerUi,

--- a/build.sbt
+++ b/build.sbt
@@ -164,7 +164,7 @@ lazy val app = mainProject("app")
     alephiumApi,
     alephiumCrypto,
     alephiumJson,
-    akkaStreams,
+    rxJava,
     alephiumHttp,
     alephiumConf,
     tapirCore,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,6 +20,7 @@ object Version {
   lazy val common = "2.0.4"
 
   lazy val akka       = "2.6.20"
+  lazy val rxJava     = "3.1.6"
   lazy val tapir      = "1.2.8"
   lazy val slick      = "3.3.2"
   lazy val postgresql = "42.2.12"
@@ -41,8 +42,9 @@ object Dependencies {
   lazy val vertx                = "io.vertx" % "vertx-core"             % "4.3.8"
   lazy val vertxReactiveStreams = "io.vertx" % "vertx-reactive-streams" % "4.3.8"
 
-  lazy val akkaStreams = "com.typesafe.akka" %% "akka-stream"  % Version.akka
-  lazy val akkaTest    = "com.typesafe.akka" %% "akka-testkit" % Version.akka % Test
+  lazy val akkaTest = "com.typesafe.akka" %% "akka-testkit" % Version.akka % Test
+
+  lazy val rxJava = "io.reactivex.rxjava3" % "rxjava" % Version.rxJava
 
   lazy val tapirCore   = "com.softwaremill.sttp.tapir" %% "tapir-core"         % Version.tapir
   lazy val tapirServer = "com.softwaremill.sttp.tapir" %% "tapir-server"       % Version.tapir

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,6 +22,7 @@ object Version {
   lazy val akka       = "2.6.20"
   lazy val rxJava     = "3.1.6"
   lazy val tapir      = "1.2.8"
+  lazy val vertx      = "4.3.8"
   lazy val slick      = "3.3.2"
   lazy val postgresql = "42.2.12"
   lazy val sttp       = "3.7.4"
@@ -39,8 +40,8 @@ object Dependencies {
   lazy val alephiumHttp     = "org.alephium" %% "alephium-http"     % Version.common
   lazy val alephiumConf     = "org.alephium" %% "alephium-conf"     % Version.common
 
-  lazy val vertx                = "io.vertx" % "vertx-core"             % "4.3.8"
-  lazy val vertxReactiveStreams = "io.vertx" % "vertx-reactive-streams" % "4.3.8"
+  lazy val vertx       = "io.vertx" % "vertx-core"     % Version.vertx
+  lazy val vertxRxJava = "io.vertx" % "vertx-rx-java3" % Version.vertx
 
   lazy val akkaTest = "com.typesafe.akka" %% "akka-testkit" % Version.akka % Test
 


### PR DESCRIPTION
Resolves #401 and #438

I first thought that the above issue was a super low priority, but actually the FE team got hit by this it when testing [this PR](https://github.com/alephium/explorer-backend/pull/456) , I could then also reproduce locally, but it was a pain the find the source of the problem.

It seems there is an issue with `vertx-reactive-streams`, it doesn't handle well back pressure and in case of heavy load, it can just hangs a request forever, without any error.

To be able to link `akka-streams` and `vertx`, we need to pass through this `vertx-reactive-streams`, so it seems the right time to migrate to `rx-java` as there are builtin integrations in `vertx` for it. 

One of the hanging point was the perfs, that weren't that better, but actually with this following change it improved a lot: 

> Use Flowable.fromCompletionStage instead of fromFuture

`fromFuture` is actually performing some blocking operations and is not recommended.
This little change improve a lot the export of txs. With the former we were reaching 600k/s, up to 700k/s when jvm and db was hot.
With the second one, it reaches around 1400k/s when cold and up to 2700k/s when hot on my various tests.