### PR TITLE
Configurable services

### DIFF
--- a/app/src/main/resources/application.conf
+++ b/app/src/main/resources/application.conf
@@ -14,25 +14,49 @@ explorer {
     boot-mode = ReadWrite
     boot-mode = ${?EXPLORER_BOOT_MODE}
 
-    # Sync interval for BlockFlowSyncService & MempoolSyncService
-    sync-period = 5 seconds
-    sync-period = ${?EXPLORER_SYNC_PERIOD}
+    services {
+      blockflow-sync = {
+        # BlockFlowSync Service is always enabled
+        # Sync interval for BlockFlowSyncService
+        sync-period = 5 seconds
+        sync-period = ${?EXPLORER_SYNC_PERIOD}
+      }
 
-    # Schedule time for TokenSupplyService
-    token-supply-service-schedule-time = "02:00"
-    token-supply-service-schedule-time = ${?EXPLORER_TOKEN_SUPPLY_SERVICE_SCHEDULE_TIME}
+      mempool-sync = {
+        enable = true,
+        # Sync interval for MempoolSyncService
+        sync-period = 5 seconds
+        sync-period = ${?EXPLORER_SYNC_PERIOD}
+      }
 
-    # Sync interval for HashRateService
-    hash-rate-service-sync-period = 1 hours
-    hash-rate-service-sync-period = ${?EXPLORER_HASH_RATE_SERVICE_SYNC_PERIOD}
+      token-supply = {
+        enable = true,
+        # Schedule time for TokenSupplyService
+        schedule-time = "02:00"
+        schedule-time = ${?EXPLORER_TOKEN_SUPPLY_SERVICE_SCHEDULE_TIME}
+      }
 
-    # Sync interval for FinalizerService
-    finalizer-service-sync-period = 10 minutes
-    finalizer-service-sync-period = ${?EXPLORER_FINALIZER_SERVICE_SYNC_PERIOD}
+      hashrate = {
+        enable = true,
+        # Sync interval for HashRateService
+        sync-period = 1 hours
+        sync-period = ${?EXPLORER_HASH_RATE_SERVICE_SYNC_PERIOD}
+      }
 
-    # Sync interval for TransactionHistoryService
-    transaction-history-service-sync-period = 15 minutes
-    transaction-history-service-sync-period = ${?EXPLORER_TRANSACTION_HISTORY_SERVICE_SYNC_PERIOD}
+      tx-history = {
+        enable = true,
+        # Sync interval for TransactionHistoryService
+        sync-period = 15 minutes
+        sync-period = ${?EXPLORER_TRANSACTION_HISTORY_SERVICE_SYNC_PERIOD}
+      }
+
+      finalizer = {
+        # FinalizerService is always enabled
+        # Sync interval for FinalizerService
+        sync-period = 10 minutes
+        sync-period = ${?EXPLORER_FINALIZER_SERVICE_SYNC_PERIOD}
+      }
+    }
 
     # Cache reloading intervals for BlockCache
     cache-row-count-reload-period = 10 seconds

--- a/app/src/main/resources/application.conf
+++ b/app/src/main/resources/application.conf
@@ -24,6 +24,7 @@ explorer {
 
       mempool-sync = {
         enable = true,
+        enable = ${?EXPLORER_MEMPOOL_SYNC_ENABLE}
         # Sync interval for MempoolSyncService
         sync-period = 5 seconds
         sync-period = ${?EXPLORER_SYNC_PERIOD}
@@ -31,12 +32,14 @@ explorer {
 
       token-supply = {
         enable = true,
+        enable = ${?EXPLORER_TOKEN_SUPPLY_ENABLE}
         # Schedule time for TokenSupplyService
         schedule-time = "02:00"
         schedule-time = ${?EXPLORER_TOKEN_SUPPLY_SERVICE_SCHEDULE_TIME}
       }
 
       hashrate = {
+        enable = ${?EXPLORER_HASHRATE_ENABLE}
         enable = true,
         # Sync interval for HashRateService
         sync-period = 1 hours
@@ -44,6 +47,7 @@ explorer {
       }
 
       tx-history = {
+        enable = ${?EXPLORER_TX_HISTORY_ENABLE}
         enable = true,
         # Sync interval for TransactionHistoryService
         sync-period = 15 minutes

--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -681,6 +681,255 @@
         }
       }
     },
+    "/mempool/transactions": {
+      "get": {
+        "tags": [
+          "Mempool"
+        ],
+        "description": "list mempool transactions",
+        "operationId": "getMempoolTransactions",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number of items per page",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MempoolTransaction"
+                  }
+                },
+                "example": [
+                  {
+                    "hash": "503bfb16230888af4924aa8f8250d7d348b862e267d75d3147f1998050b6da69",
+                    "chainFrom": 1,
+                    "chainTo": 2,
+                    "inputs": [
+                      {
+                        "outputRef": {
+                          "hint": 23412,
+                          "key": "798e9e137aec7c2d59d9655b4ffa640f301f628bf7c365083bb255f6aa5f89ef"
+                        },
+                        "unlockScript": "d1b70d2226308b46da297486adb6b4f1a8c1842cb159ac5ec04f384fe2d6f5da28",
+                        "txHashRef": "503bfb16230888af4924aa8f8250d7d348b862e267d75d3147f1998050b6da69",
+                        "address": "1AujpupFP4KWeZvqA7itsHY9cLJmx4qTzojVZrg8W9y",
+                        "attoAlphAmount": "2",
+                        "tokens": [
+                          {
+                            "id": "2d11fd6c12435ffb07aaed4d190a505b621b927a5f6e51b61ce0ebe186397bdd",
+                            "amount": "42000000000000000000"
+                          },
+                          {
+                            "id": "bd165d20bd063c7a023d22232a1e75bf46e904067f92b49323fe89fa0fd586bf",
+                            "amount": "1000000000000000000000"
+                          }
+                        ]
+                      }
+                    ],
+                    "outputs": [
+                      {
+                        "type": "AssetOutput",
+                        "hint": 1,
+                        "key": "798e9e137aec7c2d59d9655b4ffa640f301f628bf7c365083bb255f6aa5f89ef",
+                        "attoAlphAmount": "2",
+                        "address": "1AujpupFP4KWeZvqA7itsHY9cLJmx4qTzojVZrg8W9y",
+                        "tokens": [
+                          {
+                            "id": "2d11fd6c12435ffb07aaed4d190a505b621b927a5f6e51b61ce0ebe186397bdd",
+                            "amount": "42000000000000000000"
+                          },
+                          {
+                            "id": "bd165d20bd063c7a023d22232a1e75bf46e904067f92b49323fe89fa0fd586bf",
+                            "amount": "1000000000000000000000"
+                          }
+                        ],
+                        "lockTime": 1611041396892,
+                        "message": "798e9e137aec7c2d59d9655b4ffa640f301f628bf7c365083bb255f6aa5f89ef"
+                      },
+                      {
+                        "type": "ContractOutput",
+                        "hint": 1,
+                        "key": "798e9e137aec7c2d59d9655b4ffa640f301f628bf7c365083bb255f6aa5f89ef",
+                        "attoAlphAmount": "2",
+                        "address": "1AujpupFP4KWeZvqA7itsHY9cLJmx4qTzojVZrg8W9y",
+                        "tokens": [
+                          {
+                            "id": "2d11fd6c12435ffb07aaed4d190a505b621b927a5f6e51b61ce0ebe186397bdd",
+                            "amount": "42000000000000000000"
+                          },
+                          {
+                            "id": "bd165d20bd063c7a023d22232a1e75bf46e904067f92b49323fe89fa0fd586bf",
+                            "amount": "1000000000000000000000"
+                          }
+                        ]
+                      }
+                    ],
+                    "gasAmount": 20000,
+                    "gasPrice": "100000000000",
+                    "lastSeen": 1611041396892
+                  },
+                  {
+                    "hash": "503bfb16230888af4924aa8f8250d7d348b862e267d75d3147f1998050b6da69",
+                    "chainFrom": 1,
+                    "chainTo": 2,
+                    "inputs": [
+                      {
+                        "outputRef": {
+                          "hint": 23412,
+                          "key": "798e9e137aec7c2d59d9655b4ffa640f301f628bf7c365083bb255f6aa5f89ef"
+                        },
+                        "unlockScript": "d1b70d2226308b46da297486adb6b4f1a8c1842cb159ac5ec04f384fe2d6f5da28",
+                        "txHashRef": "503bfb16230888af4924aa8f8250d7d348b862e267d75d3147f1998050b6da69",
+                        "address": "1AujpupFP4KWeZvqA7itsHY9cLJmx4qTzojVZrg8W9y",
+                        "attoAlphAmount": "2",
+                        "tokens": [
+                          {
+                            "id": "2d11fd6c12435ffb07aaed4d190a505b621b927a5f6e51b61ce0ebe186397bdd",
+                            "amount": "42000000000000000000"
+                          },
+                          {
+                            "id": "bd165d20bd063c7a023d22232a1e75bf46e904067f92b49323fe89fa0fd586bf",
+                            "amount": "1000000000000000000000"
+                          }
+                        ]
+                      }
+                    ],
+                    "outputs": [
+                      {
+                        "type": "AssetOutput",
+                        "hint": 1,
+                        "key": "798e9e137aec7c2d59d9655b4ffa640f301f628bf7c365083bb255f6aa5f89ef",
+                        "attoAlphAmount": "2",
+                        "address": "1AujpupFP4KWeZvqA7itsHY9cLJmx4qTzojVZrg8W9y",
+                        "tokens": [
+                          {
+                            "id": "2d11fd6c12435ffb07aaed4d190a505b621b927a5f6e51b61ce0ebe186397bdd",
+                            "amount": "42000000000000000000"
+                          },
+                          {
+                            "id": "bd165d20bd063c7a023d22232a1e75bf46e904067f92b49323fe89fa0fd586bf",
+                            "amount": "1000000000000000000000"
+                          }
+                        ],
+                        "lockTime": 1611041396892,
+                        "message": "798e9e137aec7c2d59d9655b4ffa640f301f628bf7c365083bb255f6aa5f89ef"
+                      },
+                      {
+                        "type": "ContractOutput",
+                        "hint": 1,
+                        "key": "798e9e137aec7c2d59d9655b4ffa640f301f628bf7c365083bb255f6aa5f89ef",
+                        "attoAlphAmount": "2",
+                        "address": "1AujpupFP4KWeZvqA7itsHY9cLJmx4qTzojVZrg8W9y",
+                        "tokens": [
+                          {
+                            "id": "2d11fd6c12435ffb07aaed4d190a505b621b927a5f6e51b61ce0ebe186397bdd",
+                            "amount": "42000000000000000000"
+                          },
+                          {
+                            "id": "bd165d20bd063c7a023d22232a1e75bf46e904067f92b49323fe89fa0fd586bf",
+                            "amount": "1000000000000000000000"
+                          }
+                        ]
+                      }
+                    ],
+                    "gasAmount": 20000,
+                    "gasPrice": "100000000000",
+                    "lastSeen": 1611041396892
+                  }
+                ]
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequest"
+                },
+                "example": {
+                  "detail": "Something bad in the request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unauthorized"
+                },
+                "example": {
+                  "detail": "You shall not pass"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFound"
+                },
+                "example": {
+                  "resource": "wallet-name",
+                  "detail": "wallet-name not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                },
+                "example": {
+                  "detail": "Ouch"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailable"
+                },
+                "example": {
+                  "detail": "Self clique unsynced"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/addresses/{address}": {
       "get": {
         "tags": [
@@ -3360,13 +3609,116 @@
         }
       }
     },
-    "/mempool/transactions": {
+    "/infos/average-block-times": {
       "get": {
         "tags": [
-          "Mempool"
+          "Infos"
         ],
-        "description": "list mempool transactions",
-        "operationId": "getMempoolTransactions",
+        "description": "Get the average block time for each chain",
+        "operationId": "getInfosAverage-block-times",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PerChainDuration"
+                  }
+                },
+                "example": [
+                  {
+                    "chainFrom": 1,
+                    "chainTo": 2,
+                    "duration": 60,
+                    "value": 60
+                  },
+                  {
+                    "chainFrom": 1,
+                    "chainTo": 2,
+                    "duration": 60,
+                    "value": 60
+                  }
+                ]
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequest"
+                },
+                "example": {
+                  "detail": "Something bad in the request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unauthorized"
+                },
+                "example": {
+                  "detail": "You shall not pass"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFound"
+                },
+                "example": {
+                  "resource": "wallet-name",
+                  "detail": "wallet-name not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                },
+                "example": {
+                  "detail": "Ouch"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailable"
+                },
+                "example": {
+                  "detail": "Self clique unsynced"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/infos/supply": {
+      "get": {
+        "tags": [
+          "Infos"
+        ],
+        "description": "Get token supply list",
+        "operationId": "getInfosSupply",
         "parameters": [
           {
             "name": "page",
@@ -3396,147 +3748,371 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/MempoolTransaction"
+                    "$ref": "#/components/schemas/TokenSupply"
                   }
                 },
                 "example": [
                   {
-                    "hash": "503bfb16230888af4924aa8f8250d7d348b862e267d75d3147f1998050b6da69",
-                    "chainFrom": 1,
-                    "chainTo": 2,
-                    "inputs": [
-                      {
-                        "outputRef": {
-                          "hint": 23412,
-                          "key": "798e9e137aec7c2d59d9655b4ffa640f301f628bf7c365083bb255f6aa5f89ef"
-                        },
-                        "unlockScript": "d1b70d2226308b46da297486adb6b4f1a8c1842cb159ac5ec04f384fe2d6f5da28",
-                        "txHashRef": "503bfb16230888af4924aa8f8250d7d348b862e267d75d3147f1998050b6da69",
-                        "address": "1AujpupFP4KWeZvqA7itsHY9cLJmx4qTzojVZrg8W9y",
-                        "attoAlphAmount": "2",
-                        "tokens": [
-                          {
-                            "id": "2d11fd6c12435ffb07aaed4d190a505b621b927a5f6e51b61ce0ebe186397bdd",
-                            "amount": "42000000000000000000"
-                          },
-                          {
-                            "id": "bd165d20bd063c7a023d22232a1e75bf46e904067f92b49323fe89fa0fd586bf",
-                            "amount": "1000000000000000000000"
-                          }
-                        ]
-                      }
-                    ],
-                    "outputs": [
-                      {
-                        "type": "AssetOutput",
-                        "hint": 1,
-                        "key": "798e9e137aec7c2d59d9655b4ffa640f301f628bf7c365083bb255f6aa5f89ef",
-                        "attoAlphAmount": "2",
-                        "address": "1AujpupFP4KWeZvqA7itsHY9cLJmx4qTzojVZrg8W9y",
-                        "tokens": [
-                          {
-                            "id": "2d11fd6c12435ffb07aaed4d190a505b621b927a5f6e51b61ce0ebe186397bdd",
-                            "amount": "42000000000000000000"
-                          },
-                          {
-                            "id": "bd165d20bd063c7a023d22232a1e75bf46e904067f92b49323fe89fa0fd586bf",
-                            "amount": "1000000000000000000000"
-                          }
-                        ],
-                        "lockTime": 1611041396892,
-                        "message": "798e9e137aec7c2d59d9655b4ffa640f301f628bf7c365083bb255f6aa5f89ef"
-                      },
-                      {
-                        "type": "ContractOutput",
-                        "hint": 1,
-                        "key": "798e9e137aec7c2d59d9655b4ffa640f301f628bf7c365083bb255f6aa5f89ef",
-                        "attoAlphAmount": "2",
-                        "address": "1AujpupFP4KWeZvqA7itsHY9cLJmx4qTzojVZrg8W9y",
-                        "tokens": [
-                          {
-                            "id": "2d11fd6c12435ffb07aaed4d190a505b621b927a5f6e51b61ce0ebe186397bdd",
-                            "amount": "42000000000000000000"
-                          },
-                          {
-                            "id": "bd165d20bd063c7a023d22232a1e75bf46e904067f92b49323fe89fa0fd586bf",
-                            "amount": "1000000000000000000000"
-                          }
-                        ]
-                      }
-                    ],
-                    "gasAmount": 20000,
-                    "gasPrice": "100000000000",
-                    "lastSeen": 1611041396892
+                    "timestamp": 1611041396892,
+                    "total": "1000000000000000000",
+                    "circulating": "500000000000000000",
+                    "reserved": "10",
+                    "locked": "10",
+                    "maximum": "1000000000000000000000000000"
                   },
                   {
-                    "hash": "503bfb16230888af4924aa8f8250d7d348b862e267d75d3147f1998050b6da69",
-                    "chainFrom": 1,
-                    "chainTo": 2,
-                    "inputs": [
-                      {
-                        "outputRef": {
-                          "hint": 23412,
-                          "key": "798e9e137aec7c2d59d9655b4ffa640f301f628bf7c365083bb255f6aa5f89ef"
-                        },
-                        "unlockScript": "d1b70d2226308b46da297486adb6b4f1a8c1842cb159ac5ec04f384fe2d6f5da28",
-                        "txHashRef": "503bfb16230888af4924aa8f8250d7d348b862e267d75d3147f1998050b6da69",
-                        "address": "1AujpupFP4KWeZvqA7itsHY9cLJmx4qTzojVZrg8W9y",
-                        "attoAlphAmount": "2",
-                        "tokens": [
-                          {
-                            "id": "2d11fd6c12435ffb07aaed4d190a505b621b927a5f6e51b61ce0ebe186397bdd",
-                            "amount": "42000000000000000000"
-                          },
-                          {
-                            "id": "bd165d20bd063c7a023d22232a1e75bf46e904067f92b49323fe89fa0fd586bf",
-                            "amount": "1000000000000000000000"
-                          }
-                        ]
-                      }
-                    ],
-                    "outputs": [
-                      {
-                        "type": "AssetOutput",
-                        "hint": 1,
-                        "key": "798e9e137aec7c2d59d9655b4ffa640f301f628bf7c365083bb255f6aa5f89ef",
-                        "attoAlphAmount": "2",
-                        "address": "1AujpupFP4KWeZvqA7itsHY9cLJmx4qTzojVZrg8W9y",
-                        "tokens": [
-                          {
-                            "id": "2d11fd6c12435ffb07aaed4d190a505b621b927a5f6e51b61ce0ebe186397bdd",
-                            "amount": "42000000000000000000"
-                          },
-                          {
-                            "id": "bd165d20bd063c7a023d22232a1e75bf46e904067f92b49323fe89fa0fd586bf",
-                            "amount": "1000000000000000000000"
-                          }
-                        ],
-                        "lockTime": 1611041396892,
-                        "message": "798e9e137aec7c2d59d9655b4ffa640f301f628bf7c365083bb255f6aa5f89ef"
-                      },
-                      {
-                        "type": "ContractOutput",
-                        "hint": 1,
-                        "key": "798e9e137aec7c2d59d9655b4ffa640f301f628bf7c365083bb255f6aa5f89ef",
-                        "attoAlphAmount": "2",
-                        "address": "1AujpupFP4KWeZvqA7itsHY9cLJmx4qTzojVZrg8W9y",
-                        "tokens": [
-                          {
-                            "id": "2d11fd6c12435ffb07aaed4d190a505b621b927a5f6e51b61ce0ebe186397bdd",
-                            "amount": "42000000000000000000"
-                          },
-                          {
-                            "id": "bd165d20bd063c7a023d22232a1e75bf46e904067f92b49323fe89fa0fd586bf",
-                            "amount": "1000000000000000000000"
-                          }
-                        ]
-                      }
-                    ],
-                    "gasAmount": 20000,
-                    "gasPrice": "100000000000",
-                    "lastSeen": 1611041396892
+                    "timestamp": 1611041396892,
+                    "total": "1000000000000000000",
+                    "circulating": "500000000000000000",
+                    "reserved": "10",
+                    "locked": "10",
+                    "maximum": "1000000000000000000000000000"
                   }
                 ]
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequest"
+                },
+                "example": {
+                  "detail": "Something bad in the request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unauthorized"
+                },
+                "example": {
+                  "detail": "You shall not pass"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFound"
+                },
+                "example": {
+                  "resource": "wallet-name",
+                  "detail": "wallet-name not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                },
+                "example": {
+                  "detail": "Ouch"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailable"
+                },
+                "example": {
+                  "detail": "Self clique unsynced"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/infos/supply/circulating-alph": {
+      "get": {
+        "tags": [
+          "Infos"
+        ],
+        "description": "Get the ALPH circulating supply",
+        "operationId": "getInfosSupplyCirculating-alph",
+        "responses": {
+          "200": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "number"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequest"
+                },
+                "example": {
+                  "detail": "Something bad in the request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unauthorized"
+                },
+                "example": {
+                  "detail": "You shall not pass"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFound"
+                },
+                "example": {
+                  "resource": "wallet-name",
+                  "detail": "wallet-name not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                },
+                "example": {
+                  "detail": "Ouch"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailable"
+                },
+                "example": {
+                  "detail": "Self clique unsynced"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/infos/supply/total-alph": {
+      "get": {
+        "tags": [
+          "Infos"
+        ],
+        "description": "Get the ALPH total supply",
+        "operationId": "getInfosSupplyTotal-alph",
+        "responses": {
+          "200": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "number"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequest"
+                },
+                "example": {
+                  "detail": "Something bad in the request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unauthorized"
+                },
+                "example": {
+                  "detail": "You shall not pass"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFound"
+                },
+                "example": {
+                  "resource": "wallet-name",
+                  "detail": "wallet-name not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                },
+                "example": {
+                  "detail": "Ouch"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailable"
+                },
+                "example": {
+                  "detail": "Self clique unsynced"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/infos/supply/reserved-alph": {
+      "get": {
+        "tags": [
+          "Infos"
+        ],
+        "description": "Get the ALPH reserved supply",
+        "operationId": "getInfosSupplyReserved-alph",
+        "responses": {
+          "200": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "number"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequest"
+                },
+                "example": {
+                  "detail": "Something bad in the request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unauthorized"
+                },
+                "example": {
+                  "detail": "You shall not pass"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFound"
+                },
+                "example": {
+                  "resource": "wallet-name",
+                  "detail": "wallet-name not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                },
+                "example": {
+                  "detail": "Ouch"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailable"
+                },
+                "example": {
+                  "detail": "Self clique unsynced"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/infos/supply/locked-alph": {
+      "get": {
+        "tags": [
+          "Infos"
+        ],
+        "description": "Get the ALPH locked supply",
+        "operationId": "getInfosSupplyLocked-alph",
+        "responses": {
+          "200": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "number"
+                }
               }
             }
           },
@@ -4241,135 +4817,6 @@
         }
       }
     },
-    "/infos/supply": {
-      "get": {
-        "tags": [
-          "Infos"
-        ],
-        "description": "Get token supply list",
-        "operationId": "getInfosSupply",
-        "parameters": [
-          {
-            "name": "page",
-            "in": "query",
-            "description": "Page number",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "format": "int32"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "Number of items per page",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "format": "int32"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/TokenSupply"
-                  }
-                },
-                "example": [
-                  {
-                    "timestamp": 1611041396892,
-                    "total": "1000000000000000000",
-                    "circulating": "500000000000000000",
-                    "reserved": "10",
-                    "locked": "10",
-                    "maximum": "1000000000000000000000000000"
-                  },
-                  {
-                    "timestamp": 1611041396892,
-                    "total": "1000000000000000000",
-                    "circulating": "500000000000000000",
-                    "reserved": "10",
-                    "locked": "10",
-                    "maximum": "1000000000000000000000000000"
-                  }
-                ]
-              }
-            }
-          },
-          "400": {
-            "description": "BadRequest",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequest"
-                },
-                "example": {
-                  "detail": "Something bad in the request"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Unauthorized"
-                },
-                "example": {
-                  "detail": "You shall not pass"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "NotFound",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFound"
-                },
-                "example": {
-                  "resource": "wallet-name",
-                  "detail": "wallet-name not found"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "InternalServerError",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InternalServerError"
-                },
-                "example": {
-                  "detail": "Ouch"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "ServiceUnavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ServiceUnavailable"
-                },
-                "example": {
-                  "detail": "Self clique unsynced"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/tokens/fungible-metadata": {
       "post": {
         "tags": [
@@ -4642,954 +5089,6 @@
                   {
                     "address": "26JbotDoUoNzwVACg1YLaNTZKAJvoBDWiXJMnokZxCzvd",
                     "collectionUri": "collection://uri"
-                  }
-                ]
-              }
-            }
-          },
-          "400": {
-            "description": "BadRequest",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequest"
-                },
-                "example": {
-                  "detail": "Something bad in the request"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Unauthorized"
-                },
-                "example": {
-                  "detail": "You shall not pass"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "NotFound",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFound"
-                },
-                "example": {
-                  "resource": "wallet-name",
-                  "detail": "wallet-name not found"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "InternalServerError",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InternalServerError"
-                },
-                "example": {
-                  "detail": "Ouch"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "ServiceUnavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ServiceUnavailable"
-                },
-                "example": {
-                  "detail": "Self clique unsynced"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/infos/supply/total-alph": {
-      "get": {
-        "tags": [
-          "Infos"
-        ],
-        "description": "Get the ALPH total supply",
-        "operationId": "getInfosSupplyTotal-alph",
-        "responses": {
-          "200": {
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "number"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "BadRequest",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequest"
-                },
-                "example": {
-                  "detail": "Something bad in the request"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Unauthorized"
-                },
-                "example": {
-                  "detail": "You shall not pass"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "NotFound",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFound"
-                },
-                "example": {
-                  "resource": "wallet-name",
-                  "detail": "wallet-name not found"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "InternalServerError",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InternalServerError"
-                },
-                "example": {
-                  "detail": "Ouch"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "ServiceUnavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ServiceUnavailable"
-                },
-                "example": {
-                  "detail": "Self clique unsynced"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/infos/supply/circulating-alph": {
-      "get": {
-        "tags": [
-          "Infos"
-        ],
-        "description": "Get the ALPH circulating supply",
-        "operationId": "getInfosSupplyCirculating-alph",
-        "responses": {
-          "200": {
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "number"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "BadRequest",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequest"
-                },
-                "example": {
-                  "detail": "Something bad in the request"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Unauthorized"
-                },
-                "example": {
-                  "detail": "You shall not pass"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "NotFound",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFound"
-                },
-                "example": {
-                  "resource": "wallet-name",
-                  "detail": "wallet-name not found"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "InternalServerError",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InternalServerError"
-                },
-                "example": {
-                  "detail": "Ouch"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "ServiceUnavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ServiceUnavailable"
-                },
-                "example": {
-                  "detail": "Self clique unsynced"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/infos/supply/reserved-alph": {
-      "get": {
-        "tags": [
-          "Infos"
-        ],
-        "description": "Get the ALPH reserved supply",
-        "operationId": "getInfosSupplyReserved-alph",
-        "responses": {
-          "200": {
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "number"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "BadRequest",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequest"
-                },
-                "example": {
-                  "detail": "Something bad in the request"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Unauthorized"
-                },
-                "example": {
-                  "detail": "You shall not pass"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "NotFound",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFound"
-                },
-                "example": {
-                  "resource": "wallet-name",
-                  "detail": "wallet-name not found"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "InternalServerError",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InternalServerError"
-                },
-                "example": {
-                  "detail": "Ouch"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "ServiceUnavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ServiceUnavailable"
-                },
-                "example": {
-                  "detail": "Self clique unsynced"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/infos/supply/locked-alph": {
-      "get": {
-        "tags": [
-          "Infos"
-        ],
-        "description": "Get the ALPH locked supply",
-        "operationId": "getInfosSupplyLocked-alph",
-        "responses": {
-          "200": {
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "number"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "BadRequest",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequest"
-                },
-                "example": {
-                  "detail": "Something bad in the request"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Unauthorized"
-                },
-                "example": {
-                  "detail": "You shall not pass"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "NotFound",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFound"
-                },
-                "example": {
-                  "resource": "wallet-name",
-                  "detail": "wallet-name not found"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "InternalServerError",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InternalServerError"
-                },
-                "example": {
-                  "detail": "Ouch"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "ServiceUnavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ServiceUnavailable"
-                },
-                "example": {
-                  "detail": "Self clique unsynced"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/infos/total-transactions": {
-      "get": {
-        "tags": [
-          "Infos"
-        ],
-        "description": "Get the total number of transactions",
-        "operationId": "getInfosTotal-transactions",
-        "responses": {
-          "200": {
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "integer",
-                  "format": "int32"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "BadRequest",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequest"
-                },
-                "example": {
-                  "detail": "Something bad in the request"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Unauthorized"
-                },
-                "example": {
-                  "detail": "You shall not pass"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "NotFound",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFound"
-                },
-                "example": {
-                  "resource": "wallet-name",
-                  "detail": "wallet-name not found"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "InternalServerError",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InternalServerError"
-                },
-                "example": {
-                  "detail": "Ouch"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "ServiceUnavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ServiceUnavailable"
-                },
-                "example": {
-                  "detail": "Self clique unsynced"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/infos/average-block-times": {
-      "get": {
-        "tags": [
-          "Infos"
-        ],
-        "description": "Get the average block time for each chain",
-        "operationId": "getInfosAverage-block-times",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/PerChainDuration"
-                  }
-                },
-                "example": [
-                  {
-                    "chainFrom": 1,
-                    "chainTo": 2,
-                    "duration": 60,
-                    "value": 60
-                  },
-                  {
-                    "chainFrom": 1,
-                    "chainTo": 2,
-                    "duration": 60,
-                    "value": 60
-                  }
-                ]
-              }
-            }
-          },
-          "400": {
-            "description": "BadRequest",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequest"
-                },
-                "example": {
-                  "detail": "Something bad in the request"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Unauthorized"
-                },
-                "example": {
-                  "detail": "You shall not pass"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "NotFound",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFound"
-                },
-                "example": {
-                  "resource": "wallet-name",
-                  "detail": "wallet-name not found"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "InternalServerError",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InternalServerError"
-                },
-                "example": {
-                  "detail": "Ouch"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "ServiceUnavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ServiceUnavailable"
-                },
-                "example": {
-                  "detail": "Self clique unsynced"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/charts/hashrates": {
-      "get": {
-        "tags": [
-          "Charts"
-        ],
-        "summary": "Get hashrate chart in H/s",
-        "description": "`interval-type` query param: hourly, daily",
-        "operationId": "getChartsHashrates",
-        "parameters": [
-          {
-            "name": "fromTs",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": "0"
-            }
-          },
-          {
-            "name": "toTs",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": "0"
-            }
-          },
-          {
-            "name": "interval-type",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/IntervalType"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Hashrate"
-                  }
-                },
-                "example": [
-                  {
-                    "timestamp": 1611041396892,
-                    "hashrate": "147573952589676412928",
-                    "value": "147573952589676412928"
-                  },
-                  {
-                    "timestamp": 1611041396892,
-                    "hashrate": "147573952589676412928",
-                    "value": "147573952589676412928"
-                  }
-                ]
-              }
-            }
-          },
-          "400": {
-            "description": "BadRequest",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequest"
-                },
-                "example": {
-                  "detail": "Something bad in the request"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Unauthorized"
-                },
-                "example": {
-                  "detail": "You shall not pass"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "NotFound",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFound"
-                },
-                "example": {
-                  "resource": "wallet-name",
-                  "detail": "wallet-name not found"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "InternalServerError",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InternalServerError"
-                },
-                "example": {
-                  "detail": "Ouch"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "ServiceUnavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ServiceUnavailable"
-                },
-                "example": {
-                  "detail": "Self clique unsynced"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/charts/transactions-count": {
-      "get": {
-        "tags": [
-          "Charts"
-        ],
-        "summary": "Get transaction count history",
-        "description": "`interval-type` query param: hourly, daily",
-        "operationId": "getChartsTransactions-count",
-        "parameters": [
-          {
-            "name": "fromTs",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": "0"
-            }
-          },
-          {
-            "name": "toTs",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": "0"
-            }
-          },
-          {
-            "name": "interval-type",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/IntervalType"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/TimedCount"
-                  }
-                },
-                "example": [
-                  {
-                    "timestamp": 1611041396892,
-                    "totalCountAllChains": 10000000
-                  },
-                  {
-                    "timestamp": 1611041396892,
-                    "totalCountAllChains": 10000000
-                  }
-                ]
-              }
-            }
-          },
-          "400": {
-            "description": "BadRequest",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BadRequest"
-                },
-                "example": {
-                  "detail": "Something bad in the request"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Unauthorized"
-                },
-                "example": {
-                  "detail": "You shall not pass"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "NotFound",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/NotFound"
-                },
-                "example": {
-                  "resource": "wallet-name",
-                  "detail": "wallet-name not found"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "InternalServerError",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InternalServerError"
-                },
-                "example": {
-                  "detail": "Ouch"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "ServiceUnavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ServiceUnavailable"
-                },
-                "example": {
-                  "detail": "Self clique unsynced"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/charts/transactions-count-per-chain": {
-      "get": {
-        "tags": [
-          "Charts"
-        ],
-        "summary": "Get transaction count history per chain",
-        "description": "`interval-type` query param: hourly, daily",
-        "operationId": "getChartsTransactions-count-per-chain",
-        "parameters": [
-          {
-            "name": "fromTs",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": "0"
-            }
-          },
-          {
-            "name": "toTs",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64",
-              "minimum": "0"
-            }
-          },
-          {
-            "name": "interval-type",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "$ref": "#/components/schemas/IntervalType"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/PerChainTimedCount"
-                  }
-                },
-                "example": [
-                  {
-                    "timestamp": 1611041396892,
-                    "totalCountPerChain": [
-                      {
-                        "chainFrom": 1,
-                        "chainTo": 2,
-                        "count": 10000000
-                      },
-                      {
-                        "chainFrom": 1,
-                        "chainTo": 2,
-                        "count": 10000000
-                      }
-                    ]
-                  },
-                  {
-                    "timestamp": 1611041396892,
-                    "totalCountPerChain": [
-                      {
-                        "chainFrom": 1,
-                        "chainTo": 2,
-                        "count": 10000000
-                      },
-                      {
-                        "chainFrom": 1,
-                        "chainTo": 2,
-                        "count": 10000000
-                      }
-                    ]
                   }
                 ]
               }
@@ -6248,6 +5747,420 @@
                     "22fnZLkZJUSyhXgboirmJktWkEBRk1pV8L6gfpc53hvVM"
                   ]
                 }
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequest"
+                },
+                "example": {
+                  "detail": "Something bad in the request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unauthorized"
+                },
+                "example": {
+                  "detail": "You shall not pass"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFound"
+                },
+                "example": {
+                  "resource": "wallet-name",
+                  "detail": "wallet-name not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                },
+                "example": {
+                  "detail": "Ouch"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailable"
+                },
+                "example": {
+                  "detail": "Self clique unsynced"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/charts/hashrates": {
+      "get": {
+        "tags": [
+          "Charts"
+        ],
+        "summary": "Get hashrate chart in H/s",
+        "description": "`interval-type` query param: hourly, daily",
+        "operationId": "getChartsHashrates",
+        "parameters": [
+          {
+            "name": "fromTs",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": "0"
+            }
+          },
+          {
+            "name": "toTs",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": "0"
+            }
+          },
+          {
+            "name": "interval-type",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/IntervalType"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Hashrate"
+                  }
+                },
+                "example": [
+                  {
+                    "timestamp": 1611041396892,
+                    "hashrate": "147573952589676412928",
+                    "value": "147573952589676412928"
+                  },
+                  {
+                    "timestamp": 1611041396892,
+                    "hashrate": "147573952589676412928",
+                    "value": "147573952589676412928"
+                  }
+                ]
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequest"
+                },
+                "example": {
+                  "detail": "Something bad in the request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unauthorized"
+                },
+                "example": {
+                  "detail": "You shall not pass"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFound"
+                },
+                "example": {
+                  "resource": "wallet-name",
+                  "detail": "wallet-name not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                },
+                "example": {
+                  "detail": "Ouch"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailable"
+                },
+                "example": {
+                  "detail": "Self clique unsynced"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/charts/transactions-count": {
+      "get": {
+        "tags": [
+          "Charts"
+        ],
+        "summary": "Get transaction count history",
+        "description": "`interval-type` query param: hourly, daily",
+        "operationId": "getChartsTransactions-count",
+        "parameters": [
+          {
+            "name": "fromTs",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": "0"
+            }
+          },
+          {
+            "name": "toTs",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": "0"
+            }
+          },
+          {
+            "name": "interval-type",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/IntervalType"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TimedCount"
+                  }
+                },
+                "example": [
+                  {
+                    "timestamp": 1611041396892,
+                    "totalCountAllChains": 10000000
+                  },
+                  {
+                    "timestamp": 1611041396892,
+                    "totalCountAllChains": 10000000
+                  }
+                ]
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequest"
+                },
+                "example": {
+                  "detail": "Something bad in the request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unauthorized"
+                },
+                "example": {
+                  "detail": "You shall not pass"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFound"
+                },
+                "example": {
+                  "resource": "wallet-name",
+                  "detail": "wallet-name not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                },
+                "example": {
+                  "detail": "Ouch"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailable"
+                },
+                "example": {
+                  "detail": "Self clique unsynced"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/charts/transactions-count-per-chain": {
+      "get": {
+        "tags": [
+          "Charts"
+        ],
+        "summary": "Get transaction count history per chain",
+        "description": "`interval-type` query param: hourly, daily",
+        "operationId": "getChartsTransactions-count-per-chain",
+        "parameters": [
+          {
+            "name": "fromTs",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": "0"
+            }
+          },
+          {
+            "name": "toTs",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": "0"
+            }
+          },
+          {
+            "name": "interval-type",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/IntervalType"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PerChainTimedCount"
+                  }
+                },
+                "example": [
+                  {
+                    "timestamp": 1611041396892,
+                    "totalCountPerChain": [
+                      {
+                        "chainFrom": 1,
+                        "chainTo": 2,
+                        "count": 10000000
+                      },
+                      {
+                        "chainFrom": 1,
+                        "chainTo": 2,
+                        "count": 10000000
+                      }
+                    ]
+                  },
+                  {
+                    "timestamp": 1611041396892,
+                    "totalCountPerChain": [
+                      {
+                        "chainFrom": 1,
+                        "chainTo": 2,
+                        "count": 10000000
+                      },
+                      {
+                        "chainFrom": 1,
+                        "chainTo": 2,
+                        "count": 10000000
+                      }
+                    ]
+                  }
+                ]
               }
             }
           },

--- a/app/src/main/scala/org/alephium/explorer/AppServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/AppServer.scala
@@ -31,11 +31,13 @@ import org.alephium.explorer.web._
 // scalastyle:off magic.number parameter.number
 object AppServer {
 
+  // scalastyle:off method.length
   def routes(
       exportTxsNumberThreshold: Int,
       streamParallelism: Int,
       maxTimeIntervals: ExplorerConfig.MaxTimeIntervals,
-      marketConfig: ExplorerConfig.Market
+      marketConfig: ExplorerConfig.Market,
+      servicesConfig: ExplorerConfig.Services
   )(implicit
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile],
@@ -57,15 +59,16 @@ object AppServer {
         maxTimeIntervals.exportTxs
       )
     val transactionServer = new TransactionServer()
-    val infosServer       = new InfosServer(TokenSupplyService, BlockService, TransactionService)
+    val infosServer =
+      new InfosServer(TokenSupplyService, BlockService, TransactionService, servicesConfig)
     val utilsServer: UtilsServer   = new UtilsServer()
-    val chartsServer: ChartsServer = new ChartsServer(maxTimeIntervals.charts)
+    val chartsServer: ChartsServer = new ChartsServer(maxTimeIntervals.charts, servicesConfig)
     val tokenServer: TokenServer   = new TokenServer(TokenService)
-    val mempoolServer              = new MempoolServer()
+    val mempoolServer              = new MempoolServer(servicesConfig.mempoolSync)
     val eventServer                = new EventServer()
     val contractServer             = new ContractServer()
     val marketServer               = new MarketServer(marketService)
-    val documentationServer        = new DocumentationServer(maxTimeIntervals.exportTxs)
+    val documentationServer = new DocumentationServer(maxTimeIntervals.exportTxs, servicesConfig)
 
     blockServer.routes ++
       addressServer.routes ++

--- a/app/src/main/scala/org/alephium/explorer/ExplorerState.scala
+++ b/app/src/main/scala/org/alephium/explorer/ExplorerState.scala
@@ -97,7 +97,8 @@ sealed trait ExplorerStateRead extends ExplorerState {
           config.exportTxsNumberThreshold,
           config.streamParallelism,
           config.maxTimeInterval,
-          config.market
+          config.market,
+          config.services
         )(
           executionContext,
           database.databaseConfig,

--- a/app/src/main/scala/org/alephium/explorer/SyncServices.scala
+++ b/app/src/main/scala/org/alephium/explorer/SyncServices.scala
@@ -62,11 +62,11 @@ object SyncServices extends StrictLogging {
         ) flatMap { peers =>
           startSyncServices(
             peers = peers,
-            syncPeriod = config.syncPeriod,
-            tokenSupplyServiceScheduleTime = config.tokenSupplyServiceScheduleTime,
-            hashRateServiceSyncPeriod = config.hashRateServiceSyncPeriod,
-            finalizerServiceSyncPeriod = config.finalizerServiceSyncPeriod,
-            transactionHistoryServiceSyncPeriod = config.transactionHistoryServiceSyncPeriod
+            syncPeriod = config.services.blockflowSync.syncPeriod,
+            tokenSupplyServiceScheduleTime = config.services.tokenSupply.scheduleTime,
+            hashRateServiceSyncPeriod = config.services.hashrate.syncPeriod,
+            finalizerServiceSyncPeriod = config.services.finalizer.syncPeriod,
+            transactionHistoryServiceSyncPeriod = config.services.txHistory.syncPeriod
           )
         }
     }

--- a/app/src/main/scala/org/alephium/explorer/config/ExplorerConfig.scala
+++ b/app/src/main/scala/org/alephium/explorer/config/ExplorerConfig.scala
@@ -150,11 +150,7 @@ object ExplorerConfig {
           host,
           port,
           explorer.bootMode,
-          explorer.syncPeriod,
-          explorer.tokenSupplyServiceScheduleTime,
-          explorer.hashRateServiceSyncPeriod,
-          explorer.finalizerServiceSyncPeriod,
-          explorer.transactionHistoryServiceSyncPeriod,
+          explorer.services,
           explorer.cacheRowCountReloadPeriod,
           explorer.cacheBlockTimesReloadPeriod,
           explorer.cacheLatestBlocksReloadPeriod,
@@ -197,15 +193,50 @@ object ExplorerConfig {
       marketChartDays: Int
   )
 
+  final case class Services(
+      blockflowSync: Services.BlockflowSync,
+      mempoolSync: Services.MempoolSync,
+      tokenSupply: Services.TokenSupply,
+      hashrate: Services.Hashrate,
+      txHistory: Services.TxHistory,
+      finalizer: Services.Finalizer
+  )
+
+  object Services {
+    final case class BlockflowSync(
+        syncPeriod: FiniteDuration
+    )
+
+    final case class MempoolSync(
+        enable: Boolean,
+        syncPeriod: FiniteDuration
+    )
+
+    final case class TokenSupply(
+        enable: Boolean,
+        scheduleTime: LocalTime
+    )
+
+    final case class Hashrate(
+        enable: Boolean,
+        syncPeriod: FiniteDuration
+    )
+
+    final case class TxHistory(
+        enable: Boolean,
+        syncPeriod: FiniteDuration
+    )
+
+    final case class Finalizer(
+        syncPeriod: FiniteDuration
+    )
+  }
+
   final private case class Explorer(
       host: String,
       port: Int,
       bootMode: BootMode,
-      syncPeriod: FiniteDuration,
-      tokenSupplyServiceScheduleTime: LocalTime,
-      hashRateServiceSyncPeriod: FiniteDuration,
-      finalizerServiceSyncPeriod: FiniteDuration,
-      transactionHistoryServiceSyncPeriod: FiniteDuration,
+      services: Services,
       cacheRowCountReloadPeriod: FiniteDuration,
       cacheBlockTimesReloadPeriod: FiniteDuration,
       cacheLatestBlocksReloadPeriod: FiniteDuration,
@@ -230,11 +261,7 @@ final case class ExplorerConfig private (
     host: String,
     port: Int,
     bootMode: BootMode,
-    syncPeriod: FiniteDuration,
-    tokenSupplyServiceScheduleTime: LocalTime,
-    hashRateServiceSyncPeriod: FiniteDuration,
-    finalizerServiceSyncPeriod: FiniteDuration,
-    transactionHistoryServiceSyncPeriod: FiniteDuration,
+    services: ExplorerConfig.Services,
     cacheRowCountReloadPeriod: FiniteDuration,
     cacheBlockTimesReloadPeriod: FiniteDuration,
     cacheLatestBlocksReloadPeriod: FiniteDuration,

--- a/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
+++ b/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
@@ -21,7 +21,15 @@ import sttp.apispec.openapi.OpenAPI
 import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
 
 import org.alephium.explorer.api._
+import org.alephium.explorer.config.ExplorerConfig
 
+@SuppressWarnings(
+  Array(
+    "org.wartremover.warts.JavaSerializable",
+    "org.wartremover.warts.Product",
+    "org.wartremover.warts.Serializable"
+  )
+)
 trait Documentation
     extends BlockEndpoints
     with TransactionEndpoints
@@ -36,59 +44,126 @@ trait Documentation
     with UtilsEndpoints
     with OpenAPIDocsInterpreter {
 
+  def servicesConfig: ExplorerConfig.Services
+
+  private lazy val blocks = List(
+    listBlocks,
+    getBlockByHash,
+    getBlockTransactions
+  )
+
+  private lazy val transactions = List(
+    getTransactionById
+  )
+
+  private lazy val addresses = List(
+    getTransactionById,
+    getAddressInfo,
+    getTransactionsByAddress,
+    getTransactionsByAddresses,
+    getTransactionsByAddressTimeRanged,
+    getTotalTransactionsByAddress,
+    addressMempoolTransactions,
+    getAddressBalance,
+    listAddressTokens,
+    listAddressTokenTransactions,
+    getAddressTokenBalance,
+    listAddressTokensBalance,
+    areAddressesActive,
+    exportTransactionsCsvByAddress,
+    getAddressAmountHistoryDEPRECATED,
+    getAddressAmountHistory
+  )
+
+  private lazy val infos = List(
+    getInfos,
+    getHeights,
+    getAverageBlockTime
+  )
+
+  private lazy val tokens = List(
+    listTokens,
+    listTokenTransactions,
+    listTokenAddresses,
+    listTokenInfo,
+    listFungibleTokenMetadata,
+    listNFTMetadata,
+    listNFTCollectionMetadata
+  )
+
+  private lazy val events = List(
+    getEventsByTxId,
+    getEventsByContractAddress,
+    getEventsByContractAndInputAddress
+  )
+
+  private lazy val contracts = List(
+    getParentAddress,
+    getSubContracts
+  )
+
+  private lazy val mempool =
+    if (servicesConfig.mempoolSync.enable) {
+      List(
+        listMempoolTransactions
+      )
+    } else {
+      List.empty
+    }
+
+  private lazy val tokenSupply =
+    if (servicesConfig.tokenSupply.enable) {
+      List(
+        listTokenSupply,
+        getCirculatingSupply,
+        getTotalSupply,
+        getReservedSupply,
+        getLockedSupply
+      )
+    } else {
+      List.empty
+    }
+
+  private lazy val hashrate =
+    if (servicesConfig.hashrate.enable) {
+      List(getHashrates)
+    } else {
+      List.empty
+    }
+
+  private lazy val txHistory =
+    if (servicesConfig.txHistory.enable) {
+      List(getAllChainsTxCount, getPerChainTxCount)
+    } else {
+      List.empty
+    }
+
+  private lazy val market = List(
+    getPrices,
+    getPriceChart
+  )
+
+  private lazy val utils = List(
+    sanityCheck,
+    changeGlobalLogLevel,
+    changeLogConfig
+  )
+
   lazy val docs: OpenAPI = addComponents(
     toOpenAPI(
-      List(
-        listBlocks,
-        getBlockByHash,
-        getBlockTransactions,
-        getTransactionById,
-        getAddressInfo,
-        getTransactionsByAddress,
-        getTransactionsByAddresses,
-        getTransactionsByAddressTimeRanged,
-        getTotalTransactionsByAddress,
-        addressMempoolTransactions,
-        getAddressBalance,
-        listAddressTokens,
-        listAddressTokenTransactions,
-        getAddressTokenBalance,
-        listAddressTokensBalance,
-        areAddressesActive,
-        exportTransactionsCsvByAddress,
-        getAddressAmountHistoryDEPRECATED,
-        getAddressAmountHistory,
-        getInfos,
-        getHeights,
-        listMempoolTransactions,
-        listTokens,
-        listTokenTransactions,
-        listTokenAddresses,
-        listTokenSupply,
-        listTokenInfo,
-        listFungibleTokenMetadata,
-        listNFTMetadata,
-        listNFTCollectionMetadata,
-        getTotalSupply,
-        getCirculatingSupply,
-        getReservedSupply,
-        getLockedSupply,
-        getTotalTransactions,
-        getAverageBlockTime,
-        getHashrates,
-        getAllChainsTxCount,
-        getPerChainTxCount,
-        getEventsByTxId,
-        getEventsByContractAddress,
-        getEventsByContractAndInputAddress,
-        getParentAddress,
-        getSubContracts,
-        getPrices,
-        getPriceChart,
-        sanityCheck,
-        changeGlobalLogLevel,
-        changeLogConfig
-      ),
+      blocks ++
+        transactions ++
+        mempool ++
+        addresses ++
+        infos ++
+        tokenSupply ++
+        tokens ++
+        events ++
+        contracts ++
+        hashrate ++
+        txHistory ++
+        market ++
+        utils,
       "Alephium Explorer API",
       "1.0"
     )

--- a/app/src/main/scala/org/alephium/explorer/web/DocumentationServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/DocumentationServer.scala
@@ -22,11 +22,15 @@ import io.vertx.ext.web._
 
 import org.alephium.api.OpenAPIWriters.openApiJson
 import org.alephium.explorer.GroupSetting
+import org.alephium.explorer.config.ExplorerConfig
 import org.alephium.explorer.docs.Documentation
 import org.alephium.http.SwaggerUI
 import org.alephium.util.Duration
 
-class DocumentationServer(val maxTimeIntervalExportTxs: Duration)(implicit
+class DocumentationServer(
+    val maxTimeIntervalExportTxs: Duration,
+    val servicesConfig: ExplorerConfig.Services
+)(implicit
     groupSetting: GroupSetting
 ) extends Server
     with Documentation {

--- a/app/src/main/scala/org/alephium/explorer/web/InfosServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/InfosServer.scala
@@ -30,6 +30,7 @@ import org.alephium.explorer.{BuildInfo, GroupSetting}
 import org.alephium.explorer.api.InfosEndpoints
 import org.alephium.explorer.api.model.{ExplorerInfo, TokenSupply}
 import org.alephium.explorer.cache.{AsyncReloadingCache, BlockCache, TransactionCache}
+import org.alephium.explorer.config.ExplorerConfig
 import org.alephium.explorer.persistence.DBRunner
 import org.alephium.explorer.persistence.model.AppState
 import org.alephium.explorer.persistence.queries.AppStateQueries
@@ -41,7 +42,8 @@ import org.alephium.util.{TimeStamp, U256}
 class InfosServer(
     tokenSupplyService: TokenSupplyService,
     blockService: BlockService,
-    transactionService: TransactionService
+    transactionService: TransactionService,
+    config: ExplorerConfig.Services
 )(implicit
     val executionContext: ExecutionContext,
     dc: DatabaseConfig[PostgresProfile],
@@ -51,55 +53,59 @@ class InfosServer(
 ) extends Server
     with InfosEndpoints {
 
-  // scalafmt is struggling on this one, maybe latest version wil work.
-  // format: off
-  val routes: ArraySeq[Router=>Route] =
+  val tokenSupplyRoutes: Option[ArraySeq[Router => Route]] =
+    Option
+      .when(config.tokenSupply.enable)(
+        ArraySeq(
+          route(listTokenSupply.serverLogicSuccess[Future] { pagination =>
+            tokenSupplyService.listTokenSupply(pagination)
+          }),
+          route(getCirculatingSupply.serverLogicSuccess[Future] { _ =>
+            getLatestTokenSupply()
+              .map { supply =>
+                val circulating = supply.map(_.circulating).getOrElse(U256.Zero)
+                toALPH(circulating)
+              }
+          }),
+          route(getTotalSupply.serverLogicSuccess[Future] { _ =>
+            getLatestTokenSupply()
+              .map { supply =>
+                val total = supply.map(_.total).getOrElse(U256.Zero)
+                toALPH(total)
+              }
+          }),
+          route(getReservedSupply.serverLogicSuccess[Future] { _ =>
+            getLatestTokenSupply()
+              .map { supply =>
+                val reserved = supply.map(_.reserved).getOrElse(U256.Zero)
+                toALPH(reserved)
+              }
+          }),
+          route(getLockedSupply.serverLogicSuccess[Future] { _ =>
+            getLatestTokenSupply()
+              .map { supply =>
+                val locked = supply.map(_.locked).getOrElse(U256.Zero)
+                toALPH(locked)
+              }
+          })
+        )
+      )
+
+  val routes: ArraySeq[Router => Route] =
     ArraySeq(
       route(getInfos.serverLogicSuccess[Future] { _ =>
         getExplorerInfo()
-      }) ,
-      route(listTokenSupply.serverLogicSuccess[Future] { pagination =>
-        tokenSupplyService.listTokenSupply(pagination)
-      }) ,
-      route(getCirculatingSupply.serverLogicSuccess[Future] { _ =>
-          getLatestTokenSupply()
-          .map { supply =>
-            val circulating = supply.map(_.circulating).getOrElse(U256.Zero)
-            toALPH(circulating)
-          }
-      }) ,
-      route(getTotalSupply.serverLogicSuccess[Future] { _ =>
-          getLatestTokenSupply()
-          .map { supply =>
-            val total = supply.map(_.total).getOrElse(U256.Zero)
-            toALPH(total)
-          }
-      }) ,
-      route(getReservedSupply.serverLogicSuccess[Future] { _ =>
-          getLatestTokenSupply()
-          .map { supply =>
-            val reserved = supply.map(_.reserved).getOrElse(U256.Zero)
-            toALPH(reserved)
-          }
-      }) ,
-      route(getLockedSupply.serverLogicSuccess[Future] { _ =>
-          getLatestTokenSupply()
-          .map { supply =>
-            val locked = supply.map(_.locked).getOrElse(U256.Zero)
-            toALPH(locked)
-          }
-      }) ,
-      route(getHeights.serverLogicSuccess[Future]{ _ =>
-         blockService.listMaxHeights()
-      }) ,
-      route(getTotalTransactions.serverLogicSuccess[Future]{ _=>
+      }),
+      route(getHeights.serverLogicSuccess[Future] { _ =>
+        blockService.listMaxHeights()
+      }),
+      route(getTotalTransactions.serverLogicSuccess[Future] { _ =>
         Future(transactionService.getTotalNumber())
       }),
-      route(getAverageBlockTime.serverLogicSuccess[Future]{ _=>
+      route(getAverageBlockTime.serverLogicSuccess[Future] { _ =>
         blockService.getAverageBlockTime()
       })
-      )
-  // format: on
+    ) ++ tokenSupplyRoutes.getOrElse(ArraySeq.empty)
 
   def getExplorerInfo()(implicit
       executionContext: ExecutionContext,

--- a/app/src/main/scala/org/alephium/explorer/web/MempoolServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/MempoolServer.scala
@@ -24,17 +24,23 @@ import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
 
 import org.alephium.explorer.api.MempoolEndpoints
+import org.alephium.explorer.config.ExplorerConfig
 import org.alephium.explorer.service.TransactionService
 
-class MempoolServer(implicit
+class MempoolServer(config: ExplorerConfig.Services.MempoolSync)(implicit
     val executionContext: ExecutionContext,
     dc: DatabaseConfig[PostgresProfile]
 ) extends Server
     with MempoolEndpoints {
-  val routes: ArraySeq[Router => Route] = ArraySeq(
-    route(listMempoolTransactions.serverLogicSuccess[Future] { pagination =>
-      TransactionService
-        .listMempoolTransactions(pagination)
-    })
-  )
+  val routes: ArraySeq[Router => Route] =
+    if (config.enable) {
+      ArraySeq(
+        route(listMempoolTransactions.serverLogicSuccess[Future] { pagination =>
+          TransactionService
+            .listMempoolTransactions(pagination)
+        })
+      )
+    } else {
+      ArraySeq()
+    }
 }

--- a/app/src/test/scala/org/alephium/explorer/ConfigDefaults.scala
+++ b/app/src/test/scala/org/alephium/explorer/ConfigDefaults.scala
@@ -16,6 +16,8 @@
 
 package org.alephium.explorer
 
+import java.time.LocalTime
+
 import org.alephium.explorer.config.ExplorerConfig._
 import org.alephium.util.Duration
 
@@ -37,4 +39,29 @@ object ConfigDefaults {
       ),
       exportTxs = Duration.ofDaysUnsafe(366)
     )
+
+  val servicesConfig: Services = Services(
+    Services.BlockflowSync(
+      syncPeriod = Duration.ofSecondsUnsafe(5).asScala
+    ),
+    Services.MempoolSync(
+      enable = true,
+      syncPeriod = Duration.ofSecondsUnsafe(5).asScala
+    ),
+    Services.TokenSupply(
+      enable = true,
+      scheduleTime = LocalTime.parse("02:00")
+    ),
+    Services.Hashrate(
+      enable = true,
+      syncPeriod = Duration.ofMinutesUnsafe(60).asScala
+    ),
+    Services.TxHistory(
+      enable = true,
+      syncPeriod = Duration.ofMinutesUnsafe(15).asScala
+    ),
+    Services.Finalizer(
+      syncPeriod = Duration.ofMinutesUnsafe(10).asScala
+    )
+  )
 }

--- a/app/src/test/scala/org/alephium/explorer/web/ChartsServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/ChartsServerSpec.scala
@@ -30,7 +30,8 @@ class ChartsServerSpec()
     with HttpServerFixture {
 
   val chartServer = new ChartsServer(
-    maxTimeInterval = ConfigDefaults.maxTimeIntervals.charts
+    maxTimeInterval = ConfigDefaults.maxTimeIntervals.charts,
+    services = ConfigDefaults.servicesConfig
   )
   override val routes = chartServer.routes
 

--- a/app/src/test/scala/org/alephium/explorer/web/InfosServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/InfosServerSpec.scala
@@ -98,7 +98,7 @@ class InfosServerSpec()
   }
 
   val infoServer =
-    new InfosServer(tokenSupplyService, blockService, transactionService)
+    new InfosServer(tokenSupplyService, blockService, transactionService, servicesConfig)
 
   val routes = infoServer.routes
 

--- a/app/src/test/scala/org/alephium/explorer/web/MempoolServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/MempoolServerSpec.scala
@@ -18,7 +18,7 @@ package org.alephium.explorer.web
 
 import org.scalacheck.Gen
 
-import org.alephium.explorer.{AlephiumActorSpecLike, HttpServerFixture}
+import org.alephium.explorer.{AlephiumActorSpecLike, ConfigDefaults, HttpServerFixture}
 import org.alephium.explorer.GenApiModel._
 import org.alephium.explorer.HttpFixture._
 import org.alephium.explorer.api.model._
@@ -31,7 +31,7 @@ class MempoolServerSpec()
     with HttpServerFixture
     with DatabaseFixtureForAll {
 
-  val utxServer = new MempoolServer()
+  val utxServer = new MempoolServer(ConfigDefaults.servicesConfig.mempoolSync)
 
   val routes = utxServer.routes
 

--- a/tools/src/main/scala/org/alephium/tools/OpenApiUpdate.scala
+++ b/tools/src/main/scala/org/alephium/tools/OpenApiUpdate.scala
@@ -16,7 +16,10 @@
 
 package org.alephium.tools
 
+import com.typesafe.config.ConfigFactory
+
 import org.alephium.api.OpenAPIWriters.openApiJson
+import org.alephium.explorer.config.ExplorerConfig
 import org.alephium.explorer.docs.Documentation
 import org.alephium.util.{discard, Duration}
 
@@ -24,6 +27,11 @@ object OpenApiUpdate {
   def main(args: Array[String]): Unit = {
     discard {
       new Documentation {
+
+        private val typesafeConfig = ConfigFactory.load()
+
+        val config: ExplorerConfig = ExplorerConfig.load(typesafeConfig)
+        val servicesConfig         = config.services
 
         // scalastyle:off magic.number
         val groupNum                           = 4


### PR DESCRIPTION
User can now configure which services to start or not, `BlockFlowSyncService` and `FinalizerService` are still mandatory, not sure it makes sense to run an explorer-backend without those.

Webservers and endpoints related to those services are also disable, the endpoints won't appears in the doc.

reloves https://github.com/alephium/explorer-backend/issues/534