### PR TITLE
Introduce `Pagination.Reversible`

### DIFF
--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -288,15 +288,6 @@
               "type": "integer",
               "format": "int32"
             }
-          },
-          {
-            "name": "reverse",
-            "in": "query",
-            "description": "Reverse pagination",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
           }
         ],
         "responses": {
@@ -823,15 +814,6 @@
               "type": "integer",
               "format": "int32"
             }
-          },
-          {
-            "name": "reverse",
-            "in": "query",
-            "description": "Reverse pagination",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
           }
         ],
         "responses": {
@@ -1082,15 +1064,6 @@
             "schema": {
               "type": "integer",
               "format": "int32"
-            }
-          },
-          {
-            "name": "reverse",
-            "in": "query",
-            "description": "Reverse pagination",
-            "required": false,
-            "schema": {
-              "type": "boolean"
             }
           }
         ],
@@ -1389,15 +1362,6 @@
             "schema": {
               "type": "integer",
               "format": "int32"
-            }
-          },
-          {
-            "name": "reverse",
-            "in": "query",
-            "description": "Reverse pagination",
-            "required": false,
-            "schema": {
-              "type": "boolean"
             }
           }
         ],
@@ -2093,15 +2057,6 @@
               "type": "integer",
               "format": "int32"
             }
-          },
-          {
-            "name": "reverse",
-            "in": "query",
-            "description": "Reverse pagination",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
           }
         ],
         "responses": {
@@ -2233,15 +2188,6 @@
             "schema": {
               "type": "integer",
               "format": "int32"
-            }
-          },
-          {
-            "name": "reverse",
-            "in": "query",
-            "description": "Reverse pagination",
-            "required": false,
-            "schema": {
-              "type": "boolean"
             }
           }
         ],
@@ -3162,15 +3108,6 @@
               "type": "integer",
               "format": "int32"
             }
-          },
-          {
-            "name": "reverse",
-            "in": "query",
-            "description": "Reverse pagination",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
           }
         ],
         "responses": {
@@ -3420,15 +3357,6 @@
               "type": "integer",
               "format": "int32"
             }
-          },
-          {
-            "name": "reverse",
-            "in": "query",
-            "description": "Reverse pagination",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
           }
         ],
         "responses": {
@@ -3552,15 +3480,6 @@
             "schema": {
               "type": "integer",
               "format": "int32"
-            }
-          },
-          {
-            "name": "reverse",
-            "in": "query",
-            "description": "Reverse pagination",
-            "required": false,
-            "schema": {
-              "type": "boolean"
             }
           }
         ],
@@ -3812,15 +3731,6 @@
             "schema": {
               "type": "integer",
               "format": "int32"
-            }
-          },
-          {
-            "name": "reverse",
-            "in": "query",
-            "description": "Reverse pagination",
-            "required": false,
-            "schema": {
-              "type": "boolean"
             }
           }
         ],
@@ -5034,15 +4944,6 @@
               "type": "integer",
               "format": "int32"
             }
-          },
-          {
-            "name": "reverse",
-            "in": "query",
-            "description": "Reverse pagination",
-            "required": false,
-            "schema": {
-              "type": "boolean"
-            }
           }
         ],
         "responses": {
@@ -5197,15 +5098,6 @@
             "schema": {
               "type": "integer",
               "format": "int32"
-            }
-          },
-          {
-            "name": "reverse",
-            "in": "query",
-            "description": "Reverse pagination",
-            "required": false,
-            "schema": {
-              "type": "boolean"
             }
           }
         ],
@@ -5452,15 +5344,6 @@
             "schema": {
               "type": "integer",
               "format": "int32"
-            }
-          },
-          {
-            "name": "reverse",
-            "in": "query",
-            "description": "Reverse pagination",
-            "required": false,
-            "schema": {
-              "type": "boolean"
             }
           }
         ],

