### PR TITLE
Add more config for yearly data and default to 366 to handle leap years

### DIFF
--- a/app/src/main/resources/application.conf
+++ b/app/src/main/resources/application.conf
@@ -50,19 +50,21 @@ explorer {
         amount-history = {
             hourly = 7 days
             hourly = ${?EXPLORER_AMOUNT_HISTORY_MAX_TIME_INTERVAL_HOURLY}
-            daily  = 365 days
+            daily  = 366 days
             daily = ${?EXPLORER_AMOUNT_HISTORY_MAX_TIME_INTERVAL_DAILY}
-            weekly = 365 days
+            weekly = 366 days
             weekly = ${?EXPLORER_AMOUNT_HISTORY_MAX_TIME_INTERVAL_WEEKLY}
         }
         charts = {
             hourly = 30 days
             hourly = ${?EXPLORER_CHARTS_MAX_TIME_INTERVAL_HOURLY}
-            daily  = 365 days
+            daily  = 366 days
             daily = ${?EXPLORER_CHARTS_MAX_TIME_INTERVAL_DAILY}
-            weekly = 365 days
+            weekly = 366 days
             weekly = ${?EXPLORER_CHARTS_MAX_TIME_INTERVAL_WEEKLY}
-        }
+        },
+        export-txs = 366 days
+        export-txs = ${?EXPLORER_MAX_TIME_INTERVAL_EXPORT_TXS}
     }
 
     market {
@@ -87,7 +89,9 @@ explorer {
             "try",
             "cad"
         ]
-        coingecko-uri = "https://api.coingecko.com/api/v3"
+        coingecko-uri = "https://api.coingecko.com/api/v3",
+        market-chart-days = 366
+        market-chart-days = ${?EXPLORER_MARKET_CHART_DAYS}
     }
 }
 

--- a/app/src/main/resources/application.conf
+++ b/app/src/main/resources/application.conf
@@ -89,7 +89,7 @@ explorer {
             "try",
             "cad"
         ]
-        coingecko-uri = "https://api.coingecko.com/api/v3",
+        coingecko-uri = "https://api.coingecko.com/api/v3"
         market-chart-days = 366
         market-chart-days = ${?EXPLORER_MARKET_CHART_DAYS}
     }

--- a/app/src/main/scala/org/alephium/explorer/AppServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/AppServer.scala
@@ -53,7 +53,8 @@ object AppServer {
         TokenService,
         exportTxsNumberThreshold,
         streamParallelism,
-        maxTimeIntervals.amountHistory
+        maxTimeIntervals.amountHistory,
+        maxTimeIntervals.exportTxs
       )
     val transactionServer = new TransactionServer()
     val infosServer       = new InfosServer(TokenSupplyService, BlockService, TransactionService)
