### PR TITLE
Add chain index filtering on `/blocks` endpoint

### DIFF
--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -41,6 +41,24 @@
             "schema": {
               "type": "boolean"
             }
+          },
+          {
+            "name": "chainFrom",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "chainTo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           }
         ],
         "responses": {

--- a/app/src/main/scala/org/alephium/explorer/persistence/dao/BlockDao.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/dao/BlockDao.scala
@@ -94,12 +94,16 @@ object BlockDao {
   ): Future[Unit] =
     run(insertBlockEntity(blocks, groupSetting.groupNum)).map(_ => ())
 
-  def listMainChain(pagination: Pagination.Reversible)(implicit
+  def listMainChain(
+      pagination: Pagination.Reversible,
+      chainFrom: Option[GroupIndex],
+      chainTo: Option[GroupIndex]
+  )(implicit
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile],
       cache: BlockCache
   ): Future[(ArraySeq[BlockEntryLite], Int)] = {
-    run(listMainChainHeadersWithTxnNumber(pagination)).map { blockEntries =>
+    run(listMainChainHeadersWithTxnNumber(pagination, chainFrom, chainTo)).map { blockEntries =>
       (blockEntries, cache.getMainChainBlockCount())
     }
   }

--- a/app/src/main/scala/org/alephium/explorer/service/BlockService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/BlockService.scala
@@ -26,7 +26,7 @@ import org.alephium.explorer.GroupSetting
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.cache.BlockCache
 import org.alephium.explorer.persistence.dao.BlockDao
-import org.alephium.protocol.model.BlockHash
+import org.alephium.protocol.model.{BlockHash, GroupIndex}
 
 trait BlockService {
   def getLiteBlockByHash(hash: BlockHash)(implicit
@@ -39,7 +39,11 @@ trait BlockService {
       dc: DatabaseConfig[PostgresProfile]
   ): Future[ArraySeq[Transaction]]
 
-  def listBlocks(pagination: Pagination.Reversible)(implicit
+  def listBlocks(
+      pagination: Pagination.Reversible,
+      chainFrom: Option[GroupIndex],
+      chainTo: Option[GroupIndex]
+  )(implicit
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile],
       cache: BlockCache
@@ -72,12 +76,16 @@ object BlockService extends BlockService {
   ): Future[ArraySeq[Transaction]] =
     BlockDao.getTransactions(hash, pagination)
 
-  def listBlocks(pagination: Pagination.Reversible)(implicit
+  def listBlocks(
+      pagination: Pagination.Reversible,
+      chainFrom: Option[GroupIndex],
+      chainTo: Option[GroupIndex]
+  )(implicit
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile],
       cache: BlockCache
   ): Future[ListBlocks] =
-    BlockDao.listMainChain(pagination).map { case (blocks, total) =>
+    BlockDao.listMainChain(pagination, chainFrom, chainTo).map { case (blocks, total) =>
       ListBlocks(total, blocks)
     }
 

--- a/app/src/main/scala/org/alephium/explorer/service/IndexChecker.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/IndexChecker.scala
@@ -41,10 +41,14 @@ object IndexChecker {
   def checkAction()(implicit ec: ExecutionContext): DBActionR[ArraySeq[ExplainResult]] =
     for {
       a <- BlockQueries.explainListMainChainHeadersWithTxnNumber(
-        Pagination.Reversible.unsafe(1, 20)
+        Pagination.Reversible.unsafe(1, 20),
+        None,
+        None
       ) // first page
       b <- BlockQueries.explainListMainChainHeadersWithTxnNumber(
-        Pagination.Reversible.unsafe(10000, 20)
+        Pagination.Reversible.unsafe(10000, 20),
+        None,
+        None
       ) // far page
       c                  <- BlockQueries.explainMainChainQuery()
       oldestOutputEntity <- OutputQueries.getMainChainOutputs(true).headOrEmpty

--- a/app/src/main/scala/org/alephium/explorer/web/BlockServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/BlockServer.scala
@@ -24,6 +24,7 @@ import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
 
 import org.alephium.api.ApiError
+import org.alephium.explorer.GroupSetting
 import org.alephium.explorer.api.BlockEndpoints
 import org.alephium.explorer.cache.BlockCache
 import org.alephium.explorer.service.BlockService
@@ -31,12 +32,16 @@ import org.alephium.explorer.service.BlockService
 class BlockServer(implicit
     val executionContext: ExecutionContext,
     dc: DatabaseConfig[PostgresProfile],
-    blockCache: BlockCache
+    blockCache: BlockCache,
+    groupSetting: GroupSetting
 ) extends Server
     with BlockEndpoints {
+  override val groupNum = groupSetting.groupNum
   val routes: ArraySeq[Router => Route] =
     ArraySeq(
-      route(listBlocks.serverLogicSuccess[Future](BlockService.listBlocks(_))),
+      route(listBlocks.serverLogicSuccess[Future] { case (pagination, chainFrom, chainTo) =>
+        BlockService.listBlocks(pagination, chainFrom, chainTo)
+      }),
       route(getBlockByHash.serverLogic[Future] { hash =>
         BlockService
           .getLiteBlockByHash(hash)

--- a/app/src/test/scala/org/alephium/explorer/ExplorerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/ExplorerSpec.scala
@@ -249,6 +249,31 @@ trait ExplorerSpec
         "Invalid value for: query parameter page (expected value to be greater than or equal to 1, but got 0)"
       )
     }
+
+    Get(s"/blocks?chainFrom=0") check { response =>
+      val blocks = response.as[ListBlocks].blocks
+      Inspectors.forAll(blocks)(_.chainFrom.value is 0)
+    }
+
+    Get(s"/blocks?chainTo=0") check { response =>
+      val blocks = response.as[ListBlocks].blocks
+      Inspectors.forAll(blocks)(_.chainTo.value is 0)
+    }
+
+    Get(s"/blocks?chainFrom=0&chainTo=0") check { response =>
+      val blocks = response.as[ListBlocks].blocks
+      Inspectors.forAll(blocks) { block =>
+        block.chainFrom.value is 0
+        block.chainTo.value is 0
+      }
+    }
+
+    Get(s"/blocks?chainTo=10") check { response =>
+      response.code is StatusCode.BadRequest
+      response.as[ApiError.BadRequest] is ApiError.BadRequest(
+        "Invalid value for: query parameter chainTo (Invalid group index: 10)"
+      )
+    }
   }
 
   "get a transaction by its id" in {

--- a/app/src/test/scala/org/alephium/explorer/GenDBModel.scala
+++ b/app/src/test/scala/org/alephium/explorer/GenDBModel.scala
@@ -32,6 +32,7 @@ import org.alephium.protocol.model.{Address, BlockHash, ChainIndex, GroupIndex, 
 import org.alephium.util.{AVector, TimeStamp}
 
 /** Test-data generators for types in package [[org.alephium.explorer.persistence.model]] */
+// scalastyle:off number.of.methods
 @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
 object GenDBModel {
 
@@ -292,6 +293,13 @@ object GenDBModel {
       spentFinalized,
       spentTimestamp
     )
+
+  def blockEntityGen()(implicit groupSetting: GroupSetting): Gen[BlockEntity] =
+    blockEntryProtocolGen.map { block =>
+      BlockFlowClient.blockProtocolToEntity(
+        block
+      )
+    }
 
   def blockEntityGen(
       chainIndex: ChainIndex

--- a/app/src/test/scala/org/alephium/explorer/service/BlockFlowSyncServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/BlockFlowSyncServiceSpec.scala
@@ -291,7 +291,7 @@ class BlockFlowSyncServiceSpec extends AlephiumFutureSpec with DatabaseFixtureFo
 
     def checkMainChain(mainChain: ArraySeq[BlockHash]) = {
       val result = BlockDao
-        .listMainChain(Pagination.Reversible.unsafe(1, blocks.size))
+        .listMainChain(Pagination.Reversible.unsafe(1, blocks.size), None, None)
         .futureValue
         ._1
         .filter(block => block.chainFrom == GroupIndex.Zero && block.chainTo == GroupIndex.Zero)

--- a/app/src/test/scala/org/alephium/explorer/service/EmptyBlockService.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/EmptyBlockService.scala
@@ -25,7 +25,7 @@ import slick.jdbc.PostgresProfile
 import org.alephium.explorer._
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.cache.BlockCache
-import org.alephium.protocol.model.BlockHash
+import org.alephium.protocol.model.{BlockHash, GroupIndex}
 
 trait EmptyBlockService extends BlockService {
 
@@ -41,7 +41,11 @@ trait EmptyBlockService extends BlockService {
   ): Future[ArraySeq[Transaction]] =
     Future.successful(ArraySeq.empty)
 
-  def listBlocks(pagination: Pagination.Reversible)(implicit
+  def listBlocks(
+      pagination: Pagination.Reversible,
+      chainFrom: Option[GroupIndex],
+      chainTo: Option[GroupIndex]
+  )(implicit
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile],
       cache: BlockCache

--- a/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/DBBenchmark.scala
+++ b/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/DBBenchmark.scala
@@ -127,7 +127,7 @@ class DBBenchmark {
     implicit val cache: BlockCache                   = state.blockCache
 
     val _ =
-      Await.result(BlockDao.listMainChain(state.next), requestTimeout)
+      Await.result(BlockDao.listMainChain(state.next, None, None), requestTimeout)
   }
 
   @Benchmark
@@ -137,7 +137,7 @@ class DBBenchmark {
     implicit val cache: BlockCache                   = state.blockCache
 
     val _ =
-      Await.result(BlockDao.listMainChain(state.next), requestTimeout)
+      Await.result(BlockDao.listMainChain(state.next, None, None), requestTimeout)
   }
 
   /** CONNECTION POOL = HIKARI
@@ -152,7 +152,7 @@ class DBBenchmark {
     implicit val cache: BlockCache                   = state.blockCache
 
     val _ =
-      Await.result(BlockDao.listMainChain(state.next), requestTimeout)
+      Await.result(BlockDao.listMainChain(state.next, None, None), requestTimeout)
   }
 
   /** Address benchmarks


### PR DESCRIPTION
@h0ngcha0 as discussed on slack. 

Let's discuss here if it make sens to add those optional `chainFrom` and `chainTo` query params.

Unfortunatelly we don't have the deps on those `BlockEntryLite` in DB.

I will also try in another PR to have the deps available in our latest blocks cache