### PR TITLE
Return mempool tx toward an address

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/MempoolQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/MempoolQueries.scala
@@ -57,8 +57,12 @@ object MempoolQueries {
 
   def listUTXHashesByAddress(address: Address): DBActionSR[TransactionId] = {
     sql"""
-      SELECT DISTINCT tx_hash
+      SELECT tx_hash
       FROM uinputs
+      WHERE address = $address
+      UNION
+      SELECT tx_hash
+      FROM uoutputs
       WHERE address = $address
     """.asAS[TransactionId]
   }

--- a/app/src/test/scala/org/alephium/explorer/Generators.scala
+++ b/app/src/test/scala/org/alephium/explorer/Generators.scala
@@ -642,6 +642,18 @@ object Generators {
       }
     }
 
+  def uInOutEntityWithDuplicateTxIdsAndAddressesGen()
+    : Gen[(List[UInputEntity], List[UOutputEntity])] =
+    for {
+      (txHash, addressOpt) <- duplicateTxIdAndAddressGen()
+      inputs               <- Gen.listOf(uinputEntityGen(txHash, Gen.option(addressOpt)))
+      outputs              <- Gen.listOf(uoutputEntityGen(txHash, addressOpt))
+    } yield
+      (inputs, outputs.zipWithIndex map {
+        case (entity, index) =>
+          entity.copy(uoutputOrder = index)
+      })
+
   /** Update toUpdate's primary key to be the same as `original` */
   def copyPrimaryKeys(original: InputEntity, toUpdate: InputEntity): InputEntity =
     toUpdate.copy(

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/UInputQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/UInputQueriesSpec.scala
@@ -38,39 +38,6 @@ class UInputQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForAll wi
     ()
   }
 
-  "listUTXHashesByAddress" should {
-    "return distinct hashes for address" in {
-      forAll(uinputEntityWithDuplicateTxIdsAndAddressesGen()) { uinputs =>
-        createTestData(uinputs)
-
-        val addressAndExpectedUInputs =
-          uinputs
-            .groupBy(_.address)
-            .map {
-              case (Some(address), entities) =>
-                //collect entities with addresses
-                (address, entities)
-
-              case (None, _) =>
-                //The entity didn't generate an address.
-                //So generate one and expect empty query result
-                (addressGen.sample.get, List.empty)
-            }
-
-        addressAndExpectedUInputs foreach {
-          case (address, expectedUInputs) =>
-            val actual =
-              run(MempoolQueries.listUTXHashesByAddress(address)).futureValue
-
-            //expect distinct transaction hashes
-            val expected = expectedUInputs.map(_.txHash).distinct
-
-            actual should contain theSameElementsAs expected
-        }
-      }
-    }
-  }
-
   "uinputsFromTxs" should {
     "return distinct hashes for address" in {
       forAll(uinputEntityWithDuplicateTxIdsAndAddressesGen()) { uinputs =>


### PR DESCRIPTION
Currently we were only returning the txs going out an address. The wallet team thought it would be nice to also see when a tx is going toward an address.

We could remove the `DISTINCT` as `UNION` is removing duplicates.

Resolves: https://github.com/alephium/explorer-backend/issues/360