### PR TITLE
Token amount history

### DIFF
--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -3033,6 +3033,147 @@
         }
       }
     },
+    "/addresses/{address}/tokens/{token_id}/amount-history": {
+      "get": {
+        "tags": [
+          "Addresses"
+        ],
+        "operationId": "getAddressesAddressTokensToken_idAmount-history",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "address"
+            }
+          },
+          {
+            "name": "token_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "32-byte-hash"
+            }
+          },
+          {
+            "name": "fromTs",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": "0"
+            }
+          },
+          {
+            "name": "toTs",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": "0"
+            }
+          },
+          {
+            "name": "interval-type",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/IntervalType"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "headers": {
+              "Content-Disposition": {
+                "required": true,
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequest"
+                },
+                "example": {
+                  "detail": "Something bad in the request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unauthorized"
+                },
+                "example": {
+                  "detail": "You shall not pass"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFound"
+                },
+                "example": {
+                  "resource": "wallet-name",
+                  "detail": "wallet-name not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                },
+                "example": {
+                  "detail": "Ouch"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailable"
+                },
+                "example": {
+                  "detail": "Self clique unsynced"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/infos": {
       "get": {
         "tags": [

--- a/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
@@ -166,6 +166,16 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
       .out(header[String](HeaderNames.ContentDisposition))
       .out(streamTextBody(VertxStreams)(CodecFormat.Json()))
 
+  val getAddressTokenAmountHistory
+      : BaseEndpoint[(Address, TokenId, TimeInterval, IntervalType), (String, ReadStream[Buffer])] =
+    addressesTokensEndpoint.get
+      .in(path[TokenId]("token_id"))
+      .in("amount-history")
+      .in(timeIntervalQuery)
+      .in(intervalTypeQuery)
+      .out(header[String](HeaderNames.ContentDisposition))
+      .out(streamTextBody(VertxStreams)(CodecFormat.Json()))
+
   private case class TextCsv() extends CodecFormat {
     override val mediaType: MediaType = MediaType.TextCsv
   }

--- a/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
+++ b/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
@@ -57,6 +57,7 @@ trait Documentation
         areAddressesActive,
         exportTransactionsCsvByAddress,
         getAddressAmountHistory,
+        getAddressTokenAmountHistory,
         getInfos,
         getHeights,
         listMempoolTransactions,

--- a/app/src/main/scala/org/alephium/explorer/persistence/DBInitializer.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/DBInitializer.scala
@@ -48,6 +48,7 @@ object DBInitializer extends StrictLogging {
       InputSchema.table,
       OutputSchema.table,
       TokenOutputSchema.table,
+      TokenInputSchema.table,
       MempoolTransactionSchema.table,
       UInputSchema.table,
       UOutputSchema.table,

--- a/app/src/main/scala/org/alephium/explorer/persistence/Migrations.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/Migrations.scala
@@ -36,7 +36,7 @@ import org.alephium.util.TimeStamp
 @SuppressWarnings(Array("org.wartremover.warts.AnyVal"))
 object Migrations extends StrictLogging {
 
-  val latestVersion: MigrationVersion = MigrationVersion(5)
+  val latestVersion: MigrationVersion = MigrationVersion(6)
 
   def migration1(implicit ec: ExecutionContext): DBActionAll[Unit] =
     EventSchema.table.result.flatMap { events =>
@@ -96,12 +96,20 @@ object Migrations extends StrictLogging {
     } yield ()
   }
 
+  // Reset inputs with tokens so they get updated by `InputUpdateQueries`
+  def migration6(implicit ec: ExecutionContext): DBActionAll[Unit] = {
+    for {
+      _ <- sqlu"""UPDATE inputs SET output_ref_amount = NULL WHERE output_ref_tokens IS NOT NULL"""
+    } yield ()
+  }
+
   private def migrations(implicit ec: ExecutionContext): Seq[DBActionAll[Unit]] = Seq(
     migration1,
     migration2,
     migration3,
     migration4,
-    migration5
+    migration5,
+    migration6
   )
 
   def migrationsQuery(

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/TokenInputEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/TokenInputEntity.scala
@@ -1,0 +1,45 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.persistence.model
+
+import akka.util.ByteString
+
+import org.alephium.protocol.Hash
+import org.alephium.protocol.model.{Address, BlockHash, TokenId, TransactionId}
+import org.alephium.util.{TimeStamp, U256}
+
+final case class TokenInputEntity(
+    blockHash: BlockHash,
+    txHash: TransactionId,
+    timestamp: TimeStamp,
+    hint: Int,
+    outputRefKey: Hash,
+    unlockScript: Option[ByteString],
+    mainChain: Boolean,
+    inputOrder: Int,
+    txOrder: Int,
+    outputRefTxHash: Option[TransactionId],
+    outputRefAddress: Option[Address],
+    outputRefAmount: Option[U256],
+    token: TokenId,
+    tokenAmount: U256
+) {
+
+  /** @return All hash types associated with this [[InputEntity]] */
+  def hashes(): (TransactionId, BlockHash) =
+    (txHash, blockHash)
+}

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/OutputQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/OutputQueries.scala
@@ -154,59 +154,27 @@ object OutputQueries {
   }
 
   // scalastyle:off magic.number
-  private def insertTokenOutputs(tokenOutputs: Iterable[(Token, OutputEntity)]): DBActionW[Int] = {
-    QuerySplitter.splitUpdates(rows = tokenOutputs, columnsPerRow = 16) {
-      (tokenOutputs, placeholder) =>
-        val query =
-          s"""
-             |INSERT INTO token_outputs ("block_hash",
-             |                     "tx_hash",
-             |                     "block_timestamp",
-             |                     "output_type",
-             |                     "hint",
-             |                     "key",
-             |                     "token",
-             |                     "amount",
-             |                     "address",
-             |                     "main_chain",
-             |                     "lock_time",
-             |                     "message",
-             |                     "output_order",
-             |                     "tx_order",
-             |                     "spent_finalized",
-             |                     "spent_timestamp")
-             |VALUES $placeholder
-             |ON CONFLICT
-             |    ON CONSTRAINT token_outputs_pk
-             |    DO NOTHING
-             |""".stripMargin
-
-        val parameters: SetParameter[Unit] =
-          (_: Unit, params: PositionedParameters) =>
-            tokenOutputs foreach { case (token, output) =>
-              params >> output.blockHash
-              params >> output.txHash
-              params >> output.timestamp
-              params >> output.outputType
-              params >> output.hint
-              params >> output.key
-              params >> token.id
-              params >> token.amount
-              params >> output.address
-              params >> output.mainChain
-              params >> output.lockTime
-              params >> output.message
-              params >> output.outputOrder
-              params >> output.txOrder
-              params >> output.spentFinalized
-              params >> output.spentTimestamp
-            }
-
-        SQLActionBuilder(
-          queryParts = query,
-          unitPConv = parameters
-        ).asUpdate
-    }
+  def insertTokenOutputs(tokenOutputs: Iterable[(Token, OutputEntity)]): DBActionW[Int] = {
+    TokenQueries.insertTokenOutputs(tokenOutputs.map { case (token, output) =>
+      TokenOutputEntity(
+        output.blockHash,
+        output.txHash,
+        output.timestamp,
+        output.outputType,
+        output.hint,
+        output.key,
+        token.id,
+        token.amount,
+        output.address,
+        output.mainChain,
+        output.lockTime,
+        output.message,
+        output.outputOrder,
+        output.txOrder,
+        output.spentFinalized,
+        output.spentTimestamp
+      )
+    })
   }
   // scalastyle:on magic.number
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/TokenQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/TokenQueries.scala
@@ -357,6 +357,34 @@ object TokenQueries extends StrictLogging {
     """
   }
 
+  def sumAddressTokenInputs(address: Address, token: TokenId, from: TimeStamp, to: TimeStamp)(
+      implicit ec: ExecutionContext
+  ): DBActionR[U256] = {
+    sql"""
+      SELECT SUM(token_amount)
+      FROM token_inputs
+      WHERE output_ref_address = $address
+      AND token = $token
+      AND main_chain = true
+      AND block_timestamp >= $from
+      AND block_timestamp <= $to
+    """.asAS[Option[U256]].exactlyOne.map(_.getOrElse(U256.Zero))
+  }
+
+  def sumAddressTokenOutputs(address: Address, token: TokenId, from: TimeStamp, to: TimeStamp)(
+      implicit ec: ExecutionContext
+  ): DBActionR[U256] = {
+    sql"""
+      SELECT SUM(amount)
+      FROM token_outputs
+      WHERE address = $address
+      AND token = $token
+      AND main_chain = true
+      AND block_timestamp >= $from
+      AND block_timestamp <= $to
+    """.asAS[Option[U256]].exactlyOne.map(_.getOrElse(U256.Zero))
+  }
+
   def insertTokenInputs(tokenInputs: ArraySeq[TokenInputEntity]): DBActionWT[Int] = {
     // scalastyle:off magic.number
     QuerySplitter.splitUpdates(rows = tokenInputs, columnsPerRow = 14) { (inputs, placeholder) =>

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomGetResult.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomGetResult.scala
@@ -186,6 +186,27 @@ object CustomGetResult {
         outputRefTokens = result.<<?
       )
 
+  val inputWithBooleanGetResult: GetResult[(InputEntity, Boolean)] =
+    (result: PositionedResult) =>
+      (
+        InputEntity(
+          blockHash = result.<<,
+          txHash = result.<<,
+          timestamp = result.<<,
+          hint = result.<<,
+          outputRefKey = result.<<,
+          unlockScript = result.<<?,
+          mainChain = result.<<,
+          inputOrder = result.<<,
+          txOrder = result.<<,
+          outputRefTxHash = result.<<?,
+          outputRefAddress = result.<<?,
+          outputRefAmount = result.<<?,
+          outputRefTokens = result.<<?
+        ),
+        result.<<
+      )
+
   implicit val outputTypeGetResult: GetResult[OutputEntity.OutputType] =
     (result: PositionedResult) => OutputEntity.OutputType.unsafe(result.nextInt())
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenInputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenInputSchema.scala
@@ -1,0 +1,82 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.persistence.schema
+
+import akka.util.ByteString
+import slick.jdbc.PostgresProfile.api._
+import slick.lifted.{Index, PrimaryKey, ProvenShape}
+
+import org.alephium.explorer.persistence.DBActionW
+import org.alephium.explorer.persistence.model.TokenInputEntity
+import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
+import org.alephium.protocol.Hash
+import org.alephium.protocol.model.{Address, BlockHash, TokenId, TransactionId}
+import org.alephium.util.{TimeStamp, U256}
+
+object TokenInputSchema extends SchemaMainChain[TokenInputEntity]("token_inputs") {
+
+  class TokenInputs(tag: Tag) extends Table[TokenInputEntity](tag, name) {
+    def blockHash: Rep[BlockHash]             = column[BlockHash]("block_hash", O.SqlType("BYTEA"))
+    def txHash: Rep[TransactionId]            = column[TransactionId]("tx_hash", O.SqlType("BYTEA"))
+    def timestamp: Rep[TimeStamp]             = column[TimeStamp]("block_timestamp")
+    def hint: Rep[Int]                        = column[Int]("hint")
+    def outputRefKey: Rep[Hash]               = column[Hash]("output_ref_key", O.SqlType("BYTEA"))
+    def unlockScript: Rep[Option[ByteString]] = column[Option[ByteString]]("unlock_script")
+    def mainChain: Rep[Boolean]               = column[Boolean]("main_chain")
+    def inputOrder: Rep[Int]                  = column[Int]("input_order")
+    def txOrder: Rep[Int]                     = column[Int]("tx_order")
+    def outputRefTxHash: Rep[Option[TransactionId]] =
+      column[Option[TransactionId]]("output_ref_tx_hash")
+    def outputRefAddress: Rep[Option[Address]] = column[Option[Address]]("output_ref_address")
+    def outputRefAmount: Rep[Option[U256]] =
+      column[Option[U256]]("output_ref_amount", O.SqlType("DECIMAL(80,0)"))
+    def token: Rep[TokenId]    = column[TokenId]("token")
+    def tokenAmount: Rep[U256] = column[U256]("token_amount", O.SqlType("DECIMAL(80,0)"))
+
+    def pk: PrimaryKey = primaryKey("token_inputs_pk", (outputRefKey, blockHash))
+
+    def timestampIdx: Index        = index("token_inputs_timestamp_idx", timestamp)
+    def outputRefAddressIdx: Index = index("token_inputs_output_ref_address_idx", outputRefAddress)
+    def tokenIdx: Index            = index("token_inputs_token_idx", token)
+
+    def * : ProvenShape[TokenInputEntity] =
+      (
+        blockHash,
+        txHash,
+        timestamp,
+        hint,
+        outputRefKey,
+        unlockScript,
+        mainChain,
+        inputOrder,
+        txOrder,
+        outputRefTxHash,
+        outputRefAddress,
+        outputRefAmount,
+        token,
+        tokenAmount
+      )
+        .<>((TokenInputEntity.apply _).tupled, TokenInputEntity.unapply)
+  }
+
+  def createOutputRefAddressNullIndex(): DBActionW[Int] =
+    sqlu"""CREATE INDEX IF NOT EXISTS inputs_output_ref_amount_null_idx
+      ON #${name} (output_ref_tx_hash, output_ref_address, output_ref_amount, output_ref_tokens)
+      WHERE output_ref_amount IS NULL"""
+
+  val table: TableQuery[TokenInputs] = TableQuery[TokenInputs]
+}

--- a/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
@@ -16,9 +16,6 @@
 
 package org.alephium.explorer.service
 
-import java.math.BigInteger
-import java.time.Instant
-
 import scala.collection.immutable.ArraySeq
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
@@ -34,10 +31,9 @@ import org.alephium.explorer.cache.TransactionCache
 import org.alephium.explorer.persistence.DBRunner._
 import org.alephium.explorer.persistence.dao.{MempoolDao, TransactionDao}
 import org.alephium.explorer.persistence.queries.TransactionQueries._
-import org.alephium.explorer.util.TimeUtil
-import org.alephium.protocol.ALPH
+import org.alephium.explorer.util.FlowableUtil
 import org.alephium.protocol.model.{Address, TransactionId}
-import org.alephium.util.{Duration, TimeStamp, U256}
+import org.alephium.util.{TimeStamp, U256}
 
 trait TransactionService {
 
@@ -221,71 +217,9 @@ object TransactionService extends TransactionService {
       intervalType: IntervalType,
       paralellism: Int
   )(implicit ec: ExecutionContext, dc: DatabaseConfig[PostgresProfile]): Flowable[Buffer] = {
-    val timeranges = amountHistoryTimeRanges(from, to, intervalType)
-    val amountHistory = Flowable
-      .fromIterable(timeranges.asJava)
-      .concatMapEager(
-        { case (from: TimeStamp, to: TimeStamp) =>
-          Flowable.fromCompletionStage(getInOutAmount(address, from, to).asJava)
-        },
-        paralellism,
-        1
-      )
-      .filter {
-        // Ignore time ranges without data
-        case (in, out, _) => in != U256.Zero || out != U256.Zero
-      }
-      .scan(
-        (BigInteger.ZERO, TimeStamp.zero),
-        { (acc: (BigInteger, TimeStamp), next) =>
-          val (sum, _)      = acc
-          val (in, out, to) = next
-          val diff          = out.v.subtract(in.v)
-          val newSum        = sum.add(diff)
-          (newSum, to)
-        }
-      )
-      .skip(1) // Drop first elem which is the seed of the scan (0,0)
-
-    amountHistoryToJsonFlowable(
-      amountHistory
-    )
-  }
-
-  def amountHistoryToJsonFlowable(history: Flowable[(BigInteger, TimeStamp)]): Flowable[Buffer] = {
-    history
-      .concatMap { case (diff, to: TimeStamp) =>
-        val str = s"""[${to.millis},"$diff"]"""
-        Flowable.just(str, ",")
-      }
-      .skipLast(1) // Removing latest "," it replace the missing `intersperse`
-      .startWith(Flowable.just("""{"amountHistory":["""))
-      .concatWith(Flowable.just("]}"))
-      .map(Buffer.buffer)
-  }
-
-  @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
-  private def amountHistoryTimeRanges(
-      from: TimeStamp,
-      to: TimeStamp,
-      intervalType: IntervalType
-  ): ArraySeq[(TimeStamp, TimeStamp)] = {
-    val fromTruncated =
-      TimeStamp.unsafe(
-        Instant
-          .ofEpochMilli(
-            if (from.isBefore(ALPH.LaunchTimestamp)) ALPH.LaunchTimestamp.millis else from.millis
-          )
-          .truncatedTo(intervalType.chronoUnit)
-          .toEpochMilli
-      )
-
-    val first = (ALPH.GenesisTimestamp, fromTruncated.minusUnsafe(Duration.ofMillisUnsafe(1)))
-    first +: TimeUtil.buildTimestampRange(
-      fromTruncated,
-      to,
-      (intervalType.duration - Duration.ofMillisUnsafe(1)).get
-    )
+    FlowableUtil.getAmountHistory(from, to, intervalType, paralellism) { case (fromTs, toTs) =>
+      getInOutAmount(address, fromTs, toTs)
+    }
   }
 
   private def transactionSource(

--- a/app/src/main/scala/org/alephium/explorer/util/FlowableUtil.scala
+++ b/app/src/main/scala/org/alephium/explorer/util/FlowableUtil.scala
@@ -1,0 +1,81 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.util
+
+import java.math.BigInteger
+
+import scala.concurrent.Future
+import scala.jdk.CollectionConverters._
+import scala.jdk.FutureConverters._
+
+import io.reactivex.rxjava3.core.Flowable
+import io.vertx.core.buffer.Buffer
+
+import org.alephium.explorer.api.model._
+import org.alephium.explorer.util.TimeUtil
+import org.alephium.util.{TimeStamp, U256}
+
+object FlowableUtil {
+  def amountHistoryToJsonFlowable(history: Flowable[(BigInteger, TimeStamp)]): Flowable[Buffer] = {
+    history
+      .concatMap { case (diff, to: TimeStamp) =>
+        val str = s"""[${to.millis},"$diff"]"""
+        Flowable.just(str, ",")
+      }
+      .skipLast(1) // Removing latest "," it replace the missing `intersperse`
+      .startWith(Flowable.just("""{"amountHistory":["""))
+      .concatWith(Flowable.just("]}"))
+      .map(Buffer.buffer)
+  }
+
+  def getAmountHistory(
+      from: TimeStamp,
+      to: TimeStamp,
+      intervalType: IntervalType,
+      paralellism: Int
+  )(getInOutAmount: (TimeStamp, TimeStamp) => Future[(U256, U256, TimeStamp)]): Flowable[Buffer] = {
+    val timeranges = TimeUtil.amountHistoryTimeRanges(from, to, intervalType)
+    val amountHistory = Flowable
+      .fromIterable(timeranges.asJava)
+      .concatMapEager(
+        { case (from: TimeStamp, to: TimeStamp) =>
+          Flowable.fromCompletionStage(getInOutAmount(from, to).asJava)
+        },
+        paralellism,
+        1
+      )
+      .filter {
+        // Ignore time ranges without data
+        case (in, out, _) => in != U256.Zero || out != U256.Zero
+      }
+      .scan(
+        (BigInteger.ZERO, TimeStamp.zero),
+        { (acc: (BigInteger, TimeStamp), next) =>
+          val (sum, _)      = acc
+          val (in, out, to) = next
+          val diff          = out.v.subtract(in.v)
+          val newSum        = sum.add(diff)
+          (newSum, to)
+        }
+      )
+      .skip(1) // Drop first elem which is the seed of the scan (0,0)
+
+    amountHistoryToJsonFlowable(
+      amountHistory
+    )
+  }
+}

--- a/app/src/test/scala/org/alephium/explorer/GenDBModel.scala
+++ b/app/src/test/scala/org/alephium/explorer/GenDBModel.scala
@@ -32,6 +32,7 @@ import org.alephium.protocol.model.{Address, BlockHash, ChainIndex, GroupIndex, 
 import org.alephium.util.{AVector, TimeStamp}
 
 /** Test-data generators for types in package [[org.alephium.explorer.persistence.model]] */
+// scalastyle:off number.of.methods
 @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
 object GenDBModel {
 
@@ -292,6 +293,33 @@ object GenDBModel {
       spentFinalized,
       spentTimestamp
     )
+
+  def tokenInputEntityGen()(implicit groupSetting: GroupSetting): Gen[TokenInputEntity] =
+    for {
+      inputEntity  <- inputEntityGen()
+      outputEntity <- outputEntityGen
+      unlockScript <- Gen.option(unlockScriptGen)
+      txOrder      <- arbitrary[Int]
+      token        <- tokenIdGen
+      tokenAmount  <- amountGen
+    } yield {
+      TokenInputEntity(
+        blockHash = inputEntity.blockHash,
+        txHash = inputEntity.txHash,
+        timestamp = inputEntity.timestamp,
+        hint = inputEntity.hint,
+        outputRefKey = outputEntity.key,
+        unlockScript = unlockScript,
+        mainChain = inputEntity.mainChain,
+        inputOrder = inputEntity.inputOrder,
+        txOrder = txOrder,
+        outputRefTxHash = Some(outputEntity.txHash),
+        outputRefAddress = Some(outputEntity.address),
+        outputRefAmount = Some(outputEntity.amount),
+        token,
+        tokenAmount
+      )
+    }
 
   def blockEntityGen(
       chainIndex: ChainIndex

--- a/app/src/test/scala/org/alephium/explorer/service/EmptyTokenService.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/EmptyTokenService.scala
@@ -19,12 +19,14 @@ package org.alephium.explorer.service
 import scala.collection.immutable.ArraySeq
 import scala.concurrent.{ExecutionContext, Future}
 
+import io.reactivex.rxjava3.core.Flowable
+import io.vertx.core.buffer.Buffer
 import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
 
 import org.alephium.explorer.api.model._
 import org.alephium.protocol.model.{Address, TokenId}
-import org.alephium.util.U256
+import org.alephium.util.{TimeStamp, U256}
 
 trait EmptyTokenService extends TokenService {
   def getTokenBalance(address: Address, token: TokenId)(implicit
@@ -102,4 +104,13 @@ trait EmptyTokenService extends TokenService {
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]
   ): Future[Unit] = ???
+
+  def getAmountHistory(
+      address: Address,
+      token: TokenId,
+      from: TimeStamp,
+      to: TimeStamp,
+      intervalType: IntervalType,
+      paralellism: Int
+  )(implicit ec: ExecutionContext, dc: DatabaseConfig[PostgresProfile]): Flowable[Buffer] = ???
 }

--- a/app/src/test/scala/org/alephium/explorer/service/TokenServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TokenServiceSpec.scala
@@ -1,0 +1,138 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.service
+
+import java.math.BigInteger
+
+import scala.collection.immutable.ArraySeq
+import scala.concurrent.Future
+import scala.jdk.CollectionConverters._
+
+import io.vertx.core.buffer.Buffer
+import org.scalacheck.Gen
+
+import org.alephium.api.UtilJson._
+import org.alephium.explorer.AlephiumActorSpecLike
+import org.alephium.explorer.ConfigDefaults._
+import org.alephium.explorer.GenApiModel._
+import org.alephium.explorer.GenCoreProtocol._
+import org.alephium.explorer.GenDBModel._
+import org.alephium.explorer.api.model._
+import org.alephium.explorer.cache.{BlockCache, TestBlockCache}
+import org.alephium.explorer.persistence.DatabaseFixtureForEach
+import org.alephium.explorer.persistence.dao.BlockDao
+import org.alephium.explorer.persistence.model._
+import org.alephium.explorer.persistence.queries.InputUpdateQueries
+import org.alephium.json.Json._
+import org.alephium.protocol.model.{ChainIndex, GroupIndex}
+import org.alephium.util.{Duration, TimeStamp}
+
+@SuppressWarnings(
+  Array(
+    "org.wartremover.warts.Var",
+    "org.wartremover.warts.DefaultArguments",
+    "org.wartremover.warts.AsInstanceOf"
+  )
+)
+class TokenServiceSpec extends AlephiumActorSpecLike with DatabaseFixtureForEach {
+
+  "get amount history" in new Fixture {
+    Seq[IntervalType](IntervalType.Hourly, IntervalType.Daily).foreach { intervalType =>
+      val token = tokens.head
+      val flowable = TokenService
+        .getAmountHistory(address, token.id, fromTs, toTs, intervalType, 8)
+
+      val result: Seq[Buffer] =
+        flowable.toList().blockingGet().asScala
+
+      val amountHistory = read[ujson.Value](result.mkString)
+      val history       = read[Seq[(Long, BigInteger)]](amountHistory("amountHistory"))
+
+      val times = history.map(_._1)
+
+      // Test that history is always ordered correctly
+      times is times.sorted
+
+      // TODO Test history amount value
+    }
+  }
+
+  trait Fixture {
+    implicit val blockCache: BlockCache = TestBlockCache()
+
+    val groupIndex = GroupIndex.Zero
+    val chainIndex = ChainIndex(groupIndex, groupIndex)
+
+    val defaultBlockEntity: BlockEntity =
+      BlockEntity(
+        hash = blockHashGen.sample.get,
+        timestamp = TimeStamp.unsafe(0),
+        chainFrom = groupIndex,
+        chainTo = groupIndex,
+        height = Height.unsafe(0),
+        deps = ArraySeq.empty,
+        transactions = ArraySeq.empty,
+        inputs = ArraySeq.empty,
+        outputs = ArraySeq.empty,
+        true,
+        nonce = bytesGen.sample.get,
+        version = 1.toByte,
+        depStateHash = hashGen.sample.get,
+        txsHash = hashGen.sample.get,
+        target = bytesGen.sample.get,
+        hashrate = BigInteger.ZERO
+      )
+
+    val address = addressGen.sample.get
+
+    val halfDay = Duration.ofHoursUnsafe(12)
+    val now     = TimeStamp.now()
+
+    val blocks = Gen
+      .listOfN(5, blockEntityGen(chainIndex))
+      .map(_.zipWithIndex.map { case (block, index) =>
+        val timestamp = now + (halfDay.timesUnsafe(index.toLong))
+        block.copy(
+          timestamp = timestamp,
+          outputs = block.outputs.map(_.copy(address = address, timestamp = timestamp)),
+          inputs =
+            block.inputs.map(_.copy(outputRefAddress = Some(address), timestamp = timestamp)),
+          transactions = block.transactions.map { tx =>
+            tx.copy(timestamp = timestamp)
+          }
+        )
+      })
+      .sample
+      .get
+
+    BlockDao.insertAll(blocks).futureValue
+    Future
+      .sequence(blocks.map { block =>
+        for {
+          _ <- databaseConfig.db.run(InputUpdateQueries.updateInputs())
+          _ <- BlockDao.updateMainChainStatus(block.hash, true)
+        } yield (())
+      })
+      .futureValue
+
+    val transactions = blocks.flatMap(_.transactions).sortBy(_.timestamp)
+    val timestamps   = transactions.map(_.timestamp).distinct
+    val fromTs       = timestamps.head
+    val toTs         = timestamps.last + Duration.ofMillisUnsafe(1)
+    val tokens       = blocks.flatMap(_.outputs.flatMap(_.tokens)).flatten
+  }
+}

--- a/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
@@ -40,6 +40,7 @@ import org.alephium.explorer.service.{
   EmptyTransactionService,
   TransactionService
 }
+import org.alephium.explorer.util.FlowableUtil
 import org.alephium.protocol.model.{Address, TokenId}
 import org.alephium.util.{Duration, TimeStamp, U256}
 
@@ -117,7 +118,7 @@ class AddressServerSpec()
         intervalType: IntervalType,
         paralellism: Int
     )(implicit ec: ExecutionContext, dc: DatabaseConfig[PostgresProfile]): Flowable[Buffer] =
-      TransactionService.amountHistoryToJsonFlowable(Flowable.fromIterable(amountHistory.asJava))
+      FlowableUtil.amountHistoryToJsonFlowable(Flowable.fromIterable(amountHistory.asJava))
   }
 
   val tokenService = new EmptyTokenService {


### PR DESCRIPTION
Resolves #497

High priority as it blocks the next release of the wallet

It might looks like a huge PR, but it's mostly some functions extracted  and some other copy/pasted and adapted from our current `amount-history` for ALPH endpoint.

The only "real" new part is the new `token_inputs` table, we need it in order to compute the diff of token amount.

For example the `sumAddressToken*` are taken from [here](https://github.com/alephium/explorer-backend/blob/35c86efffbb6d1047af14198beee42175e634a2a/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala#L349-L373)