### PR TITLE
Update workflows to fix deprecation messages

### DIFF
--- a/.github/workflows/docker-buildx.yml
+++ b/.github/workflows/docker-buildx.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_branch }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,8 +22,10 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push Docker image
-        uses: olafurpg/setup-scala@v10
+        uses: actions/setup-java@v3
         with:
-          java-version: 8
+          distribution: temurin
+          java-version: 11
+          cache: sbt
       - run: sbt app/docker
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,9 @@ jobs:
           submodules: true
       - uses: actions/setup-java@v3
         with:
+          distribution: temurin
           java-version: 11
+          cache: sbt
       - name: Get the version
         id: get_version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,18 +8,18 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
-          java-version: 8
+          java-version: 11
       - name: Get the version
         id: get_version
         run: |
           version=$(echo ${GITHUB_REF/refs\/tags\//} | cut -c 2-)
-          echo ::set-output name=VERSION::$version
+          echo "VERSION=$version" >> $GITHUB_OUTPUT
         shell: bash
       - run: sbt app/assembly
       - name: Create Release

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -24,8 +24,8 @@ jobs:
           - 5432:5432
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-java@v1
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v3
       with:
         java-version: 11
     - run: sbt ";scalafmtCheck;test:scalafmtCheck;scalafmtSbtCheck;scalastyle;test:scalastyle;test;unidoc;app/assembly"

--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -27,5 +27,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-java@v3
       with:
+        distribution: temurin
         java-version: 11
+        cache: sbt
     - run: sbt ";scalafmtCheck;test:scalafmtCheck;scalafmtSbtCheck;scalastyle;test:scalastyle;test;unidoc;app/assembly"


### PR DESCRIPTION
See more:
* https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
* https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/