### PR TITLE
Introduce `/infos/latest-blocks` endpoints

### DIFF
--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -3378,6 +3378,109 @@
         }
       }
     },
+    "/infos/latest-blocks": {
+      "get": {
+        "tags": [
+          "Infos"
+        ],
+        "description": "List latest height for each chain",
+        "operationId": "getInfosLatest-blocks",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LatestBlock"
+                  }
+                },
+                "example": [
+                  {
+                    "hash": "bdaf9dc514ce7d34b6474b8ca10a3dfb93ba997cb9d5ff1ea724ebe2af48abe5",
+                    "timestamp": 1611041396892,
+                    "chainFrom": 1,
+                    "chainTo": 2,
+                    "height": 42,
+                    "deps": [
+                      "bdaf9dc514ce7d34b6474b8ca10a3dfb93ba997cb9d5ff1ea724ebe2af48abe5"
+                    ],
+                    "target": "",
+                    "hashRate": "147573952589676412928"
+                  }
+                ]
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequest"
+                },
+                "example": {
+                  "detail": "Something bad in the request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unauthorized"
+                },
+                "example": {
+                  "detail": "You shall not pass"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFound"
+                },
+                "example": {
+                  "resource": "wallet-name",
+                  "detail": "wallet-name not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                },
+                "example": {
+                  "detail": "Ouch"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailable"
+                },
+                "example": {
+                  "detail": "Self clique unsynced"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/mempool/transactions": {
       "get": {
         "tags": [
@@ -7296,6 +7399,55 @@
           "hourly",
           "weekly"
         ]
+      },
+      "LatestBlock": {
+        "required": [
+          "hash",
+          "timestamp",
+          "chainFrom",
+          "chainTo",
+          "height",
+          "target",
+          "hashRate"
+        ],
+        "type": "object",
+        "properties": {
+          "hash": {
+            "type": "string",
+            "format": "block-hash"
+          },
+          "timestamp": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "chainFrom": {
+            "type": "integer",
+            "format": "group-index"
+          },
+          "chainTo": {
+            "type": "integer",
+            "format": "group-index"
+          },
+          "height": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "deps": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "block-hash"
+            }
+          },
+          "target": {
+            "type": "string",
+            "format": "hex-string"
+          },
+          "hashRate": {
+            "type": "string",
+            "format": "bigint"
+          }
+        }
       },
       "ListBlocks": {
         "required": [

--- a/app/src/main/scala/org/alephium/explorer/api/EndpointExamples.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/EndpointExamples.scala
@@ -24,6 +24,7 @@ import sttp.tapir.EndpointIO.Example
 import org.alephium.api.EndpointsExamples
 import org.alephium.api.model.{Amount, ValBool}
 import org.alephium.explorer.api.model._
+import org.alephium.explorer.persistence.model.LatestBlock
 import org.alephium.explorer.persistence.queries.ExplainResult
 import org.alephium.protocol.ALPH
 import org.alephium.protocol.mining.HashRate
@@ -117,6 +118,18 @@ object EndpointExamples extends EndpointsExamples {
       height = Height.unsafe(42),
       txNumber = 1,
       mainChain = true,
+      hashRate = HashRate.a128EhPerSecond.value
+    )
+
+  private val latestBlock: LatestBlock =
+    LatestBlock(
+      hash = blockHash,
+      timestamp = ts,
+      chainFrom = groupIndex1,
+      chainTo = groupIndex2,
+      height = Height.unsafe(42),
+      deps = Some(ArraySeq(blockHash)),
+      target = ByteString.empty,
       hashRate = HashRate.a128EhPerSecond.value
     )
 
@@ -299,6 +312,9 @@ object EndpointExamples extends EndpointsExamples {
     */
   implicit val blockEntryLiteExample: List[Example[BlockEntryLite]] =
     simpleExample(blockEntryLite)
+
+  implicit val latestBlocksExample: List[Example[ArraySeq[LatestBlock]]] =
+    simpleExample(ArraySeq(latestBlock))
 
   implicit val transactionsExample: List[Example[ArraySeq[Transaction]]] =
     simpleExample(ArraySeq(transaction, transaction))

--- a/app/src/main/scala/org/alephium/explorer/api/InfosEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/InfosEndpoints.scala
@@ -26,6 +26,7 @@ import sttp.tapir.generic.auto._
 import org.alephium.api.Endpoints.jsonBody
 import org.alephium.explorer.api.EndpointExamples._
 import org.alephium.explorer.api.model._
+import org.alephium.explorer.persistence.model.LatestBlock
 
 // scalastyle:off magic.number
 trait InfosEndpoints extends BaseEndpoint with QueryParams {
@@ -78,6 +79,12 @@ trait InfosEndpoints extends BaseEndpoint with QueryParams {
     infosEndpoint.get
       .in("heights")
       .out(jsonBody[ArraySeq[PerChainHeight]])
+      .description("List latest height for each chain")
+
+  val latestBlocks: BaseEndpoint[Unit, ArraySeq[LatestBlock]] =
+    infosEndpoint.get
+      .in("latest-blocks")
+      .out(jsonBody[ArraySeq[LatestBlock]])
       .description("List latest height for each chain")
 
   val getTotalTransactions: BaseEndpoint[Unit, Int] =

--- a/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
+++ b/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
@@ -60,6 +60,7 @@ trait Documentation
         getAddressAmountHistory,
         getInfos,
         getHeights,
+        latestBlocks,
         listMempoolTransactions,
         listTokens,
         listTokenTransactions,

--- a/app/src/main/scala/org/alephium/explorer/persistence/Migrations.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/Migrations.scala
@@ -36,7 +36,7 @@ import org.alephium.util.TimeStamp
 @SuppressWarnings(Array("org.wartremover.warts.AnyVal"))
 object Migrations extends StrictLogging {
 
-  val latestVersion: MigrationVersion = MigrationVersion(5)
+  val latestVersion: MigrationVersion = MigrationVersion(6)
 
   def migration1(implicit ec: ExecutionContext): DBActionAll[Unit] =
     EventSchema.table.result.flatMap { events =>
@@ -96,12 +96,19 @@ object Migrations extends StrictLogging {
     } yield ()
   }
 
+  def migration6(implicit ec: ExecutionContext): DBActionAll[Unit] = {
+    for {
+      _ <- sqlu"""ALTER TABLE latest_blocks ADD COLUMN IF NOT EXISTS deps bytea"""
+    } yield ()
+  }
+
   private def migrations(implicit ec: ExecutionContext): Seq[DBActionAll[Unit]] = Seq(
     migration1,
     migration2,
     migration3,
     migration4,
-    migration5
+    migration5,
+    migration6
   )
 
   def migrationsQuery(

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/LatestBlock.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/LatestBlock.scala
@@ -18,9 +18,15 @@ package org.alephium.explorer.persistence.model
 
 import java.math.BigInteger
 
+import scala.collection.immutable.ArraySeq
+
 import akka.util.ByteString
 
+import org.alephium.api.UtilJson._
+import org.alephium.explorer.api.Codecs._
+import org.alephium.explorer.api.Json.groupIndexReadWriter
 import org.alephium.explorer.api.model.Height
+import org.alephium.json.Json._
 import org.alephium.protocol.model.{BlockHash, GroupIndex}
 import org.alephium.util.TimeStamp
 
@@ -30,11 +36,14 @@ final case class LatestBlock(
     chainFrom: GroupIndex,
     chainTo: GroupIndex,
     height: Height,
+    deps: Option[ArraySeq[BlockHash]], // currently optional for backward compatibility
     target: ByteString,
-    hashrate: BigInteger
+    hashRate: BigInteger
 )
 
 object LatestBlock {
+  implicit val codec: ReadWriter[LatestBlock] = macroRW
+
   def fromEntity(block: BlockEntity): LatestBlock = {
     LatestBlock(
       block.hash,
@@ -42,6 +51,7 @@ object LatestBlock {
       block.chainFrom,
       block.chainTo,
       block.height,
+      Some(block.deps),
       block.target,
       block.hashrate
     )

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomJdbcTypes.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomJdbcTypes.scala
@@ -147,6 +147,16 @@ object CustomJdbcTypes {
       bytes => readBinary[ArraySeq[Val]](bytes)
     )
 
+  implicit val blockHashesType: JdbcType[ArraySeq[BlockHash]] =
+    MappedJdbcType.base[ArraySeq[BlockHash], Array[Byte]](
+      blockHashes => serialize(blockHashes).toArray,
+      bytes =>
+        deserialize[ArraySeq[BlockHash]](ByteString.fromArrayUnsafe(bytes)) match {
+          case Left(error)  => throw error
+          case Right(value) => value
+        }
+    )
+
   implicit val intervalTypeType: JdbcType[IntervalType] =
     MappedJdbcType.base[IntervalType, Int](
       _.value,

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/LatestBlockSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/LatestBlockSchema.scala
@@ -18,6 +18,8 @@ package org.alephium.explorer.persistence.schema
 
 import java.math.BigInteger
 
+import scala.collection.immutable.ArraySeq
+
 import akka.util.ByteString
 import slick.jdbc.PostgresProfile.api._
 import slick.lifted.{PrimaryKey, ProvenShape}
@@ -31,12 +33,13 @@ import org.alephium.util.TimeStamp
 object LatestBlockSchema extends Schema[LatestBlock]("latest_blocks") {
 
   class LatestBlocks(tag: Tag) extends Table[LatestBlock](tag, name) {
-    def hash: Rep[BlockHash]       = column[BlockHash]("hash", O.SqlType("bytea"))
-    def timestamp: Rep[TimeStamp]  = column[TimeStamp]("block_timestamp")
-    def chainFrom: Rep[GroupIndex] = column[GroupIndex]("chain_from")
-    def chainTo: Rep[GroupIndex]   = column[GroupIndex]("chain_to")
-    def height: Rep[Height]        = column[Height]("height")
-    def target: Rep[ByteString]    = column[ByteString]("target")
+    def hash: Rep[BlockHash]                   = column[BlockHash]("hash", O.SqlType("bytea"))
+    def timestamp: Rep[TimeStamp]              = column[TimeStamp]("block_timestamp")
+    def chainFrom: Rep[GroupIndex]             = column[GroupIndex]("chain_from")
+    def chainTo: Rep[GroupIndex]               = column[GroupIndex]("chain_to")
+    def height: Rep[Height]                    = column[Height]("height")
+    def deps: Rep[Option[ArraySeq[BlockHash]]] = column[Option[ArraySeq[BlockHash]]]("deps")
+    def target: Rep[ByteString]                = column[ByteString]("target")
     def hashrate: Rep[BigInteger] =
       column[BigInteger](
         "hashrate",
@@ -46,7 +49,7 @@ object LatestBlockSchema extends Schema[LatestBlock]("latest_blocks") {
     def pk: PrimaryKey = primaryKey("latest_block_pk", (chainFrom, chainTo))
 
     def * : ProvenShape[LatestBlock] =
-      (hash, timestamp, chainFrom, chainTo, height, target, hashrate)
+      (hash, timestamp, chainFrom, chainTo, height, deps, target, hashrate)
         .<>((LatestBlock.apply _).tupled, LatestBlock.unapply)
   }
 

--- a/app/src/main/scala/org/alephium/explorer/service/BlockService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/BlockService.scala
@@ -26,6 +26,7 @@ import org.alephium.explorer.GroupSetting
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.cache.BlockCache
 import org.alephium.explorer.persistence.dao.BlockDao
+import org.alephium.explorer.persistence.model.LatestBlock
 import org.alephium.protocol.model.{BlockHash, GroupIndex}
 
 trait BlockService {
@@ -54,6 +55,12 @@ trait BlockService {
       groupSetting: GroupSetting,
       ec: ExecutionContext
   ): Future[ArraySeq[PerChainHeight]]
+
+  def latestBlocks()(implicit
+      cache: BlockCache,
+      groupSetting: GroupSetting,
+      ec: ExecutionContext
+  ): Future[ArraySeq[LatestBlock]]
 
   def getAverageBlockTime()(implicit
       cache: BlockCache,
@@ -100,6 +107,15 @@ object BlockService extends BlockService {
         val height = block.height.value.toLong
         PerChainHeight(chainIndex.from.value, chainIndex.to.value, height, height)
       })
+
+  def latestBlocks()(implicit
+      cache: BlockCache,
+      groupSetting: GroupSetting,
+      ec: ExecutionContext
+  ): Future[ArraySeq[LatestBlock]] =
+    BlockDao
+      .latestBlocks()
+      .map(_.map(_._2))
 
   def getAverageBlockTime()(implicit
       cache: BlockCache,

--- a/app/src/main/scala/org/alephium/explorer/web/InfosServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/InfosServer.scala
@@ -92,6 +92,9 @@ class InfosServer(
       route(getHeights.serverLogicSuccess[Future]{ _ =>
          blockService.listMaxHeights()
       }) ,
+      route(latestBlocks.serverLogicSuccess[Future]{ _ =>
+         blockService.latestBlocks()
+      }),
       route(getTotalTransactions.serverLogicSuccess[Future]{ _=>
         Future(transactionService.getTotalNumber())
       }),

--- a/app/src/test/scala/org/alephium/explorer/service/EmptyBlockService.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/EmptyBlockService.scala
@@ -25,6 +25,7 @@ import slick.jdbc.PostgresProfile
 import org.alephium.explorer._
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.cache.BlockCache
+import org.alephium.explorer.persistence.model.LatestBlock
 import org.alephium.protocol.model.{BlockHash, GroupIndex}
 
 trait EmptyBlockService extends BlockService {
@@ -57,6 +58,13 @@ trait EmptyBlockService extends BlockService {
       groupSetting: GroupSetting,
       ec: ExecutionContext
   ): Future[ArraySeq[PerChainHeight]] =
+    Future.successful(ArraySeq.empty)
+
+  def latestBlocks()(implicit
+      cache: BlockCache,
+      groupSetting: GroupSetting,
+      ec: ExecutionContext
+  ): Future[ArraySeq[LatestBlock]] =
     Future.successful(ArraySeq.empty)
 
   def getAverageBlockTime()(implicit


### PR DESCRIPTION
@h0ngcha0 second proposition, we take advantage of the `latest block` cache that we already have. Currently it was only use to return the `latest heights`, but we could return everything in a new endpoint.

I addded `deps` to `LatestBlock`, I had to put them as optional for backward compatibility reason, otherwise I should have done a complex migration. But a soon as each chain sync a block, the deps will be there and correct


Here is the result of the endpoint (my db isn't sync, so data are old):
[latest-blocks.json](https://github.com/alephium/explorer-backend/files/14383414/latest-blocks.json)

We could also decide to merge both propositions, [the other one](https://github.com/alephium/explorer-backend/pull/516) could still make sense if someone want to explore only one chain