@@ -64,7 +65,7 @@ object AppServer {
     val eventServer                = new EventServer()
     val contractServer             = new ContractServer()
     val marketServer               = new MarketServer(marketService)
-    val documentationServer        = new DocumentationServer()
+    val documentationServer        = new DocumentationServer(maxTimeIntervals.exportTxs)
 
     blockServer.routes ++
       addressServer.routes ++

--- a/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
@@ -42,7 +42,7 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
 
   lazy val maxSizeAddresses: Int = groupNum * gapLimit
 
-  private val oneYear = Duration.ofDaysUnsafe(365)
+  def maxTimeIntervalExportTxs: Duration
 
   private val baseAddressesEndpoint =
     baseEndpoint
@@ -148,12 +148,12 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
       .out(jsonBody[ArraySeq[Boolean]])
       .description("Are the addresses used (at least 1 transaction)")
 
-  val exportTransactionsCsvByAddress
+  lazy val exportTransactionsCsvByAddress
       : BaseEndpoint[(Address, TimeInterval), (String, ReadStream[Buffer])] =
     addressesEndpoint.get
       .in("export-transactions")
       .in("csv")
-      .in(timeIntervalWithMaxQuery(oneYear))
+      .in(timeIntervalWithMaxQuery(maxTimeIntervalExportTxs))
       .out(header[String](HeaderNames.ContentDisposition))
       .out(streamTextBody(VertxStreams)(TextCsv()))
 

--- a/app/src/main/scala/org/alephium/explorer/config/ExplorerConfig.scala
+++ b/app/src/main/scala/org/alephium/explorer/config/ExplorerConfig.scala
@@ -186,13 +186,15 @@ object ExplorerConfig {
 
   final case class MaxTimeIntervals(
       amountHistory: MaxTimeInterval,
-      charts: MaxTimeInterval
+      charts: MaxTimeInterval,
+      exportTxs: util.Duration
   )
 
   final case class Market(
       symbolName: ListMap[String, String],
       currencies: ArraySeq[String],
-      coingeckoUri: String
+      coingeckoUri: String,
+      marketChartDays: Int
   )
 
   final private case class Explorer(

--- a/app/src/main/scala/org/alephium/explorer/service/MarketService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/MarketService.scala
@@ -230,7 +230,10 @@ object MarketService extends StrictLogging {
     ): Future[Either[String, ArraySeq[(TimeStamp, Double)]]] = {
       logger.debug(s"Query coingecko `/coins/$id/market_chart`, nb of attempts $retried")
       basicRequest
-        .method(Method.GET, uri"$baseUri/coins/$id/market_chart?vs_currency=$baseCurrency&days=365")
+        .method(
+          Method.GET,
+          uri"$baseUri/coins/$id/market_chart?vs_currency=$baseCurrency&days=${marketConfig.marketChartDays}"
+        )
         .send(backend)
         .flatMap { response =>
           handleChartResponse(id, response, retried)

--- a/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
@@ -35,13 +35,15 @@ import org.alephium.explorer.api.model._
 import org.alephium.explorer.config.ExplorerConfig
 import org.alephium.explorer.service.{TokenService, TransactionService}
 import org.alephium.protocol.model.Address
+import org.alephium.util.Duration
 
 class AddressServer(
     transactionService: TransactionService,
     tokenService: TokenService,
     exportTxsNumberThreshold: Int,
     streamParallelism: Int,
-    maxTimeInterval: ExplorerConfig.MaxTimeInterval
+    maxTimeInterval: ExplorerConfig.MaxTimeInterval,
+    val maxTimeIntervalExportTxs: Duration
 )(implicit
     val executionContext: ExecutionContext,
     groupSetting: GroupSetting,

--- a/app/src/main/scala/org/alephium/explorer/web/DocumentationServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/DocumentationServer.scala
@@ -24,8 +24,12 @@ import org.alephium.api.OpenAPIWriters.openApiJson
 import org.alephium.explorer.GroupSetting
 import org.alephium.explorer.docs.Documentation
 import org.alephium.http.SwaggerUI
+import org.alephium.util.Duration
 
-class DocumentationServer()(implicit groupSetting: GroupSetting) extends Server with Documentation {
+class DocumentationServer(val maxTimeIntervalExportTxs: Duration)(implicit
+    groupSetting: GroupSetting
+) extends Server
+    with Documentation {
 
   val groupNum = groupSetting.groupNum
 

--- a/app/src/test/scala/org/alephium/explorer/ConfigDefaults.scala
+++ b/app/src/test/scala/org/alephium/explorer/ConfigDefaults.scala
@@ -26,13 +26,14 @@ object ConfigDefaults {
     MaxTimeIntervals(
       amountHistory = MaxTimeInterval(
         hourly = Duration.ofDaysUnsafe(7),
-        daily = Duration.ofDaysUnsafe(365),
-        weekly = Duration.ofDaysUnsafe(365)
+        daily = Duration.ofDaysUnsafe(366),
+        weekly = Duration.ofDaysUnsafe(366)
       ),
       charts = MaxTimeInterval(
         hourly = Duration.ofDaysUnsafe(30),
-        daily = Duration.ofDaysUnsafe(365),
-        weekly = Duration.ofDaysUnsafe(365)
-      )
+        daily = Duration.ofDaysUnsafe(366),
+        weekly = Duration.ofDaysUnsafe(366)
+      ),
+      exportTxs = Duration.ofDaysUnsafe(366)
     )
 }

--- a/app/src/test/scala/org/alephium/explorer/service/MarketServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/MarketServiceSpec.scala
@@ -110,7 +110,8 @@ class MarketServiceSpec extends AlephiumFutureSpec {
         "AYIN" -> "ayin"
       ),
       ArraySeq("btc", "usd", "eur", "chf", "gbp", "idr", "vnd", "rub", "try", "cad"),
-      s"http://${localhost.getHostAddress()}:$port"
+      s"http://${localhost.getHostAddress()}:$port",
+      marketChartDays = 366
     )
 
     val coingecko: MarketServiceSpec.CoingeckoMock =

--- a/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
@@ -149,7 +149,8 @@ class AddressServerSpec()
       tokenService,
       exportTxsNumberThreshold = 1000,
       streamParallelism = 8,
-      maxTimeInterval = ConfigDefaults.maxTimeIntervals.amountHistory
+      maxTimeInterval = ConfigDefaults.maxTimeIntervals.amountHistory,
+      maxTimeIntervalExportTxs = ConfigDefaults.maxTimeIntervals.exportTxs
     )
 
   val routes = server.routes
@@ -247,7 +248,7 @@ class AddressServerSpec()
       val address = addressGen.sample.get
       val long    = Gen.posNum[Long].sample.get
       val fromTs  = TimeStamp.now().millis
-      val toTs    = fromTs + Duration.ofDaysUnsafe(365).millis
+      val toTs    = fromTs + Duration.ofDaysUnsafe(366).millis
 
       Get(s"/addresses/${address}/export-transactions/csv?fromTs=$fromTs&toTs=$toTs") check {
         response =>
@@ -280,8 +281,8 @@ class AddressServerSpec()
     val fromTs        = timestamps.head
     def maxTimeSpan(intervalType: IntervalType) = intervalType match {
       case IntervalType.Hourly => Duration.ofDaysUnsafe(7)
-      case IntervalType.Daily  => Duration.ofDaysUnsafe(365)
-      case IntervalType.Weekly => Duration.ofDaysUnsafe(365)
+      case IntervalType.Daily  => Duration.ofDaysUnsafe(366)
+      case IntervalType.Weekly => Duration.ofDaysUnsafe(366)
     }
     def getToTs(intervalType: IntervalType) =
       fromTs + maxTimeSpan(intervalType).millis

--- a/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/DBBenchmark.scala
+++ b/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/DBBenchmark.scala
@@ -282,7 +282,7 @@ class DBBenchmark {
     implicit val dc: DatabaseConfig[PostgresProfile] = state.config
     val timestamps                                   = state.blocks.map(_.timestamp)
     val from                                         = timestamps.min
-    val to           = from.plusMillisUnsafe(Duration.ofDaysUnsafe(365L).millis)
+    val to           = from.plusMillisUnsafe(Duration.ofDaysUnsafe(366L).millis)
     val intervalType = IntervalType.Daily
 
     val flowable = TransactionService
@@ -298,7 +298,7 @@ class DBBenchmark {
     implicit val dc: DatabaseConfig[PostgresProfile] = state.config
     val timestamps                                   = state.blocks.map(_.timestamp)
     val from                                         = timestamps.min
-    val to           = from.plusMillisUnsafe(Duration.ofDaysUnsafe(365L).millis)
+    val to           = from.plusMillisUnsafe(Duration.ofDaysUnsafe(366L).millis)
     val intervalType = IntervalType.Daily
 
     val res = TransactionService

--- a/tools/src/main/scala/org/alephium/tools/OpenApiUpdate.scala
+++ b/tools/src/main/scala/org/alephium/tools/OpenApiUpdate.scala
@@ -18,14 +18,17 @@ package org.alephium.tools
 
 import org.alephium.api.OpenAPIWriters.openApiJson
 import org.alephium.explorer.docs.Documentation
-import org.alephium.util.discard
+import org.alephium.util.{discard, Duration}
 
 object OpenApiUpdate {
   def main(args: Array[String]): Unit = {
     discard {
       new Documentation {
 
-        val groupNum = 4
+        // scalastyle:off magic.number
+        val groupNum                           = 4
+        val maxTimeIntervalExportTxs: Duration = Duration.ofDaysUnsafe(366)
+        // scalastyle:on magic.number
 
         private val json = openApiJson(docs, dropAuth = false)
 


### PR DESCRIPTION
From the front end, if you query for march 05 2023 to march 05 2024, then you have 366 days as it's a leap year. 

I think we can safely put 366 as default max value, one day won't change much and at least we are fine with leap years.

I added more config value so now every thing can be change from the config

cc @mvaivre 