### PR TITLE
Std interface schema

### DIFF
--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -3508,10 +3508,20 @@
           {
             "name": "interface-id",
             "in": "query",
+            "description": "fungible, non-fungible, non-standard or any interface id in hex-string format, e.g: 0001",
             "required": false,
             "schema": {
-              "type": "string",
-              "description": "fungible, non-fungible, non-standard or any interface id in hex-string format, e.g: 0001"
+              "format": "string",
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/TokenStdInterfaceId"
+                },
+                {
+                  "type": "string",
+                  "description": "Raw interface id, e.g. 0001",
+                  "format": "hex-string"
+                }
+              ]
             }
           }
         ],
@@ -7152,10 +7162,26 @@
             "format": "32-byte-hash"
           },
           "stdInterfaceId": {
-            "type": "string",
-            "description": "fungible, non-fungible, non-standard or any interface id in hex-string format, e.g: 0001"
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/TokenStdInterfaceId"
+              },
+              {
+                "type": "string",
+                "description": "Raw interface id, e.g. 0001",
+                "format": "hex-string"
+              }
+            ]
           }
         }
+      },
+      "TokenStdInterfaceId": {
+        "type": "string",
+        "enum": [
+          "fungible",
+          "non-fungible",
+          "non-standard"
+        ]
       },
       "TokenSupply": {
         "required": [
@@ -7414,14 +7440,6 @@
         "type": "integer",
         "enum": [
           80
-        ]
-      },
-      "TokenStdInterfaceId": {
-        "type": "string",
-        "enum": [
-          "fungible",
-          "non-fungible",
-          "non-standard"
         ]
       }
     }

--- a/app/src/main/scala/org/alephium/explorer/api/BaseEndpoint.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/BaseEndpoint.scala
@@ -30,7 +30,7 @@ trait BaseEndpoint extends ErrorExamples with TapirCodecs with TapirSchemasLike 
   import ApiError._
 
   implicit val customConfiguration: Configuration =
-    Configuration.default.withDiscriminator("type")
+    Schemas.configuration
 
   type BaseEndpoint[I, O] = Endpoint[Unit, I, ApiError[_ <: StatusCode], O, VertxStreams]
 

--- a/app/src/main/scala/org/alephium/explorer/api/Codecs.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/Codecs.scala
@@ -22,7 +22,7 @@ import sttp.tapir.{Codec, CodecFormat, DecodeResult}
 import sttp.tapir.Codec.PlainCodec
 
 import org.alephium.api.TapirCodecs
-import org.alephium.explorer.api.model.{IntervalType, StdInterfaceId}
+import org.alephium.explorer.api.model._
 import org.alephium.json.Json._
 import org.alephium.protocol.model.Address
 
@@ -43,8 +43,11 @@ object Codecs extends TapirCodecs {
       _.string
     )
 