--- a/app/src/main/scala/org/alephium/explorer/api/BlockEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/BlockEndpoints.scala
@@ -47,9 +47,9 @@ trait BlockEndpoints extends BaseEndpoint with QueryParams {
       .out(jsonBody[ArraySeq[Transaction]])
       .description("Get block's transactions")
 
-  val listBlocks: BaseEndpoint[Pagination, ListBlocks] =
+  val listBlocks: BaseEndpoint[Pagination.Reversible, ListBlocks] =
     blocksEndpoint.get
-      .in(pagination)
+      .in(paginationReversible)
       .out(jsonBody[ListBlocks])
       .description("List latest blocks")
 }

--- a/app/src/main/scala/org/alephium/explorer/api/model/Pagination.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/Pagination.scala
@@ -16,19 +16,27 @@
 
 package org.alephium.explorer.api.model
 
-final case class Pagination private (page: Int, limit: Int, reverse: Boolean) {
+final case class Pagination private (page: Int, limit: Int) {
   val offset: Int = (page - 1) * limit
 }
 
 object Pagination {
 
+  final case class Reversible private (page: Int, limit: Int, reverse: Boolean) {
+    val offset: Int = (page - 1) * limit
+  }
+  object Reversible {
+    @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
+    def unsafe(page: Int, limit: Int, reverse: Boolean = false): Reversible = {
+      Reversible(page, limit, reverse)
+    }
+  }
   val defaultPage: Int  = 1
   val defaultLimit: Int = 20
   val maxLimit: Int     = 100
   val thousand: Int     = 1000
 
-  @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
-  def unsafe(page: Int, limit: Int, reverse: Boolean = false): Pagination = {
-    Pagination(page, limit, reverse)
+  def unsafe(page: Int, limit: Int): Pagination = {
+    Pagination(page, limit)
   }
 }

--- a/app/src/main/scala/org/alephium/explorer/persistence/dao/BlockDao.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/dao/BlockDao.scala
@@ -85,7 +85,7 @@ object BlockDao {
                                                groupSetting: GroupSetting): Future[Unit] =
     run(insertBlockEntity(blocks, groupSetting.groupNum)).map(_ => ())
 
-  def listMainChain(pagination: Pagination)(
+  def listMainChain(pagination: Pagination.Reversible)(
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile],
       cache: BlockCache): Future[(ArraySeq[BlockEntryLite], Int)] = {

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
@@ -166,11 +166,11 @@ object BlockQueries extends StrictLogging {
     * Fetches all main_chain [[org.alephium.explorer.persistence.schema.BlockHeaderSchema.table]] rows
     */
   def listMainChainHeadersWithTxnNumberSQL(
-      pagination: Pagination): DBActionRWT[ArraySeq[BlockEntryLite]] =
+      pagination: Pagination.Reversible): DBActionRWT[ArraySeq[BlockEntryLite]] =
     listMainChainHeadersWithTxnNumberSQLBuilder(pagination)
       .asASE[BlockEntryLite](blockEntryListGetResult)
 
-  def explainListMainChainHeadersWithTxnNumber(pagination: Pagination)(
+  def explainListMainChainHeadersWithTxnNumber(pagination: Pagination.Reversible)(
       implicit ec: ExecutionContext): DBActionR[ExplainResult] =
     listMainChainHeadersWithTxnNumberSQLBuilder(pagination).explainAnalyze() map { explain =>
       ExplainResult(
@@ -182,7 +182,8 @@ object BlockQueries extends StrictLogging {
       )
     }
 
-  def listMainChainHeadersWithTxnNumberSQLBuilder(pagination: Pagination): SQLActionBuilder = {
+  def listMainChainHeadersWithTxnNumberSQLBuilder(
+      pagination: Pagination.Reversible): SQLActionBuilder = {
     //order by for inner query
     val orderBy =
       if (pagination.reverse) {

--- a/app/src/main/scala/org/alephium/explorer/service/BlockService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/BlockService.scala
@@ -37,9 +37,9 @@ trait BlockService {
       implicit ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]]
 
-  def listBlocks(pagination: Pagination)(implicit ec: ExecutionContext,
-                                         dc: DatabaseConfig[PostgresProfile],
-                                         cache: BlockCache): Future[ListBlocks]
+  def listBlocks(pagination: Pagination.Reversible)(implicit ec: ExecutionContext,
+                                                    dc: DatabaseConfig[PostgresProfile],
+                                                    cache: BlockCache): Future[ListBlocks]
 
   def listMaxHeights()(implicit cache: BlockCache,
                        groupSetting: GroupSetting,
@@ -62,9 +62,9 @@ object BlockService extends BlockService {
       dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]] =
     BlockDao.getTransactions(hash, pagination)
 
-  def listBlocks(pagination: Pagination)(implicit ec: ExecutionContext,
-                                         dc: DatabaseConfig[PostgresProfile],
-                                         cache: BlockCache): Future[ListBlocks] =
+  def listBlocks(pagination: Pagination.Reversible)(implicit ec: ExecutionContext,
+                                                    dc: DatabaseConfig[PostgresProfile],
+                                                    cache: BlockCache): Future[ListBlocks] =
     BlockDao.listMainChain(pagination).map {
       case (blocks, total) =>
         ListBlocks(total, blocks)

--- a/app/src/main/scala/org/alephium/explorer/service/IndexChecker.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/IndexChecker.scala
@@ -38,8 +38,10 @@ object IndexChecker {
 
   def checkAction()(implicit ec: ExecutionContext): DBActionR[ArraySeq[ExplainResult]] =
     for {
-      a                  <- BlockQueries.explainListMainChainHeadersWithTxnNumber(Pagination.unsafe(1, 20)) //first page
-      b                  <- BlockQueries.explainListMainChainHeadersWithTxnNumber(Pagination.unsafe(10000, 20)) //far page
+      a <- BlockQueries.explainListMainChainHeadersWithTxnNumber(
+        Pagination.Reversible.unsafe(1, 20)) //first page
+      b <- BlockQueries.explainListMainChainHeadersWithTxnNumber(
+        Pagination.Reversible.unsafe(10000, 20)) //far page
       c                  <- BlockQueries.explainMainChainQuery()
       oldestOutputEntity <- OutputQueries.getMainChainOutputs(true).headOrEmpty
       latestOutputEntity <- OutputQueries.getMainChainOutputs(false).headOrEmpty

--- a/app/src/test/scala/org/alephium/explorer/Generators.scala
+++ b/app/src/test/scala/org/alephium/explorer/Generators.scala
@@ -761,6 +761,5 @@ object Generators {
       maxDataCount <- maxDataCountGen
       page         <- Gen.choose(maxDataCount min 1, maxDataCount) //Requirement: Page should be >= 1
       limit        <- Gen.choose(0, maxDataCount)
-      reverse      <- Arbitrary.arbitrary[Boolean]
-    } yield Pagination.unsafe(page, limit, reverse)
+    } yield Pagination.unsafe(page, limit)
 }

--- a/app/src/test/scala/org/alephium/explorer/persistence/dao/BlockDaoSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/dao/BlockDaoSpec.scala
@@ -165,7 +165,7 @@ class BlockDaoSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with D
       //invoking listMainChainSQL would populate the cache with the row count
       eventually {
         BlockDao
-          .listMainChain(Pagination.unsafe(1, 1))
+          .listMainChain(Pagination.Reversible.unsafe(1, 1))
           .futureValue
           ._2 is expectedMainChainCount
       }
@@ -191,7 +191,7 @@ class BlockDaoSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with D
         //Assert the query return expected count
         eventually {
           BlockDao
-            .listMainChain(Pagination.unsafe(1, 1, Random.nextBoolean()))
+            .listMainChain(Pagination.Reversible.unsafe(1, 1, Random.nextBoolean()))
             .futureValue
             ._2 is expectedMainChainCount
         }
@@ -204,7 +204,7 @@ class BlockDaoSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with D
         //Dispatch a query so the cache get populated
         eventually {
           BlockDao
-            .listMainChain(Pagination.unsafe(1, 1, Random.nextBoolean()))
+            .listMainChain(Pagination.Reversible.unsafe(1, 1, Random.nextBoolean()))
             .futureValue
             ._2 is expectedMainChainCountTotal
         }

--- a/app/src/test/scala/org/alephium/explorer/service/BlockFlowSyncServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/BlockFlowSyncServiceSpec.scala
@@ -276,7 +276,7 @@ class BlockFlowSyncServiceSpec extends AlephiumFutureSpec with DatabaseFixtureFo
 
     def checkMainChain(mainChain: ArraySeq[BlockHash]) = {
       val result = BlockDao
-        .listMainChain(Pagination.unsafe(1, blocks.size))
+        .listMainChain(Pagination.Reversible.unsafe(1, blocks.size))
         .futureValue
         ._1
         .filter(block =>

--- a/app/src/test/scala/org/alephium/explorer/service/EmptyBlockService.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/EmptyBlockService.scala
@@ -39,9 +39,9 @@ trait EmptyBlockService extends BlockService {
       dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Transaction]] =
     Future.successful(ArraySeq.empty)
 
-  def listBlocks(pagination: Pagination)(implicit ec: ExecutionContext,
-                                         dc: DatabaseConfig[PostgresProfile],
-                                         cache: BlockCache): Future[ListBlocks] =
+  def listBlocks(pagination: Pagination.Reversible)(implicit ec: ExecutionContext,
+                                                    dc: DatabaseConfig[PostgresProfile],
+                                                    cache: BlockCache): Future[ListBlocks] =
     Future.successful(ListBlocks(0, ArraySeq.empty))
 
   def listMaxHeights()(implicit cache: BlockCache,

--- a/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/AddressReadState.scala
+++ b/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/AddressReadState.scala
@@ -73,9 +73,8 @@ class AddressReadState(val db: DBExecutor)
   lazy val txHashes: ArraySeq[TransactionId] = hashes.map(_._1)
 
   val pagination: Pagination = Pagination.unsafe(
-    page    = 1,
-    limit   = 100,
-    reverse = false
+    page  = 1,
+    limit = 100
   )
 
   private def generateInput(blockHash: BlockHash,

--- a/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/ListBlocksReadState.scala
+++ b/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/ListBlocksReadState.scala
@@ -44,7 +44,7 @@ class ListBlocksReadState(reverse: Boolean,
                           limitPerPage: Int,
                           transactionsPerBlock: Int,
                           val db: DBExecutor)
-    extends ReadBenchmarkState[Pagination](testDataCount = maxPages, db = db) {
+    extends ReadBenchmarkState[Pagination.Reversible](testDataCount = maxPages, db = db) {
 
   import config.profile.api._
 
@@ -58,8 +58,8 @@ class ListBlocksReadState(reverse: Boolean,
   /**
     * Generates a [[org.alephium.explorer.api.model.Pagination]] instance for each page to query.
     */
-  def generateData(currentCacheSize: Int): Pagination =
-    Pagination.unsafe(
+  def generateData(currentCacheSize: Int): Pagination.Reversible =
+    Pagination.Reversible.unsafe(
       page    = currentCacheSize + 1,
       limit   = limitPerPage,
       reverse = reverse
@@ -102,7 +102,7 @@ class ListBlocksReadState(reverse: Boolean,
       )
     }
 
-  def persist(cache: Array[Pagination]): Unit = {
+  def persist(cache: Array[Pagination.Reversible]): Unit = {
     logger.info(s"Generating data. Pages: ${cache.last.offset + 1}. Limit: ${cache.last.limit}.")
 
     val blocks       = List.fill(cache.length * limitPerPage)(generateBlockHeader()) //generate blocks


### PR DESCRIPTION
Only one endpoint was actually using the `reverse` field, all others were ignoring it, which was confusing for users.

The idea here is to remove that reverse field and use it only when we explicitly want it.

Resolves: https://github.com/alephium/explorer-backend/issues/428