### PR TITLE
Optimize amount history

### DIFF
--- a/app/src/main/resources/application.conf
+++ b/app/src/main/resources/application.conf
@@ -45,6 +45,25 @@ explorer {
     #Number of allowed parallelism when using `mapAsync` on streams.
     stream-parallelism = 8
     stream-parallelism = ${?EXPLORER_STREAM_PARALLELISM}
+
+    max-time-intervals {
+        amount-history = {
+            hourly = 7 days
+            hourly = ${?EXPLORER_AMOUNT_HISTORY_MAX_TIME_INTERVAL_HOURLY}
+            daily  = 365 days
+            daily = ${?EXPLORER_AMOUNT_HISTORY_MAX_TIME_INTERVAL_DAILY}
+            weekly = 365 days
+            weekly = ${?EXPLORER_AMOUNT_HISTORY_MAX_TIME_INTERVAL_WEEKLY}
+        }
+        charts = {
+            hourly = 30 days
+            hourly = ${?EXPLORER_CHARTS_MAX_TIME_INTERVAL_HOURLY}
+            daily  = 365 days
+            daily = ${?EXPLORER_CHARTS_MAX_TIME_INTERVAL_DAILY}
+            weekly = 365 days
+            weekly = ${?EXPLORER_CHARTS_MAX_TIME_INTERVAL_WEEKLY}
+        }
+    }
 }
 
 blockflow {

--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -6905,7 +6905,8 @@
         "type": "string",
         "enum": [
           "daily",
-          "hourly"
+          "hourly",
+          "weekly"
         ]
       },
       "ListBlocks": {

--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -2901,12 +2901,12 @@
         }
       }
     },
-    "/addresses/{address}/amount-history": {
+    "/addresses/{address}/amount-history-DEPRECATED": {
       "get": {
         "tags": [
           "Addresses"
         ],
-        "operationId": "getAddressesAddressAmount-history",
+        "operationId": "getAddressesAddressAmount-history-deprecated",
         "parameters": [
           {
             "name": "address",
@@ -3030,6 +3030,10 @@
               }
             }
           }
+        },
+        "deprecated": true
+      }
+    },
         }
       }
     },

--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -3034,6 +3034,135 @@
         "deprecated": true
       }
     },
+    "/addresses/{address}/amount-history": {
+      "get": {
+        "tags": [
+          "Addresses"
+        ],
+        "operationId": "getAddressesAddressAmount-history",
+        "parameters": [
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "address"
+            }
+          },
+          {
+            "name": "fromTs",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": "0"
+            }
+          },
+          {
+            "name": "toTs",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": "0"
+            }
+          },
+          {
+            "name": "interval-type",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/IntervalType"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AmountHistory"
+                },
+                "example": {
+                  "amountHistory": [
+                    [
+                      1611041396892,
+                      "1"
+                    ]
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequest"
+                },
+                "example": {
+                  "detail": "Something bad in the request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unauthorized"
+                },
+                "example": {
+                  "detail": "You shall not pass"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFound"
+                },
+                "example": {
+                  "resource": "wallet-name",
+                  "detail": "wallet-name not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                },
+                "example": {
+                  "detail": "Ouch"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailable"
+                },
+                "example": {
+                  "detail": "Self clique unsynced"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -6454,6 +6583,17 @@
           }
         }
       },
+      "AmountHistory": {
+        "type": "object",
+        "properties": {
+          "amountHistory": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TimedAmount"
+            }
+          }
+        }
+      },
       "AssetOutput": {
         "required": [
           "hint",
@@ -7108,6 +7248,23 @@
               "type": "string",
               "format": "address"
             }
+          }
+        }
+      },
+      "TimedAmount": {
+        "required": [
+          "timestamp",
+          "amount"
+        ],
+        "type": "object",
+        "properties": {
+          "timestamp": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "amount": {
+            "type": "string",
+            "format": "bigint"
           }
         }
       },

--- a/app/src/main/scala/org/alephium/explorer/AppServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/AppServer.scala
@@ -24,13 +24,18 @@ import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
 
 import org.alephium.explorer.cache.{BlockCache, TransactionCache}
