### PR TITLE
Convert MarketSevice into a start/stoppable service

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/AppServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/AppServer.scala
@@ -34,19 +34,18 @@ object AppServer {
   def routes(
       exportTxsNumberThreshold: Int,
       streamParallelism: Int,
-      maxTimeIntervals: ExplorerConfig.MaxTimeIntervals,
-      marketConfig: ExplorerConfig.Market
+      maxTimeIntervals: ExplorerConfig.MaxTimeIntervals
   )(implicit
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile],
       blockFlowClient: BlockFlowClient,
+      marketService: MarketService,
       blockCache: BlockCache,
       transactionCache: TransactionCache,
       groupSetting: GroupSetting
   ): ArraySeq[Router => Route] = {
 
-    val marketService = MarketService.CoinGecko.default(marketConfig)
-    val blockServer   = new BlockServer()
+    val blockServer = new BlockServer()
     val addressServer =
       new AddressServer(
         TransactionService,

--- a/app/src/main/scala/org/alephium/explorer/AppServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/AppServer.scala
@@ -32,6 +32,7 @@ import org.alephium.explorer.web._
 object AppServer {
 
   def routes(
+      marketService: MarketService,
       exportTxsNumberThreshold: Int,
       streamParallelism: Int,
       maxTimeIntervals: ExplorerConfig.MaxTimeIntervals
@@ -39,7 +40,6 @@ object AppServer {
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile],
       blockFlowClient: BlockFlowClient,
-      marketService: MarketService,
       blockCache: BlockCache,
       transactionCache: TransactionCache,
       groupSetting: GroupSetting

--- a/app/src/main/scala/org/alephium/explorer/ExplorerState.scala
+++ b/app/src/main/scala/org/alephium/explorer/ExplorerState.scala
@@ -97,6 +97,7 @@ sealed trait ExplorerStateRead extends ExplorerState {
       config.port,
       AppServer
         .routes(
+          marketService,
           config.exportTxsNumberThreshold,
           config.streamParallelism,
           config.maxTimeInterval
@@ -104,7 +105,6 @@ sealed trait ExplorerStateRead extends ExplorerState {
           executionContext,
           database.databaseConfig,
           blockFlowClient,
-          marketService,
           blockCache,
           transactionCache,
           groupSettings

--- a/app/src/main/scala/org/alephium/explorer/ExplorerState.scala
+++ b/app/src/main/scala/org/alephium/explorer/ExplorerState.scala
@@ -88,6 +88,9 @@ sealed trait ExplorerState extends Service with StrictLogging {
 }
 
 sealed trait ExplorerStateRead extends ExplorerState {
+
+  val marketService: MarketService.CoinGecko = MarketService.CoinGecko.default(config.market)
+
   lazy val httpServer: ExplorerHttpServer =
     new ExplorerHttpServer(
       config.host,
@@ -96,19 +99,19 @@ sealed trait ExplorerStateRead extends ExplorerState {
         .routes(
           config.exportTxsNumberThreshold,
           config.streamParallelism,
-          config.maxTimeInterval,
-          config.market
+          config.maxTimeInterval
         )(
           executionContext,
           database.databaseConfig,
           blockFlowClient,
+          marketService,
           blockCache,
           transactionCache,
           groupSettings
         )
     )
 
-  override lazy val customServices: ArraySeq[Service] = ArraySeq(httpServer)
+  override lazy val customServices: ArraySeq[Service] = ArraySeq(marketService, httpServer)
 }
 
 object ExplorerState {

--- a/app/src/main/scala/org/alephium/explorer/service/MarketService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/MarketService.scala
@@ -23,27 +23,24 @@ import scala.util.{Failure, Success, Try}
 import com.typesafe.scalalogging.StrictLogging
 import sttp.client3._
 import sttp.client3.asynchttpclient.future.AsyncHttpClientFutureBackend
-import sttp.model.{Method, StatusCode}
+import sttp.model.{Method, StatusCode, Uri}
 
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.cache._
 import org.alephium.explorer.config.ExplorerConfig
 import org.alephium.explorer.util.Scheduler
 import org.alephium.json.Json._
-import org.alephium.util.{Duration, Math, TimeStamp}
+import org.alephium.util.{Duration, Math, Service, TimeStamp}
 
 trait MarketService {
-  def getPrices(ids: ArraySeq[String], currency: String)(implicit
-      ec: ExecutionContext
+  def getPrices(
+      ids: ArraySeq[String],
+      currency: String
   ): Future[Either[String, ArraySeq[Option[Double]]]]
 
-  def getExchangeRates()(implicit
-      ec: ExecutionContext
-  ): Future[Either[String, ArraySeq[ExchangeRate]]]
+  def getExchangeRates(): Future[Either[String, ArraySeq[ExchangeRate]]]
 
-  def getPriceChart(symbol: String, currency: String)(implicit
-      ec: ExecutionContext
-  ): Future[Either[String, TimedPrices]]
+  def getPriceChart(symbol: String, currency: String): Future[Either[String, TimedPrices]]
 }
 
 object MarketService extends StrictLogging {
@@ -52,12 +49,13 @@ object MarketService extends StrictLogging {
   object CoinGecko {
     def default(marketConfig: ExplorerConfig.Market)(implicit
         ec: ExecutionContext
-    ): MarketService = new CoinGecko(marketConfig)
+    ): CoinGecko = new CoinGecko(marketConfig)
   }
 
   class CoinGecko(marketConfig: ExplorerConfig.Market)(implicit
-      ec: ExecutionContext
-  ) extends MarketService {
+      val executionContext: ExecutionContext
+  ) extends MarketService
+      with Service {
 
     private val baseUri = marketConfig.coingeckoUri
 
@@ -80,9 +78,22 @@ object MarketService extends StrictLogging {
     def maxDelay: Duration  = Duration.ofMinutesUnsafe(8)
     def maxRetry: Int       = 4
     // scalastyle:on magic.number
-    private val backend   = AsyncHttpClientFutureBackend()
-    private val scheduler = Scheduler("MARKET_SERVICE_SCHEDULER")
 
+    // scalastyle:off null
+    private var backend: SttpBackend[Future, Any] = null
+    private val scheduler                         = Scheduler("MARKET_SERVICE_SCHEDULER")
+
+    override def startSelfOnce(): Future[Unit] = {
+      backend = AsyncHttpClientFutureBackend()
+      expireAndReloadCaches()
+      Future.unit
+    }
+
+    override def stopSelfOnce(): Future[Unit] = {
+      backend.close()
+    }
+
+    override def subServices: ArraySeq[Service] = ArraySeq.empty
     /*
      * We use our `AsyncReloadCache` that always return the latest cached value
      * even if it's expired, like this we guarantee to always return fast a data.
@@ -120,18 +131,21 @@ object MarketService extends StrictLogging {
      * on start, we delay the load of 2 price charts every minute
      * eventually every charts will be in caches.
      */
-    logger.debug("Load initial price and exchange rate caches")
-    pricesCache.expireAndReload()
-    ratesCache.expireAndReload()
-    priceChartsCache.grouped(2).zipWithIndex.foreach { case (caches, idx) =>
-      scheduler.scheduleOnce(
-        s"Expire and reload chart prices for ${caches.map(_._1).mkString(", ")}",
-        Duration.ofMinutesUnsafe((1 * idx).toLong).asScala
-      )(Future.successful(caches.foreach(_._2.expireAndReload())))
+    def expireAndReloadCaches(): Unit = {
+      logger.debug("Load initial price and exchange rate caches")
+      pricesCache.expireAndReload()
+      ratesCache.expireAndReload()
+      priceChartsCache.grouped(2).zipWithIndex.foreach { case (caches, idx) =>
+        scheduler.scheduleOnce(
+          s"Expire and reload chart prices for ${caches.map(_._1).mkString(", ")}",
+          Duration.ofMinutesUnsafe((1 * idx).toLong).asScala
+        )(Future.successful(caches.foreach(_._2.expireAndReload())))
+      }
     }
 
-    def getPrices(ids: ArraySeq[String], currency: String)(implicit
-        ec: ExecutionContext
+    def getPrices(
+        ids: ArraySeq[String],
+        currency: String
     ): Future[Either[String, ArraySeq[Option[Double]]]] = {
       Future.successful(
         for {
@@ -147,19 +161,13 @@ object MarketService extends StrictLogging {
       )
     }
 
-    private def getPricesRemote(retried: Int)(implicit
-        ec: ExecutionContext
-    ): Future[Either[String, ArraySeq[Price]]] = {
+    private def getPricesRemote(retried: Int): Future[Either[String, ArraySeq[Price]]] = {
       logger.debug(s"Query coingecko `/price`, nb of attempts $retried")
-      basicRequest
-        .method(
-          Method.GET,
-          uri"$baseUri/simple/price?ids=${ids.values.mkString(",")}&vs_currencies=$baseCurrency"
-        )
-        .send(backend)
-        .flatMap { response =>
-          handlePricesRateResponse(response, retried)
-        }
+      request(
+        uri"$baseUri/simple/price?ids=${ids.values.mkString(",")}&vs_currencies=$baseCurrency"
+      ) { response =>
+        handlePricesRateResponse(response, retried)
+      }
     }
 
     private def handlePricesRateResponse(
@@ -175,22 +183,17 @@ object MarketService extends StrictLogging {
       )
     }
 
-    def getExchangeRates()(implicit
-        ec: ExecutionContext
-    ): Future[Either[String, ArraySeq[ExchangeRate]]] = {
+    def getExchangeRates(): Future[Either[String, ArraySeq[ExchangeRate]]] = {
       Future.successful(ratesCache.get())
     }
 
-    private def getExchangeRatesRemote(retried: Int)(implicit
-        ec: ExecutionContext
+    private def getExchangeRatesRemote(
+        retried: Int
     ): Future[Either[String, ArraySeq[ExchangeRate]]] = {
       logger.debug(s"Query coingecko `/exchange_rates`, nb of attempts $retried")
-      basicRequest
-        .method(Method.GET, uri"$baseUri/exchange_rates")
-        .send(backend)
-        .flatMap { response =>
-          handleExchangeRateResponse(response, retried)
-        }
+      request(uri"$baseUri/exchange_rates") { response =>
+        handleExchangeRateResponse(response, retried)
+      }
     }
 
     private def handleExchangeRateResponse(
@@ -206,9 +209,7 @@ object MarketService extends StrictLogging {
       )
     }
 
-    def getPriceChart(symbol: String, currency: String)(implicit
-        ec: ExecutionContext
-    ): Future[Either[String, TimedPrices]] = {
+    def getPriceChart(symbol: String, currency: String): Future[Either[String, TimedPrices]] = {
       Future.successful(
         for {
           rates <- ratesCache.get()
@@ -225,19 +226,29 @@ object MarketService extends StrictLogging {
       )
     }
 
-    def getPriceChartRemote(id: String, retried: Int)(implicit
-        ec: ExecutionContext
+    def getPriceChartRemote(
+        id: String,
+        retried: Int
     ): Future[Either[String, ArraySeq[(TimeStamp, Double)]]] = {
       logger.debug(s"Query coingecko `/coins/$id/market_chart`, nb of attempts $retried")
-      basicRequest
-        .method(
-          Method.GET,
-          uri"$baseUri/coins/$id/market_chart?vs_currency=$baseCurrency&days=${marketConfig.marketChartDays}"
-        )
-        .send(backend)
-        .flatMap { response =>
-          handleChartResponse(id, response, retried)
-        }
+      request(
+        uri"$baseUri/coins/$id/market_chart?vs_currency=$baseCurrency&days=${marketConfig.marketChartDays}"
+      ) { response =>
+        handleChartResponse(id, response, retried)
+      }
+    }
+
+    def request[A](uri: Uri)(
+        f: Response[Either[String, String]] => Future[Either[String, A]]
+    ): Future[Either[String, A]] = {
+      if (backend == null) {
+        Future.successful(Left("Market service not initialized"))
+      } else {
+        basicRequest
+          .method(Method.GET, uri)
+          .send(backend)
+          .flatMap(f)
+      }
     }
 
     def handleChartResponse(

--- a/app/src/test/scala/org/alephium/explorer/service/MarketServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/MarketServiceSpec.scala
@@ -39,7 +39,17 @@ import org.alephium.json.Json._
 class MarketServiceSpec extends AlephiumFutureSpec {
   import MarketServiceSpec._
 
+  "return error when not started" in new Fixture {
+    eventually {
+      marketService.getPrices(marketConfig.symbolName.keys.toList, "btc").futureValue.isLeft is true
+      marketService.getExchangeRates().futureValue.isLeft is true
+      marketService.getPriceChart(alph, "usd").futureValue.isLeft is true
+    }
+  }
+
   "get prices, exchange rates and charts" in new Fixture {
+
+    marketService.start().futureValue
 
     eventually {
       val prices =
@@ -116,7 +126,7 @@ class MarketServiceSpec extends AlephiumFutureSpec {
 
     val coingecko: MarketServiceSpec.CoingeckoMock =
       new MarketServiceSpec.CoingeckoMock(localhost, port)
-    val marketService: MarketService =
+    val marketService: MarketService.CoinGecko =
       new MarketService.CoinGecko(marketConfig)
   }
 }


### PR DESCRIPTION
This fix the shutdown of the explorer-backend, otherwise the sttp backend was not close and the explorer-backend was hanging infinitely when stopping.