-  implicit val tokenStdInterfaceIdCodec: Codec[String, StdInterfaceId, CodecFormat.TextPlain] =
-    fromJson[StdInterfaceId]
+  implicit val tokenStdInterfaceIdCodec: Codec[String, TokenStdInterfaceId, CodecFormat.TextPlain] =
+    fromJson[TokenStdInterfaceId](
+      StdInterfaceId.tokenReadWriter,
+      StdInterfaceId.tokenWithHexStringSchema
+    )
 
   def explorerFromJson[A: ReadWriter]: PlainCodec[A] =
     Codec.string.mapDecode[A] { raw =>

--- a/app/src/main/scala/org/alephium/explorer/api/EndpointExamples.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/EndpointExamples.scala
@@ -369,7 +369,7 @@ object EndpointExamples extends EndpointsExamples {
   implicit val logbackValueExample: List[Example[ArraySeq[LogbackValue]]] =
     simpleExample(ArraySeq(logbackValue))
 
-  implicit val stdInterfaceIdExample: List[Example[StdInterfaceId]] =
+  implicit val stdInterfaceIdExample: List[Example[TokenStdInterfaceId]] =
     simpleExample(StdInterfaceId.FungibleToken)
 
   implicit val fungibleTokenMetadataExample: List[Example[FungibleTokenMetadata]] =

--- a/app/src/main/scala/org/alephium/explorer/api/QueryParams.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/QueryParams.scala
@@ -23,7 +23,7 @@ import org.alephium.api.TapirCodecs
 import org.alephium.api.model.TimeInterval
 import org.alephium.explorer.api.Codecs._
 import org.alephium.explorer.api.Schemas._
-import org.alephium.explorer.api.model.{IntervalType, Pagination, StdInterfaceId}
+import org.alephium.explorer.api.model._
 import org.alephium.protocol.model.TokenId
 import org.alephium.util.{Duration, TimeStamp}
 
@@ -100,6 +100,10 @@ trait QueryParams extends TapirCodecs {
   val intervalTypeQuery: EndpointInput[IntervalType] =
     query[IntervalType]("interval-type")
 
-  val tokenInterfaceIdQuery: EndpointInput[Option[StdInterfaceId]] =
-    query[Option[StdInterfaceId]]("interface-id")
+  val tokenInterfaceIdQuery: EndpointInput[Option[TokenStdInterfaceId]] =
+    query[Option[TokenStdInterfaceId]]("interface-id")
+      .description(
+        s"${StdInterfaceId.tokenStdInterfaceIds.map(_.value).mkString(", ")} or any interface id in hex-string format, e.g: 0001"
+      )
+      .schema(StdInterfaceId.tokenWithHexStringSchema.format("string").asOption)
 }

--- a/app/src/main/scala/org/alephium/explorer/api/Schemas.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/Schemas.scala
@@ -17,10 +17,14 @@
 package org.alephium.explorer.api
 
 import sttp.tapir.Schema
+import sttp.tapir.generic.Configuration
 
 import org.alephium.api.TapirSchemas
-import org.alephium.protocol.model.TokenId
+import org.alephium.protocol.model._
 
 object Schemas {
-  implicit val tokenIdSchema: Schema[TokenId] = TapirSchemas.hashSchema.as[TokenId]
+  implicit val configuration: Configuration = Configuration.default.withDiscriminator("type")
+
+  implicit val contractIdSchema: Schema[ContractId] = TapirSchemas.hashSchema.as[ContractId]
+  implicit val tokenIdSchema: Schema[TokenId]       = TapirSchemas.hashSchema.as[TokenId]
 }

--- a/app/src/main/scala/org/alephium/explorer/api/TokensEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/TokensEndpoints.scala
@@ -19,10 +19,10 @@ package org.alephium.explorer.api
 import scala.collection.immutable.ArraySeq
 
 import sttp.tapir._
-import sttp.tapir.generic.auto._
 
 import org.alephium.api.Endpoints.jsonBody
 import org.alephium.explorer.api.EndpointExamples._
+import org.alephium.explorer.api.Schemas.tokenIdSchema
 import org.alephium.explorer.api.model._
 import org.alephium.protocol.model.{Address, TokenId}
 
@@ -36,7 +36,7 @@ trait TokensEndpoints extends BaseEndpoint with QueryParams {
       .tag("Tokens")
       .in("tokens")
 
-  val listTokens: BaseEndpoint[(Pagination, Option[StdInterfaceId]), ArraySeq[TokenInfo]] =
+  val listTokens: BaseEndpoint[(Pagination, Option[TokenStdInterfaceId]), ArraySeq[TokenInfo]] =
     tokensEndpoint.get
       .in(pagination)
       .in(tokenInterfaceIdQuery)

--- a/app/src/main/scala/org/alephium/explorer/api/model/FungibleTokenMetadata.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/FungibleTokenMetadata.scala
@@ -16,7 +16,11 @@
 
 package org.alephium.explorer.api.model
 
+import sttp.tapir.Schema
+
+import org.alephium.api.TapirSchemas._
 import org.alephium.explorer.api.Json._
+import org.alephium.explorer.api.Schemas._
 import org.alephium.json.Json._
 import org.alephium.protocol.model.TokenId
 import org.alephium.util.U256
@@ -30,4 +34,5 @@ final case class FungibleTokenMetadata(
 
 object FungibleTokenMetadata {
   implicit val readWriter: ReadWriter[FungibleTokenMetadata] = macroRW
+  implicit val schema: Schema[FungibleTokenMetadata]         = Schema.derived[FungibleTokenMetadata]
 }

--- a/app/src/main/scala/org/alephium/explorer/api/model/Input.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/Input.scala
@@ -19,7 +19,9 @@ package org.alephium.explorer.api.model
 import scala.collection.immutable.ArraySeq
 
 import akka.util.ByteString
+import sttp.tapir.Schema
 
+import org.alephium.api.TapirSchemas._
 import org.alephium.api.UtilJson._
 import org.alephium.explorer.api.Json._
 import org.alephium.json.Json._
@@ -38,5 +40,5 @@ final case class Input(
 
 object Input {
   implicit val readWriter: ReadWriter[Input] = macroRW
-
+  implicit val schema: Schema[Input]         = Schema.derived[Input]
 }

--- a/app/src/main/scala/org/alephium/explorer/api/model/NFTCollectionMetadata.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/NFTCollectionMetadata.scala
@@ -16,6 +16,9 @@
 
 package org.alephium.explorer.api.model
 
+import sttp.tapir.Schema
+
+import org.alephium.api.TapirSchemas._
 import org.alephium.explorer.api.Json._
 import org.alephium.json.Json._
 import org.alephium.protocol.model.Address
@@ -27,4 +30,5 @@ final case class NFTCollectionMetadata(
 
 object NFTCollectionMetadata {
   implicit val readWriter: ReadWriter[NFTCollectionMetadata] = macroRW
+  implicit val schema: Schema[NFTCollectionMetadata]         = Schema.derived[NFTCollectionMetadata]
 }

--- a/app/src/main/scala/org/alephium/explorer/api/model/NFTMetadata.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/NFTMetadata.scala
@@ -16,7 +16,11 @@
 
 package org.alephium.explorer.api.model
 
+import sttp.tapir.Schema
+
+import org.alephium.api.TapirSchemas._
 import org.alephium.explorer.api.Json._
+import org.alephium.explorer.api.Schemas._
 import org.alephium.json.Json._
 import org.alephium.protocol.model.{ContractId, TokenId}
 import org.alephium.util.U256
@@ -30,4 +34,5 @@ final case class NFTMetadata(
 
 object NFTMetadata {
   implicit val readWriter: ReadWriter[NFTMetadata] = macroRW
+  implicit val schema: Schema[NFTMetadata]         = Schema.derived[NFTMetadata]
 }

--- a/app/src/main/scala/org/alephium/explorer/api/model/Output.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/Output.scala
@@ -19,9 +19,12 @@ package org.alephium.explorer.api.model
 import scala.collection.immutable.ArraySeq
 
 import akka.util.ByteString
+import sttp.tapir.Schema
 
+import org.alephium.api.TapirSchemas._
 import org.alephium.api.UtilJson._
 import org.alephium.explorer.api.Json._
+import org.alephium.explorer.api.Schemas.configuration
 import org.alephium.json.Json._
 import org.alephium.protocol.Hash
 import org.alephium.protocol.model.{Address, TransactionId}
@@ -61,9 +64,13 @@ final case class ContractOutput(
 ) extends Output
 
 object Output {
+
   implicit val assetReadWriter: ReadWriter[AssetOutput]       = macroRW
   implicit val contractReadWriter: ReadWriter[ContractOutput] = macroRW
 
   implicit val outputReadWriter: ReadWriter[Output] =
     ReadWriter.merge(assetReadWriter, contractReadWriter)
+  implicit val contractSchema: Schema[ContractOutput] = Schema.derived[ContractOutput]
+  implicit val AssetSchema: Schema[AssetOutput]       = Schema.derived[AssetOutput]
+  implicit val schema: Schema[Output]                 = Schema.derived[Output]
 }

--- a/app/src/main/scala/org/alephium/explorer/api/model/OutputRef.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/OutputRef.scala
@@ -16,6 +16,9 @@
 
 package org.alephium.explorer.api.model
 
+import sttp.tapir.Schema
+
+import org.alephium.api.TapirSchemas._
 import org.alephium.explorer.api.Json._
 import org.alephium.json.Json._
 import org.alephium.protocol.Hash
@@ -24,4 +27,5 @@ final case class OutputRef(hint: Int, key: Hash)
 
 object OutputRef {
   implicit val readWriter: ReadWriter[OutputRef] = macroRW
+  implicit val schema: Schema[OutputRef]         = Schema.derived[OutputRef]
 }

--- a/app/src/main/scala/org/alephium/explorer/api/model/Token.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/Token.scala
@@ -16,7 +16,11 @@
 
 package org.alephium.explorer.api.model
 
+import sttp.tapir.Schema
+
+import org.alephium.api.TapirSchemas._
 import org.alephium.explorer.api.Json._
+import org.alephium.explorer.api.Schemas._
 import org.alephium.json.Json._
 import org.alephium.protocol.model.TokenId
 import org.alephium.serde._
@@ -31,4 +35,5 @@ object Token {
       Token.apply,
       t => (t.id, t.amount)
     )
+  implicit val schema: Schema[Token] = Schema.derived[Token]
 }

--- a/app/src/main/scala/org/alephium/explorer/api/model/TokenInfo.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/TokenInfo.scala
@@ -16,12 +16,29 @@
 
 package org.alephium.explorer.api.model
 
+import sttp.tapir._
+
 import org.alephium.explorer.api.Json._
+import org.alephium.explorer.api.Schemas.tokenIdSchema
 import org.alephium.json.Json._
 import org.alephium.protocol.model.TokenId
 
-final case class TokenInfo(token: TokenId, stdInterfaceId: Option[StdInterfaceId])
+final case class TokenInfo(token: TokenId, stdInterfaceId: Option[TokenStdInterfaceId])
 
 object TokenInfo {
+
   implicit val readWriter: ReadWriter[TokenInfo] = macroRW
+
+  implicit val schema: Schema[TokenInfo] = Schema[TokenInfo](
+    SchemaType.SProduct(
+      List(
+        SchemaType.SProductField(FieldName("token", "token"), tokenIdSchema, _ => None),
+        SchemaType.SProductField(
+          FieldName("stdInterfaceId", "stdInterfaceId"),
+          StdInterfaceId.tokenWithHexStringSchema.asOption,
+          _ => None
+        )
+      )
+    )
+  ).name(Schema.SName("TokenInfo"))
 }

--- a/app/src/main/scala/org/alephium/explorer/api/model/Transaction.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/Transaction.scala
@@ -20,6 +20,9 @@ import java.time.Instant
 
 import scala.collection.immutable.ArraySeq
 
+import sttp.tapir.Schema
+
+import org.alephium.api.TapirSchemas._
 import org.alephium.api.UtilJson.{timestampReader, timestampWriter}
 import org.alephium.explorer.api.Json._
 import org.alephium.explorer.util.UtxoUtil
@@ -63,4 +66,6 @@ object Transaction {
 
   val csvHeader: String =
     "hash,blockHash,unixTimestamp,dateTimeUTC,fromAddresses,toAddresses,amount,hintAmount\n"
+
+  implicit val schema: Schema[Transaction] = Schema.derived[Transaction]
 }

--- a/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
+++ b/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
@@ -21,7 +21,6 @@ import sttp.apispec.openapi.OpenAPI
 import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
 
 import org.alephium.explorer.api._
-import org.alephium.explorer.api.model.StdInterfaceId
 
 trait Documentation
     extends BlockEndpoints
@@ -107,19 +106,6 @@ trait Documentation
           Schema(
             `type` = Some(SchemaType.Integer),
             `enum` = Some(List(ExampleSingleValue(maxSizeAddresses)))
-          )
-        )
-        .addSchema(
-          "TokenStdInterfaceId",
-          Schema(
-            `type` = Some(SchemaType.String),
-            `enum` = Some(
-              List(
-                ExampleSingleValue(StdInterfaceId.FungibleToken.value),
-                ExampleSingleValue(StdInterfaceId.NFT.value),
-                ExampleSingleValue(StdInterfaceId.NonStandard.value)
-              )
-            )
           )
         )
     )

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/TokenInfoEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/TokenInfoEntity.scala
@@ -16,7 +16,7 @@
 
 package org.alephium.explorer.persistence.model
 
-import org.alephium.explorer.api.model.TokenInfo
+import org.alephium.explorer.api.model._
 import org.alephium.protocol.model.TokenId
 import org.alephium.util.TimeStamp
 
@@ -29,6 +29,11 @@ final case class TokenInfoEntity(
   def toApi(): TokenInfo =
     TokenInfo(
       token,
-      interfaceId.map(_.toApi)
+      interfaceId.map(
+        _.toApi match {
+          case tokenInterface: TokenStdInterfaceId => tokenInterface
+          case other                               => StdInterfaceId.Unknown(other.id)
+        }
+      )
     )
 }


### PR DESCRIPTION
Nothing change on scala side, the goal is to have better types when
generating the TS api on the FE side. Now we have a proper type when using the token interface id:

```
TokenStdInterfaceId | string
```
here are the generated TS: 

```typescript
export interface TokenInfo {
  /** @Format 32-byte-hash */
  token: string
  /** Raw interface id, e.g. 0001 */
  stdInterfaceId?: TokenStdInterfaceId | string
}

export enum TokenStdInterfaceId {
  Fungible = 'fungible',
  NonFungible = 'non-fungible',
  NonStandard = 'non-standard'
}
```

also for the `interface-id` query param:

```typescript
/**
 * fungible, non-fungible, non-standard or any interface id in hex-string format, e.g: 0001
 * @Format string
 */
'interface-id'?: TokenStdInterfaceId | string
```

I also change some auto-gen schema to semi-derivated. When using auto-gen there are too many unknown stuff happening in background and it's a mess as soon as you want to customize a bit the schemas