+import org.alephium.explorer.config.ExplorerConfig
 import org.alephium.explorer.service._
 import org.alephium.explorer.web._
 
 // scalastyle:off magic.number
 object AppServer {
 
-  def routes(exportTxsNumberThreshold: Int, streamParallelism: Int)(implicit
+  def routes(
+      exportTxsNumberThreshold: Int,
+      streamParallelism: Int,
+      maxTimeIntervals: ExplorerConfig.MaxTimeIntervals
+  )(implicit
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile],
       blockFlowClient: BlockFlowClient,
@@ -45,12 +50,13 @@ object AppServer {
         TransactionService,
         TokenService,
         exportTxsNumberThreshold,
-        streamParallelism
+        streamParallelism,
+        maxTimeIntervals.amountHistory
       )
     val transactionServer = new TransactionServer()
     val infosServer       = new InfosServer(TokenSupplyService, BlockService, TransactionService)
     val utilsServer: UtilsServer   = new UtilsServer()
-    val chartsServer: ChartsServer = new ChartsServer()
+    val chartsServer: ChartsServer = new ChartsServer(maxTimeIntervals.charts)
     val tokenServer: TokenServer   = new TokenServer(TokenService)
     val mempoolServer              = new MempoolServer()
     val eventServer                = new EventServer()

--- a/app/src/main/scala/org/alephium/explorer/ExplorerState.scala
+++ b/app/src/main/scala/org/alephium/explorer/ExplorerState.scala
@@ -92,14 +92,15 @@ sealed trait ExplorerStateRead extends ExplorerState {
     new ExplorerHttpServer(
       config.host,
       config.port,
-      AppServer.routes(config.exportTxsNumberThreshold, config.streamParallelism)(
-        executionContext,
-        database.databaseConfig,
-        blockFlowClient,
-        blockCache,
-        transactionCache,
-        groupSettings
-      )
+      AppServer
+        .routes(config.exportTxsNumberThreshold, config.streamParallelism, config.maxTimeInterval)(
+          executionContext,
+          database.databaseConfig,
+          blockFlowClient,
+          blockCache,
+          transactionCache,
+          groupSettings
+        )
     )
 
   override lazy val customServices: ArraySeq[Service] = ArraySeq(httpServer)

--- a/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
@@ -157,14 +157,15 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
       .out(header[String](HeaderNames.ContentDisposition))
       .out(streamTextBody(VertxStreams)(TextCsv()))
 
-  val getAddressAmountHistory
+  val getAddressAmountHistoryDEPRECATED
       : BaseEndpoint[(Address, TimeInterval, IntervalType), (String, ReadStream[Buffer])] =
     addressesEndpoint.get
-      .in("amount-history")
+      .in("amount-history-DEPRECATED")
       .in(timeIntervalQuery)
       .in(intervalTypeQuery)
       .out(header[String](HeaderNames.ContentDisposition))
       .out(streamTextBody(VertxStreams)(CodecFormat.Json()))
+      .deprecated()
 
   private case class TextCsv() extends CodecFormat {
     override val mediaType: MediaType = MediaType.TextCsv

--- a/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
@@ -167,6 +167,13 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
       .out(streamTextBody(VertxStreams)(CodecFormat.Json()))
       .deprecated()
 
+  val getAddressAmountHistory: BaseEndpoint[(Address, TimeInterval, IntervalType), AmountHistory] =
+    addressesEndpoint.get
+      .in("amount-history")
+      .in(timeIntervalQuery)
+      .in(intervalTypeQuery)
+      .out(jsonBody[AmountHistory])
+
   private case class TextCsv() extends CodecFormat {
     override val mediaType: MediaType = MediaType.TextCsv
   }

--- a/app/src/main/scala/org/alephium/explorer/api/ChartsEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/ChartsEndpoints.scala
@@ -29,7 +29,7 @@ import org.alephium.explorer.api.model.{Hashrate, IntervalType, PerChainTimedCou
 // scalastyle:off magic.number
 trait ChartsEndpoints extends BaseEndpoint with QueryParams {
 
-  val intervalTypes: String = IntervalType.all.map(_.string).mkString(", ")
+  val intervalTypes: String = IntervalType.all.dropRight(1).map(_.string).mkString(", ")
 
   private val chartsEndpoint =
     baseEndpoint

--- a/app/src/main/scala/org/alephium/explorer/api/EndpointExamples.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/EndpointExamples.scala
@@ -387,6 +387,9 @@ object EndpointExamples extends EndpointsExamples {
   implicit val tokenInfosExample: List[Example[ArraySeq[TokenInfo]]] =
     simpleExample(ArraySeq(TokenInfo(token, Some(StdInterfaceId.FungibleToken))))
 
+  implicit val amountHistory: List[Example[AmountHistory]] =
+    simpleExample(AmountHistory(ArraySeq(TimedAmount(ts, U256.One.v))))
+
   implicit val nftMetadataExample: List[Example[NFTMetadata]] =
     simpleExample(NFTMetadata(token, "token://uri", contract, U256.One))
 }

--- a/app/src/main/scala/org/alephium/explorer/api/model/AmountHistory.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/AmountHistory.scala
@@ -1,0 +1,30 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.api.model
+
+import scala.collection.immutable.ArraySeq
+
+import org.alephium.json.Json._
+
+@SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
+final case class AmountHistory(
+    amountHistory: ArraySeq[TimedAmount]
+)
+
+object AmountHistory {
+  implicit val readWriter: ReadWriter[AmountHistory] = macroRW[AmountHistory]
+}

--- a/app/src/main/scala/org/alephium/explorer/api/model/TimedAmount.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/TimedAmount.scala
@@ -1,0 +1,36 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.api.model
+
+import java.math.BigInteger
+
+import org.alephium.api.UtilJson._
+import org.alephium.json.Json._
+import org.alephium.util.TimeStamp
+
+@SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
+final case class TimedAmount(
+    timestamp: TimeStamp,
+    amount: BigInteger
+)
+
+object TimedAmount {
+  implicit val readWriter: ReadWriter[TimedAmount] = readwriter[(TimeStamp, BigInteger)].bimap(
+    timedAmount => (timedAmount.timestamp, timedAmount.amount),
+    { case (time, amount) => TimedAmount(time, amount) }
+  )
+}

--- a/app/src/main/scala/org/alephium/explorer/config/ExplorerConfig.scala
+++ b/app/src/main/scala/org/alephium/explorer/config/ExplorerConfig.scala
@@ -33,6 +33,7 @@ import org.alephium.api.model.ApiKey
 import org.alephium.conf._
 import org.alephium.explorer.error.ExplorerError._
 import org.alephium.protocol.model.NetworkId
+import org.alephium.util
 
 @SuppressWarnings(Array("org.wartremover.warts.TryPartial"))
 object ExplorerConfig {
@@ -143,7 +144,8 @@ object ExplorerConfig {
           explorer.cacheBlockTimesReloadPeriod,
           explorer.cacheLatestBlocksReloadPeriod,
           explorer.exportTxsNumberThreshold,
-          explorer.streamParallelism
+          explorer.streamParallelism,
+          explorer.maxTimeIntervals
         )
       }).get
     }
@@ -160,6 +162,17 @@ object ExplorerConfig {
       apiKey: Option[ApiKey]
   )
 
+  final case class MaxTimeInterval(
+      hourly: util.Duration,
+      daily: util.Duration,
+      weekly: util.Duration
+  )
+
+  final case class MaxTimeIntervals(
+      amountHistory: MaxTimeInterval,
+      charts: MaxTimeInterval
+  )
+
   final private case class Explorer(
       host: String,
       port: Int,
@@ -173,7 +186,8 @@ object ExplorerConfig {
       cacheBlockTimesReloadPeriod: FiniteDuration,
       cacheLatestBlocksReloadPeriod: FiniteDuration,
       exportTxsNumberThreshold: Int,
-      streamParallelism: Int
+      streamParallelism: Int,
+      maxTimeIntervals: MaxTimeIntervals
   )
 
 }
@@ -200,5 +214,6 @@ final case class ExplorerConfig private (
     cacheBlockTimesReloadPeriod: FiniteDuration,
     cacheLatestBlocksReloadPeriod: FiniteDuration,
     exportTxsNumberThreshold: Int,
-    streamParallelism: Int
+    streamParallelism: Int,
+    maxTimeInterval: ExplorerConfig.MaxTimeIntervals
 )

--- a/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
+++ b/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
@@ -56,6 +56,7 @@ trait Documentation
         listAddressTokensBalance,
         areAddressesActive,
         exportTransactionsCsvByAddress,
+        getAddressAmountHistoryDEPRECATED,
         getAddressAmountHistory,
         getInfos,
         getHeights,

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/HashrateQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/HashrateQueries.scala
@@ -47,10 +47,7 @@ object HashrateQueries {
   }
 
   def computeHashratesAndInsert(from: TimeStamp, intervalType: IntervalType): DBActionW[Int] = {
-    val dateGroup = intervalType match {
-      case IntervalType.Hourly => hourlyQuery
-      case IntervalType.Daily  => dailyQuery
-    }
+    val dateGroup = QueryUtil.dateGroupQuery(intervalType)
 
     sqlu"""
         INSERT INTO hashrates (block_timestamp, value, interval_type)
@@ -67,29 +64,10 @@ object HashrateQueries {
       """
   }
 
-  /*
-   * The following 3 queries are averaging the hashrates from the block_header table over different time intervals.
-   * An hashrate at a given time is always part of it's above time interval point.
-   * For example in hourly interval, the hashrate of a block at 08:26 will be included in the value at 09:00
-   * and the value at 09:00:00.001 will be averaged with the value at 10:00.
-   * The idea is to have round time value, to ease the charts reading, rather than averaging at 08:59:59.999
-   * Have a look at `HashrateServiceSpec` for multiple examples
-   */
-
-  private val timestampTZ = "to_timestamp(block_timestamp/1000.0) AT TIME ZONE 'UTC'"
-
-  private val hourlyQuery =
-    s"DATE_TRUNC('HOUR', $timestampTZ) + ((CEILING((EXTRACT(MINUTE FROM $timestampTZ) + EXTRACT(SECOND FROM $timestampTZ)/60) / 60)) * INTERVAL '1 HOUR')"
-
-  private val dailyQuery =
-    s"""DATE_TRUNC('DAY', $timestampTZ) +
-      ((CEILING((EXTRACT(HOUR FROM $timestampTZ)*60 + EXTRACT(MINUTE FROM $timestampTZ) + EXTRACT(SECOND FROM $timestampTZ)/60)/60/24)) * INTERVAL '1 DAY')
-    """
-
   private def computeHourlyHashrateRawString(from: TimeStamp) = {
     computeHashrateRawString(
       from,
-      hourlyQuery,
+      QueryUtil.hourlyQuery,
       IntervalType.Hourly
     )
   }
@@ -103,7 +81,7 @@ object HashrateQueries {
   private def computeDailyHashrateRawString(from: TimeStamp) = {
     computeHashrateRawString(
       from,
-      dailyQuery,
+      QueryUtil.dailyQuery,
       IntervalType.Daily
     )
   }

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/HashrateQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/HashrateQueries.scala
@@ -52,7 +52,7 @@ object HashrateQueries {
     sqlu"""
         INSERT INTO hashrates (block_timestamp, value, interval_type)
         SELECT
-        EXTRACT(EPOCH FROM ((#$dateGroup) AT TIME ZONE 'UTC')) * 1000 as ts,
+        #${QueryUtil.extractEpoch(dateGroup)} as ts,
         AVG(hashrate),
         ${intervalType.value}
         FROM block_headers
@@ -100,7 +100,7 @@ object HashrateQueries {
   ) = {
     sql"""
         SELECT
-        EXTRACT(EPOCH FROM ((#$dateGroup) AT TIME ZONE 'UTC')) * 1000 as ts,
+        #${QueryUtil.extractEpoch(dateGroup)} as ts,
         AVG(hashrate),
         ${intervalType.value}
         FROM block_headers

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/QueryUtil.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/QueryUtil.scala
@@ -37,9 +37,18 @@ object QueryUtil {
       ((CEILING((EXTRACT(HOUR FROM $timestampTZ)*60 + EXTRACT(MINUTE FROM $timestampTZ) + EXTRACT(SECOND FROM $timestampTZ)/60)/60/24)) * INTERVAL '1 DAY')
     """
 
+  val weeklyQuery: String =
+    s"""DATE_TRUNC('WEEK', $timestampTZ) +
+      ((CEILING((EXTRACT(HOUR FROM $timestampTZ)*60 + EXTRACT(MINUTE FROM $timestampTZ) + EXTRACT(SECOND FROM $timestampTZ)/60)/60/24)) * INTERVAL '7 DAY')
+    """
+
+  def extractEpoch(query: String): String =
+    s"(EXTRACT(EPOCH FROM (($query) AT TIME ZONE 'UTC')) * 1000)"
+
   def dateGroupQuery(intervalType: IntervalType): String =
     intervalType match {
       case IntervalType.Hourly => hourlyQuery
       case IntervalType.Daily  => dailyQuery
+      case IntervalType.Weekly => weeklyQuery
     }
 }

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/QueryUtil.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/QueryUtil.scala
@@ -1,0 +1,45 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.persistence.queries
+
+import org.alephium.explorer.api.model.IntervalType
+object QueryUtil {
+  /*
+   * The following 3 queries help averaging data over different time intervals.
+   * The data at a given time is always part of it's above time interval point.
+   * For example in hourly interval, data at 08:26 will be included in the value at 09:00
+   * and the value at 09:00:00.001 will be averaged with the value at 10:00.
+   * The idea is to have round time value, to ease the charts reading, rather than averaging at 08:59:59.999
+   * Have a look at `HashrateServiceSpec` for multiple examples
+   */
+
+  private val timestampTZ: String = "to_timestamp(block_timestamp/1000.0) AT TIME ZONE 'UTC'"
+
+  val hourlyQuery: String =
+    s"DATE_TRUNC('HOUR', $timestampTZ) + ((CEILING((EXTRACT(MINUTE FROM $timestampTZ) + EXTRACT(SECOND FROM $timestampTZ)/60) / 60)) * INTERVAL '1 HOUR')"
+
+  val dailyQuery: String =
+    s"""DATE_TRUNC('DAY', $timestampTZ) +
+      ((CEILING((EXTRACT(HOUR FROM $timestampTZ)*60 + EXTRACT(MINUTE FROM $timestampTZ) + EXTRACT(SECOND FROM $timestampTZ)/60)/60/24)) * INTERVAL '1 DAY')
+    """
+
+  def dateGroupQuery(intervalType: IntervalType): String =
+    intervalType match {
+      case IntervalType.Hourly => hourlyQuery
+      case IntervalType.Daily  => dailyQuery
+    }
+}

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
@@ -360,7 +360,7 @@ object TransactionQueries extends StrictLogging {
     val dateGroup = QueryUtil.dateGroupQuery(intervalType)
     sql"""
       SELECT
-        LEAST($to, GREATEST($from, (EXTRACT(EPOCH FROM ((#$dateGroup) AT TIME ZONE 'UTC')) * 1000) - 1)) as ts,
+        LEAST($to, GREATEST($from, #${QueryUtil.extractEpoch(dateGroup)} - 1)) as ts,
         SUM(amount)
       FROM outputs
       WHERE address = $address
@@ -411,7 +411,7 @@ object TransactionQueries extends StrictLogging {
 
     sql"""
       SELECT
-        LEAST($to, GREATEST($from, (EXTRACT(EPOCH FROM ((#$dateGroup) AT TIME ZONE 'UTC')) * 1000) - 1)) as ts,
+        LEAST($to, GREATEST($from, #${QueryUtil.extractEpoch(dateGroup)} - 1)) as ts,
         SUM(output_ref_amount)
       FROM inputs
       WHERE output_ref_address = $address

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
@@ -346,7 +346,7 @@ object TransactionQueries extends StrictLogging {
     }
   }
 
-  def sumAddressOutputs(address: Address, from: TimeStamp, to: TimeStamp)(implicit
+  def sumAddressOutputsDEPRECATED(address: Address, from: TimeStamp, to: TimeStamp)(implicit
       ec: ExecutionContext
   ): DBActionR[U256] = {
     sql"""
@@ -359,7 +359,7 @@ object TransactionQueries extends StrictLogging {
     """.asAS[Option[U256]].exactlyOne.map(_.getOrElse(U256.Zero))
   }
 
-  def sumAddressInputs(address: Address, from: TimeStamp, to: TimeStamp)(implicit
+  def sumAddressInputsDEPRECATED(address: Address, from: TimeStamp, to: TimeStamp)(implicit
       ec: ExecutionContext
   ): DBActionR[U256] = {
     sql"""

--- a/app/src/main/scala/org/alephium/explorer/service/TransactionHistoryService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/TransactionHistoryService.scala
@@ -46,6 +46,7 @@ case object TransactionHistoryService extends StrictLogging {
 
   val hourlyStepBack: Duration = Duration.ofHoursUnsafe(2)
   val dailyStepBack: Duration  = Duration.ofDaysUnsafe(1)
+  val weeklyStepBack: Duration = Duration.ofDaysUnsafe(7)
 
   def start(interval: FiniteDuration)(implicit
       executionContext: ExecutionContext,
@@ -148,8 +149,9 @@ case object TransactionHistoryService extends StrictLogging {
 
   private def truncate(timestamp: TimeStamp, intervalType: IntervalType): TimeStamp =
     intervalType match {
-      case IntervalType.Daily  => truncatedToDay(timestamp)
       case IntervalType.Hourly => truncatedToHour(timestamp)
+      case IntervalType.Daily  => truncatedToDay(timestamp)
+      case IntervalType.Weekly => truncatedToWeek(timestamp)
     }
 
   @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
@@ -167,8 +169,9 @@ case object TransactionHistoryService extends StrictLogging {
       ArraySeq.empty
     } else {
       val step = (intervalType match {
-        case IntervalType.Daily  => Duration.ofDaysUnsafe(1)
         case IntervalType.Hourly => Duration.ofHoursUnsafe(1)
+        case IntervalType.Daily  => Duration.ofDaysUnsafe(1)
+        case IntervalType.Weekly => Duration.ofDaysUnsafe(7)
       }).-(oneMillis).get
 
       buildTimestampRange(start, end, step)
@@ -181,8 +184,9 @@ case object TransactionHistoryService extends StrictLogging {
    */
   private def stepBack(timestamp: TimeStamp, intervalType: IntervalType): TimeStamp =
     intervalType match {
-      case IntervalType.Daily  => timestamp.minusUnsafe(dailyStepBack)
       case IntervalType.Hourly => timestamp.minusUnsafe(hourlyStepBack)
+      case IntervalType.Daily  => timestamp.minusUnsafe(dailyStepBack)
+      case IntervalType.Weekly => timestamp.minusUnsafe(weeklyStepBack)
     }
 
   // TODO Replace by accessing a `Latest Transaction cache`

--- a/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
@@ -104,7 +104,7 @@ trait TransactionService {
       paralellism: Int
   )(implicit ec: ExecutionContext, dc: DatabaseConfig[PostgresProfile]): Flowable[Buffer]
 
-  def getAmountHistory(
+  def getAmountHistoryDEPRECATED(
       address: Address,
       from: TimeStamp,
       to: TimeStamp,
@@ -201,20 +201,22 @@ object TransactionService extends TransactionService {
 
   }
 
-  private def getInOutAmount(address: Address, from: TimeStamp, to: TimeStamp)(implicit
+  private def getInOutAmountDEPRECATED(address: Address, from: TimeStamp, to: TimeStamp)(implicit
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]
   ): Future[(U256, U256, TimeStamp)] = {
     run(
       for {
-        in  <- sumAddressInputs(address, from, to)
-        out <- sumAddressOutputs(address, from, to)
-      } yield (in, out, to)
+        in  <- sumAddressInputsDEPRECATED(address, from, to)
+        out <- sumAddressOutputsDEPRECATED(address, from, to)
+      } yield {
+        (in, out, to)
+      }
     )
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
-  def getAmountHistory(
+  def getAmountHistoryDEPRECATED(
       address: Address,
       from: TimeStamp,
       to: TimeStamp,
@@ -226,7 +228,7 @@ object TransactionService extends TransactionService {
       .fromIterable(timeranges.asJava)
       .concatMapEager(
         { case (from: TimeStamp, to: TimeStamp) =>
-          Flowable.fromCompletionStage(getInOutAmount(address, from, to).asJava)
+          Flowable.fromCompletionStage(getInOutAmountDEPRECATED(address, from, to).asJava)
         },
         paralellism,
         1

--- a/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
@@ -111,6 +111,16 @@ trait TransactionService {
       intervalType: IntervalType,
       paralellism: Int
   )(implicit ec: ExecutionContext, dc: DatabaseConfig[PostgresProfile]): Flowable[Buffer]
+
+  def getAmountHistory(
+      address: Address,
+      from: TimeStamp,
+      to: TimeStamp,
+      intervalType: IntervalType
+  )(implicit
+      ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile]
+  ): Future[ArraySeq[(TimeStamp, BigInteger)]]
 }
 
 object TransactionService extends TransactionService {
@@ -251,6 +261,52 @@ object TransactionService extends TransactionService {
 
     amountHistoryToJsonFlowable(
       amountHistory
+    )
+  }
+
+  def getAmountHistory(
+      address: Address,
+      from: TimeStamp,
+      to: TimeStamp,
+      intervalType: IntervalType
+  )(implicit
+      ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile]
+  ): Future[ArraySeq[(TimeStamp, BigInteger)]] = {
+    run(
+      for {
+        inputs  <- sumAddressInputs(address, from, to, intervalType)
+        outputs <- sumAddressOutputs(address, from, to, intervalType)
+      } yield {
+        val ins  = inputs.collect { case (ts, Some(u256)) => (ts, u256) }.toMap
+        val outs = outputs.collect { case (ts, Some(u256)) => (ts, u256) }.toMap
+
+        val timestamps = scala.collection.SortedSet.from(ins.keys ++ outs.keys)
+
+        val (_, result) = timestamps
+          .foldLeft((BigInteger.ZERO, ArraySeq.empty[(TimeStamp, BigInteger)])) { case (acc, ts) =>
+            val (sum, res) = acc
+
+            (ins.get(ts), outs.get(ts)) match {
+              case (Some(in), Some(out)) =>
+                val diff   = out.v.subtract(in.v)
+                val newSum = sum.add(diff)
+                (newSum, res :+ (ts, newSum))
+              case (Some(in), None) =>
+                // No Output, all inputs are spent
+                val newSum = sum.subtract(in.v)
+                (newSum, res :+ (ts, newSum))
+              case (None, Some(out)) =>
+                // No Input, all outputs are for the address
+                val newSum = sum.add(out.v)
+                (newSum, res :+ (ts, newSum))
+              case (None, None) =>
+                (sum, res)
+            }
+          }
+
+        result
+      }
     )
   }
 

--- a/app/src/main/scala/org/alephium/explorer/util/TimeUtil.scala
+++ b/app/src/main/scala/org/alephium/explorer/util/TimeUtil.scala
@@ -41,6 +41,9 @@ object TimeUtil {
   def truncatedToHour(timestamp: TimeStamp): TimeStamp =
     mapInstant(timestamp)(_.truncatedTo(ChronoUnit.HOURS))
 
+  def truncatedToWeek(timestamp: TimeStamp): TimeStamp =
+    mapInstant(timestamp)(_.truncatedTo(ChronoUnit.WEEKS))
+
   private def mapInstant(timestamp: TimeStamp)(f: Instant => Instant): TimeStamp = {
     val instant = toInstant(timestamp)
     TimeStamp

--- a/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
@@ -32,15 +32,16 @@ import org.alephium.api.model.TimeInterval
 import org.alephium.explorer.GroupSetting
 import org.alephium.explorer.api.AddressesEndpoints
 import org.alephium.explorer.api.model._
+import org.alephium.explorer.config.ExplorerConfig
 import org.alephium.explorer.service.{TokenService, TransactionService}
 import org.alephium.protocol.model.Address
-import org.alephium.util.Duration
 
 class AddressServer(
     transactionService: TransactionService,
     tokenService: TokenService,
     exportTxsNumberThreshold: Int,
-    streamParallelism: Int
+    streamParallelism: Int,
+    maxTimeInterval: ExplorerConfig.MaxTimeInterval
 )(implicit
     val executionContext: ExecutionContext,
     groupSetting: GroupSetting,
@@ -49,12 +50,6 @@ class AddressServer(
     with AddressesEndpoints {
 
   val groupNum = groupSetting.groupNum
-
-  // scalastyle:off magic.number
-  private val maxHourlyTimeSpan = Duration.ofDaysUnsafe(7)
-  private val maxDailyTimeSpan  = Duration.ofDaysUnsafe(365)
-  private val maxWeeklyTimeSpan = Duration.ofDaysUnsafe(365)
-  // scalastyle:on magic.number
 
   val routes: ArraySeq[Router => Route] =
     ArraySeq(
@@ -195,9 +190,9 @@ class AddressServer(
     IntervalType.validateTimeInterval(
       timeInterval,
       intervalType,
-      maxHourlyTimeSpan,
-      maxDailyTimeSpan,
-      maxWeeklyTimeSpan
+      maxTimeInterval.hourly,
+      maxTimeInterval.daily,
+      maxTimeInterval.weekly
     )(contd)
 }
 

--- a/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
@@ -142,6 +142,23 @@ class AddressServer(
               )
             )
           }
+      }),
+      route(getAddressAmountHistory.serverLogic[Future] {
+        case (address, timeInterval, intervalType) =>
+          validateTimeInterval(timeInterval, intervalType) {
+            transactionService
+              .getAmountHistory(
+                address,
+                timeInterval.from,
+                timeInterval.to,
+                intervalType
+              )
+              .map { values =>
+                AmountHistory(values.map { case (ts, value) =>
+                  TimedAmount(ts, value)
+                })
+              }
+          }
       })
     )
 

--- a/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
@@ -124,11 +124,11 @@ class AddressServer(
           (AddressServer.exportFileNameHeader(address, timeInterval), stream)
         })
       }),
-      route(getAddressAmountHistory.serverLogic[Future] {
+      route(getAddressAmountHistoryDEPRECATED.serverLogic[Future] {
         case (address, timeInterval, intervalType) =>
           validateTimeInterval(timeInterval, intervalType) {
             val flowable =
-              transactionService.getAmountHistory(
+              transactionService.getAmountHistoryDEPRECATED(
                 address,
                 timeInterval.from,
                 timeInterval.to,

--- a/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
@@ -53,6 +53,7 @@ class AddressServer(
   // scalastyle:off magic.number
   private val maxHourlyTimeSpan = Duration.ofDaysUnsafe(7)
   private val maxDailyTimeSpan  = Duration.ofDaysUnsafe(365)
+  private val maxWeeklyTimeSpan = Duration.ofDaysUnsafe(365)
   // scalastyle:on magic.number
 
   val routes: ArraySeq[Router => Route] =
@@ -195,7 +196,8 @@ class AddressServer(
       timeInterval,
       intervalType,
       maxHourlyTimeSpan,
-      maxDailyTimeSpan
+      maxDailyTimeSpan,
+      maxWeeklyTimeSpan
     )(contd)
 }
 

--- a/app/src/main/scala/org/alephium/explorer/web/ChartsServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/ChartsServer.scala
@@ -28,20 +28,16 @@ import org.alephium.api.ApiError
 import org.alephium.api.model.TimeInterval
 import org.alephium.explorer.api.ChartsEndpoints
 import org.alephium.explorer.api.model.{IntervalType, TimedCount}
+import org.alephium.explorer.config.ExplorerConfig
 import org.alephium.explorer.service.{HashrateService, TransactionHistoryService}
-import org.alephium.util.Duration
 
-class ChartsServer()(implicit
+class ChartsServer(
+    maxTimeInterval: ExplorerConfig.MaxTimeInterval
+)(implicit
     val executionContext: ExecutionContext,
     dc: DatabaseConfig[PostgresProfile]
 ) extends Server
     with ChartsEndpoints {
-
-  // scalastyle:off magic.number
-  private val maxHourlyTimeSpan = Duration.ofDaysUnsafe(30)
-  private val maxDailyTimeSpan  = Duration.ofDaysUnsafe(365)
-  private val maxWeeklyTimeSpan = Duration.ofDaysUnsafe(365)
-  // scalastyle:on magic.number
 
   val routes: ArraySeq[Router => Route] =
     ArraySeq(
@@ -75,8 +71,8 @@ class ChartsServer()(implicit
     IntervalType.validateTimeInterval(
       timeInterval,
       intervalType,
-      maxHourlyTimeSpan,
-      maxDailyTimeSpan,
-      maxWeeklyTimeSpan
+      maxTimeInterval.hourly,
+      maxTimeInterval.daily,
+      maxTimeInterval.weekly
     )(contd)
 }

--- a/app/src/main/scala/org/alephium/explorer/web/ChartsServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/ChartsServer.scala
@@ -40,6 +40,7 @@ class ChartsServer()(implicit
   // scalastyle:off magic.number
   private val maxHourlyTimeSpan = Duration.ofDaysUnsafe(30)
   private val maxDailyTimeSpan  = Duration.ofDaysUnsafe(365)
+  private val maxWeeklyTimeSpan = Duration.ofDaysUnsafe(365)
   // scalastyle:on magic.number
 
   val routes: ArraySeq[Router => Route] =
@@ -75,6 +76,7 @@ class ChartsServer()(implicit
       timeInterval,
       intervalType,
       maxHourlyTimeSpan,
-      maxDailyTimeSpan
+      maxDailyTimeSpan,
+      maxWeeklyTimeSpan
     )(contd)
 }

--- a/app/src/test/scala/org/alephium/explorer/ConfigDefaults.scala
+++ b/app/src/test/scala/org/alephium/explorer/ConfigDefaults.scala
@@ -16,6 +16,23 @@
 
 package org.alephium.explorer
 
+import org.alephium.explorer.config.ExplorerConfig._
+import org.alephium.util.Duration
+
 object ConfigDefaults {
   implicit val groupSetting: GroupSetting = Generators.groupSettingGen.sample.get
+
+  val maxTimeIntervals: MaxTimeIntervals =
+    MaxTimeIntervals(
+      amountHistory = MaxTimeInterval(
+        hourly = Duration.ofDaysUnsafe(7),
+        daily = Duration.ofDaysUnsafe(365),
+        weekly = Duration.ofDaysUnsafe(365)
+      ),
+      charts = MaxTimeInterval(
+        hourly = Duration.ofDaysUnsafe(30),
+        daily = Duration.ofDaysUnsafe(365),
+        weekly = Duration.ofDaysUnsafe(365)
+      )
+    )
 }

--- a/app/src/test/scala/org/alephium/explorer/api/model/IntervalTypeSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/api/model/IntervalTypeSpec.scala
@@ -36,7 +36,7 @@ class IntervalTypeSpec() extends AlephiumFutureSpec {
         val timeInterval = TimeInterval(now, to)
 
         IntervalType
-          .validateTimeInterval(timeInterval, intervalType, duration, duration)(
+          .validateTimeInterval(timeInterval, intervalType, duration, duration, duration)(
             Future.successful(())
           )
           .futureValue is Right(())
@@ -44,7 +44,13 @@ class IntervalTypeSpec() extends AlephiumFutureSpec {
         val shorterDuration = (duration - (Duration.ofMillisUnsafe(1))).get
 
         IntervalType
-          .validateTimeInterval(timeInterval, intervalType, shorterDuration, shorterDuration)(
+          .validateTimeInterval(
+            timeInterval,
+            intervalType,
+            shorterDuration,
+            shorterDuration,
+            shorterDuration
+          )(
             Future.successful(())
           )
           .futureValue is Left(

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/QueryUtilSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/QueryUtilSpec.scala
@@ -1,0 +1,74 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.persistence.queries
+
+import slick.jdbc.PostgresProfile.api._
+
+import org.alephium.explorer.AlephiumFutureSpec
+import org.alephium.explorer.persistence.{DatabaseFixtureForEach, DBRunner}
+import org.alephium.explorer.persistence.queries.QueryUtil._
+import org.alephium.explorer.persistence.schema.CustomGetResult._
+import org.alephium.explorer.persistence.schema.TimeStampTableFixture._
+import org.alephium.util._
+
+class QueryUtilSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with DBRunner {
+
+  "date group" in {
+    run(sqlu"DROP TABLE IF EXISTS timestamps").futureValue
+    run(timestampTable.schema.create).futureValue
+
+    val t1 = "2020-12-31T23:59:59.999Z"
+    val t2 = "2021-01-01T01:01:01.000Z"
+    val t3 = "2021-01-01T02:00:00.000Z"
+    val t4 = "2021-01-01T03:01:00.000Z"
+    val t5 = "2021-01-01T03:14:00.000Z"
+    val t6 = "2021-01-02T03:14:00.000Z"
+    val t7 = "2021-02-24T03:14:00.000Z"
+    val t8 = "2021-02-26T03:14:00.000Z"
+
+    val timestamps = Seq(t1, t2, t3, t4, t5, t6, t7, t8).map(ts)
+
+    run(timestampTable ++= timestamps).futureValue
+
+    val hourly = run(sql"""SELECT #${extractEpoch(
+        hourlyQuery
+      )} as ts FROM timestamps GROUP BY ts ORDER BY ts""".as[TimeStamp]).futureValue
+    val daily = run(sql"""SELECT #${extractEpoch(
+        dailyQuery
+      )} as ts FROM timestamps GROUP BY ts ORDER BY ts""".as[TimeStamp]).futureValue
+    val weekly = run(sql"""SELECT #${extractEpoch(
+        weeklyQuery
+      )} as ts FROM timestamps GROUP BY ts ORDER BY ts""".as[TimeStamp]).futureValue
+
+    hourly is Vector(
+      "2021-01-01T00:00:00.000Z",
+      "2021-01-01T02:00:00.000Z",
+      "2021-01-01T04:00:00.000Z",
+      "2021-01-02T04:00:00.000Z",
+      "2021-02-24T04:00:00.000Z",
+      "2021-02-26T04:00:00.000Z"
+    ).map(ts)
+    daily is Vector(
+      "2021-01-01T00:00:00.000Z",
+      "2021-01-02T00:00:00.000Z",
+      "2021-01-03T00:00:00.000Z",
+      "2021-02-25T00:00:00.000Z",
+      "2021-02-27T00:00:00.000Z"
+    ).map(ts)
+    weekly is Vector("2021-01-04T00:00:00.000Z", "2021-03-01T00:00:00.000Z").map(ts)
+  }
+}

--- a/app/src/test/scala/org/alephium/explorer/persistence/schema/TimeStampTableFixture.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/schema/TimeStampTableFixture.scala
@@ -1,0 +1,37 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.persistence.schema
+
+import slick.jdbc.PostgresProfile.api._
+import slick.lifted.ProvenShape
+
+import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
+import org.alephium.util._
+
+object TimeStampTableFixture {
+
+  def ts(str: String): TimeStamp = {
+    TimeStamp.unsafe(java.time.Instant.parse(str).toEpochMilli)
+  }
+
+  class TimeStamps(tag: Tag) extends Table[TimeStamp](tag, "timestamps") {
+    def timestamp: Rep[TimeStamp]  = column[TimeStamp]("block_timestamp")
+    def * : ProvenShape[TimeStamp] = timestamp
+  }
+
+  val timestampTable: TableQuery[TimeStamps] = TableQuery[TimeStamps]
+}

--- a/app/src/test/scala/org/alephium/explorer/service/EmptyTransactionService.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/EmptyTransactionService.scala
@@ -16,6 +16,8 @@
 
 package org.alephium.explorer.service
 
+import java.math.BigInteger
+
 import scala.collection.immutable.ArraySeq
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -113,4 +115,14 @@ trait EmptyTransactionService extends TransactionService {
       paralellism: Int
   )(implicit ec: ExecutionContext, dc: DatabaseConfig[PostgresProfile]): Flowable[Buffer] =
     ???
+
+  def getAmountHistory(
+      address: Address,
+      from: TimeStamp,
+      to: TimeStamp,
+      intervalType: IntervalType
+  )(implicit
+      ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile]
+  ): Future[ArraySeq[(TimeStamp, BigInteger)]] = ???
 }

--- a/app/src/test/scala/org/alephium/explorer/service/EmptyTransactionService.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/EmptyTransactionService.scala
@@ -105,7 +105,7 @@ trait EmptyTransactionService extends TransactionService {
       paralellism: Int
   )(implicit ec: ExecutionContext, dc: DatabaseConfig[PostgresProfile]): Flowable[Buffer] = ???
 
-  def getAmountHistory(
+  def getAmountHistoryDEPRECATED(
       address: Address,
       from: TimeStamp,
       to: TimeStamp,

--- a/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
@@ -477,7 +477,7 @@ class TransactionServiceSpec extends AlephiumActorSpecLike with DatabaseFixtureF
   "get amount history" in new TxsByAddressFixture {
     Seq[IntervalType](IntervalType.Hourly, IntervalType.Daily).foreach { intervalType =>
       val flowable = TransactionService
-        .getAmountHistory(address, fromTs, toTs, intervalType, 8)
+        .getAmountHistoryDEPRECATED(address, fromTs, toTs, intervalType, 8)
 
       val result: Seq[Buffer] =
         flowable.toList().blockingGet().asScala

--- a/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
@@ -479,11 +479,16 @@ class TransactionServiceSpec extends AlephiumActorSpecLike with DatabaseFixtureF
       val flowable = TransactionService
         .getAmountHistoryDEPRECATED(address, fromTs, toTs, intervalType, 8)
 
-      val result: Seq[Buffer] =
-        flowable.toList().blockingGet().asScala
+      val result: Seq[Buffer] = flowable.toList().blockingGet().asScala
+      val amountHistory       = read[ujson.Value](result.mkString)
+      val historyDepracted    = read[Seq[(Long, BigInteger)]](amountHistory("amountHistory"))
 
-      val amountHistory = read[ujson.Value](result.mkString)
-      val history       = read[Seq[(Long, BigInteger)]](amountHistory("amountHistory"))
+      val history = TransactionService
+        .getAmountHistory(address, fromTs, toTs, intervalType)
+        .futureValue
+        .map { case (ts, sum) => (ts.millis, sum) }
+
+      history is historyDepracted
 
       val times = history.map(_._1)
 
@@ -491,6 +496,7 @@ class TransactionServiceSpec extends AlephiumActorSpecLike with DatabaseFixtureF
       times is times.sorted
 
       // TODO Test history amount value
+      history.nonEmpty is true
     }
   }
 

--- a/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
@@ -280,6 +280,7 @@ class AddressServerSpec()
     def maxTimeSpan(intervalType: IntervalType) = intervalType match {
       case IntervalType.Hourly => Duration.ofDaysUnsafe(7)
       case IntervalType.Daily  => Duration.ofDaysUnsafe(365)
+      case IntervalType.Weekly => Duration.ofDaysUnsafe(365)
     }
     def getToTs(intervalType: IntervalType) =
       fromTs + maxTimeSpan(intervalType).millis

--- a/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
@@ -148,7 +148,8 @@ class AddressServerSpec()
       transactionService,
       tokenService,
       exportTxsNumberThreshold = 1000,
-      streamParallelism = 8
+      streamParallelism = 8,
+      maxTimeInterval = ConfigDefaults.maxTimeIntervals.amountHistory
     )
 
   val routes = server.routes

--- a/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
@@ -110,7 +110,7 @@ class AddressServerSpec()
       )
     }
 
-    override def getAmountHistory(
+    override def getAmountHistoryDEPRECATED(
         address: Address,
         from: TimeStamp,
         to: TimeStamp,
@@ -271,12 +271,12 @@ class AddressServerSpec()
     def getToTs(intervalType: IntervalType) =
       fromTs + maxTimeSpan(intervalType).millis
 
-    "return the amount history as json " in {
+    "return the deprecated amount history as json" in {
       intervalTypes.foreach { intervalType =>
         val toTs = getToTs(intervalType)
 
         Get(
-          s"/addresses/${address}/amount-history?fromTs=$fromTs&toTs=$toTs&interval-type=$intervalType"
+          s"/addresses/${address}/amount-history-DEPRECATED?fromTs=$fromTs&toTs=$toTs&interval-type=$intervalType"
         ) check { response =>
           response.body is Right(
             s"""{"amountHistory":${amountHistory

--- a/app/src/test/scala/org/alephium/explorer/web/ChartsServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/ChartsServerSpec.scala
@@ -29,7 +29,9 @@ class ChartsServerSpec()
     with DatabaseFixtureForAll
     with HttpServerFixture {
 
-  val chartServer     = new ChartsServer()
+  val chartServer = new ChartsServer(
+    maxTimeInterval = ConfigDefaults.maxTimeIntervals.charts
+  )
   override val routes = chartServer.routes
 
   "validate hourly/daily time range " in {


### PR DESCRIPTION
Here is the optimization for the `/addresses/<address>/amount-history` endpoint.
On the previous version, for every time interval we were executing the query to get the sum of outputs/inputs for that given time interval. So for a full year we were executing 365 query, pretty bad, plus the FE is calling this every time a wallet is opened.

With this new version we use the same approach as the `HashrateQueries` where we group the time interval inside the query itself, so it's only 1 query.

here is the result of the benchmark:
![image](https://github.com/alephium/explorer-backend/assets/2979182/653a0aa1-54ce-4e47-bdea-d2eba4206b94)

We discussed with the FE and they will also now cache the results on their side and only re-query the missing time intervals.

Below I show the cur time difference between the deprecated and the new endpoint, we are calling [this address](https://explorer.alephium.org/addresses/1HgGznFFoMRtA8Roak1fVBietj991Kd3pQComE7oJQRzn), which is kind of a "regular" address, with some activities every day:
I called multiple time the endpoints to have the difference between a cold and hot database.

![image](https://github.com/alephium/explorer-backend/assets/2979182/77cbb2ee-5170-4162-ab1d-dcd7551239c5)

I recommend reviewing per commit, as there lots of renaming and moving some functions else where.
