### PR TITLE
Fix fetch of metadata

### DIFF
--- a/app/src/test/scala/org/alephium/explorer/service/BlockFlowClientSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/BlockFlowClientSpec.scala
@@ -72,9 +72,9 @@ class BlockFlowClientSpec extends AlephiumFutureSpec with DatabaseFixtureForAll 
     }
   }
   "BlockFlowClient companion" should {
-    def contractResult(value: model.Val): model.CallContractResult = {
+    def contractResult(value: model.Val*): model.CallContractResult = {
       val result = callContractSucceededGen.sample.get
-      result.copy(returns = value +: result.returns)
+      result.copy(returns = AVector.from(value) ++ result.returns)
     }
     "extract fungible token metadata" in {
       forAll(
@@ -107,12 +107,11 @@ class BlockFlowClientSpec extends AlephiumFutureSpec with DatabaseFixtureForAll 
       forAll(tokenIdGen, multipleCallContractResult, valByteVecGen, valU256Gen, valByteVecGen) {
 
         case (token, result, contractId, nftIndex, uri) =>
-          val uriResult: model.CallContractResult        = contractResult(uri)
-          val contractIdResult: model.CallContractResult = contractResult(contractId)
-          val nftIndexResult: model.CallContractResult   = contractResult(nftIndex)
+          val uriResult: model.CallContractResult             = contractResult(uri)
+          val contractIdIndexResult: model.CallContractResult = contractResult(contractId, nftIndex)
 
           val results: AVector[model.CallContractResult] =
-            AVector(uriResult, contractIdResult, nftIndexResult) ++ result.results
+            AVector(uriResult, contractIdIndexResult) ++ result.results
           val callContract = result.copy(results = results)
 
           BlockFlowClient.extractNFTMetadata(token, callContract) is Some(


### PR DESCRIPTION
We were using a deprecated way of fetching nft metadata, we now follow what's inside our web3 package:

https://github.com/alephium/alephium-web3/blob/72ae2e0ef8c0274ffb3e0cedb33f609585b5757a/packages/web3/src/api/node-provider.ts#L136-L180

I tested it both in mainnet and testnet, everything seems fine. Of course on testnet we have some nft that are deprecated so we can't get their metadata, but that's expected.

@h0ngcha0 I put you as reviewer as you wrote the web3 part, you confirm that now `collectionId` and `index` are in the same `CallContractSucceeded`?

First elem is the collection_id and second is the index.