### PR TITLE
Add Welcome message when explorer-backend is succesfully started

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/Main.scala
+++ b/app/src/main/scala/org/alephium/explorer/Main.scala
@@ -69,7 +69,7 @@ class BootUp extends StrictLogging {
     explorer
       .start()
       .onComplete {
-        case Success(_) => ()
+        case Success(_) => logger.info(WelcomeMessage.message(config))
         case Failure(error) =>
           logger.error("Fatal error during initialization", error)
           explorer.stop().failed foreach { error =>

--- a/app/src/main/scala/org/alephium/explorer/WelcomeMessage.scala
+++ b/app/src/main/scala/org/alephium/explorer/WelcomeMessage.scala
@@ -1,0 +1,64 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer
+
+import org.alephium.explorer.config.{BootMode, ExplorerConfig}
+
+object WelcomeMessage {
+
+  def message(config: ExplorerConfig): String = {
+
+    val logCurl =
+      s"The API: curl -X 'PUT' '${config.host}:${config.port}/utils/update-global-loglevel' -d 'DEBUG'"
+    val logEnv =
+      s"An environment variable: `EXPLORER_LOG_LEVEL=DEBUG`"
+
+    val readInfo =
+      if (BootMode.readable(config.bootMode)) {
+        s"Access the API at: ${config.host}:${config.port}/docs"
+      } else {
+        "No API available in this mode"
+      }
+
+    val loggingInfo = {
+      "Activate debug logs with:\n" ++
+        (if (BootMode.readable(config.bootMode)) {
+           s"""|* $logCurl
+               |* $logEnv
+               |""".stripMargin
+         } else {
+           s"* $logEnv"
+         })
+    }
+
+    val writeInfo =
+      if (BootMode.writable(config.bootMode)) {
+        s"Syncing blocks with node at: ${config.blockFlowUri}"
+      } else {
+        "No syncing in this mode"
+      }
+
+    s"""|
+        |############################################
+        |Explorer-backend started with ${config.bootMode} mode
+        |${writeInfo}
+        |${readInfo}
+        |${loggingInfo}
+        |############################################
+        |""".stripMargin
+  }
+}

--- a/app/src/main/scala/org/alephium/explorer/config/BootMode.scala
+++ b/app/src/main/scala/org/alephium/explorer/config/BootMode.scala
@@ -29,15 +29,16 @@ object BootMode {
 
   /** [[BootMode]]s with reads enabled */
   sealed trait Readable extends BootMode
+  sealed trait Writable extends BootMode
 
   /** Serve HTTP requests only. Disables Sync. */
   case object ReadOnly extends Readable
 
   /** Enables both Read and Sync */
-  case object ReadWrite extends Readable
+  case object ReadWrite extends Readable with Writable
 
   /** Enables Sync only */
-  case object WriteOnly extends BootMode
+  case object WriteOnly extends Writable
 
   /** All boot modes */
   def all: Array[BootMode] =
@@ -54,4 +55,14 @@ object BootMode {
       case None       => Failure(InvalidBootMode(mode))
     }
 
+  def writable(mode: BootMode): Boolean =
+    mode match {
+      case _: Writable => true
+      case _           => false
+    }
+  def readable(mode: BootMode): Boolean =
+    mode match {
+      case _: Readable => true
+      case _           => false
+    }
 }


### PR DESCRIPTION
The current info logs were not very clear if the explorer-backend was really started or not, so users were confused.

In this PR when the explorer-backend is successfully started, we then logs useful info. Here are the 3 possible cases based on the mode.
![image](https://github.com/alephium/explorer-backend/assets/2979182/66f82fa6-686c-47ba-ae42-588f1a5e0ab3)
![image](https://github.com/alephium/explorer-backend/assets/2979182/82f8d105-2c68-47bc-83b6-427c03ee8089)
![image](https://github.com/alephium/explorer-backend/assets/2979182/6d7338c6-1e53-444e-b950-09a9bad76fd0)
