### PR TITLE
Compute hashrate only when necessary

### DIFF
--- a/app/src/main/resources/application.conf
+++ b/app/src/main/resources/application.conf
@@ -23,7 +23,7 @@ explorer {
     token-supply-service-schedule-time = ${?EXPLORER_TOKEN_SUPPLY_SERVICE_SCHEDULE_TIME}
 
     # Sync interval for HashRateService
-    hash-rate-service-sync-period = 1 minute
+    hash-rate-service-sync-period = 1 hours
     hash-rate-service-sync-period = ${?EXPLORER_HASH_RATE_SERVICE_SYNC_PERIOD}
 
     # Sync interval for FinalizerService

--- a/app/src/test/scala/org/alephium/explorer/service/HashrateServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/HashrateServiceSpec.scala
@@ -164,6 +164,14 @@ class HashrateServiceSpec extends AlephiumFutureSpec with DatabaseFixtureForEach
     }
   }
 
+  "compute first sync interval" in new Fixture {
+    checkSyncInterval("2022-01-08T12:21:34.321Z", "2022-01-08T13:01:00.000Z")
+    checkSyncInterval("2022-01-08T23:21:34.321Z", "2022-01-09T00:01:00.000Z")
+    checkSyncInterval("2022-01-09T00:01:00.000Z", "2022-01-09T00:01:00.000Z")
+    checkSyncInterval("2022-01-09T00:00:30.000Z", "2022-01-09T00:01:00.000Z")
+    checkSyncInterval("2022-01-09T00:01:00.001Z", "2022-01-09T01:01:00.000Z")
+  }
+
   trait Fixture {
 
     val from = TimeStamp.zero
@@ -180,5 +188,11 @@ class HashrateServiceSpec extends AlephiumFutureSpec with DatabaseFixtureForEach
 
     def v(time: String, value: Double)  = (ts(time), bg(value))
     def hr(time: String, value: Double) = Hashrate(ts(time), bg(value), bg(value))
+
+    def checkSyncInterval(from: String, expected: String) = {
+      val timestamp = ts(from)
+      val duration  = HashrateService.computeFirstSyncInterval(timestamp)
+      timestamp.plusUnsafe(duration) is ts(expected)
+    }
   }
 }


### PR DESCRIPTION
Related to: https://github.com/alephium/explorer-backend/issues/315

Hashrate are computed once on start. As hashrates are grouped by hourly/daily interval we can schedule the next hashrate computation on next round hour + a delay e.g if it's 08:20, next sync will occurs at 09:00 + syncDelay.

Currently we were re-scheduling every minutes to be sure we didn't miss the new round hour (aaaaargs)