### PR TITLE
Expose currencies and tokens with price in openapi

### DIFF
--- a/app/src/main/resources/application.conf
+++ b/app/src/main/resources/application.conf
@@ -79,6 +79,7 @@ explorer {
         }
         currencies = [
             "btc",
+            "eth",
             "usd",
             "eur",
             "chf",

--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -8338,6 +8338,34 @@
         "enum": [
           80
         ]
+      },
+      "TokensWithPrice": {
+        "type": "string",
+        "enum": [
+          "WETH",
+          "ALPH",
+          "USDT",
+          "AYIN",
+          "DAI",
+          "USDC",
+          "WBTC"
+        ]
+      },
+      "Currencies": {
+        "type": "string",
+        "enum": [
+          "btc",
+          "usd",
+          "eur",
+          "chf",
+          "gbp",
+          "idr",
+          "vnd",
+          "rub",
+          "try",
+          "cad",
+          "aud"
+        ]
       }
     }
   }

--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -8355,6 +8355,7 @@
         "type": "string",
         "enum": [
           "btc",
+          "eth",
           "usd",
           "eur",
           "chf",

--- a/app/src/main/scala/org/alephium/explorer/AppServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/AppServer.scala
@@ -28,14 +28,15 @@ import org.alephium.explorer.config.ExplorerConfig
 import org.alephium.explorer.service._
 import org.alephium.explorer.web._
 
-// scalastyle:off magic.number parameter.number
+// scalastyle:off magic.number parameter.number method.length
 object AppServer {
 
   def routes(
       marketService: MarketService,
       exportTxsNumberThreshold: Int,
       streamParallelism: Int,
-      maxTimeIntervals: ExplorerConfig.MaxTimeIntervals
+      maxTimeIntervals: ExplorerConfig.MaxTimeIntervals,
+      marketConfig: ExplorerConfig.Market
   )(implicit
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile],
@@ -64,7 +65,11 @@ object AppServer {
     val eventServer                = new EventServer()
     val contractServer             = new ContractServer()
     val marketServer               = new MarketServer(marketService)
-    val documentationServer        = new DocumentationServer(maxTimeIntervals.exportTxs)
+    val documentationServer = new DocumentationServer(
+      maxTimeIntervals.exportTxs,
+      marketConfig.currencies,
+      marketConfig.symbolName
+    )
 
     blockServer.routes ++
       addressServer.routes ++

--- a/app/src/main/scala/org/alephium/explorer/ExplorerState.scala
+++ b/app/src/main/scala/org/alephium/explorer/ExplorerState.scala
@@ -100,7 +100,8 @@ sealed trait ExplorerStateRead extends ExplorerState {
           marketService,
           config.exportTxsNumberThreshold,
           config.streamParallelism,
-          config.maxTimeInterval
+          config.maxTimeInterval,
+          config.market
         )(
           executionContext,
           database.databaseConfig,

--- a/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
+++ b/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
@@ -16,6 +16,8 @@
 
 package org.alephium.explorer.docs
 
+import scala.collection.immutable.{ArraySeq, ListMap}
+
 import sttp.apispec._
 import sttp.apispec.openapi.OpenAPI
 import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
@@ -35,6 +37,9 @@ trait Documentation
     with MarketEndpoints
     with UtilsEndpoints
     with OpenAPIDocsInterpreter {
+
+  def currencies: ArraySeq[String]
+  def tokensWithPrice: ListMap[String, String]
 
   lazy val docs: OpenAPI = addComponents(
     toOpenAPI(
@@ -122,6 +127,21 @@ trait Documentation
             `enum` = Some(List(ExampleSingleValue(maxSizeAddresses)))
           )
         )
+        .addSchema(
+          "TokensWithPrice",
+          Schema(
+            `type` = Some(SchemaType.String),
+            enum = Some(
+              tokensWithPrice.map { case (symbol, _) => ExampleSingleValue(symbol) }.toList
+            )
+          )
+        )
+        .addSchema(
+          "Currencies",
+          Schema(
+            `type` = Some(SchemaType.String),
+            enum = Some(currencies.map { name => ExampleSingleValue(name) }.toList)
+          )
+        )
     )
-
 }

--- a/app/src/main/scala/org/alephium/explorer/web/DocumentationServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/DocumentationServer.scala
@@ -16,7 +16,7 @@
 
 package org.alephium.explorer.web
 
-import scala.collection.immutable.ArraySeq
+import scala.collection.immutable.{ArraySeq, ListMap}
 
 import io.vertx.ext.web._
 
@@ -26,7 +26,11 @@ import org.alephium.explorer.docs.Documentation
 import org.alephium.http.SwaggerUI
 import org.alephium.util.Duration
 
-class DocumentationServer(val maxTimeIntervalExportTxs: Duration)(implicit
+class DocumentationServer(
+    val maxTimeIntervalExportTxs: Duration,
+    val currencies: ArraySeq[String],
+    val tokensWithPrice: ListMap[String, String]
+)(implicit
     groupSetting: GroupSetting
 ) extends Server
     with Documentation {

--- a/tools/src/main/scala/org/alephium/tools/OpenApiUpdate.scala
+++ b/tools/src/main/scala/org/alephium/tools/OpenApiUpdate.scala
@@ -16,7 +16,10 @@
 
 package org.alephium.tools
 
+import com.typesafe.config.ConfigFactory
+
 import org.alephium.api.OpenAPIWriters.openApiJson
+import org.alephium.explorer.config._
 import org.alephium.explorer.docs.Documentation
 import org.alephium.util.{discard, Duration}
 
@@ -25,10 +28,13 @@ object OpenApiUpdate {
     discard {
       new Documentation {
 
-        // scalastyle:off magic.number
-        val groupNum                           = 4
-        val maxTimeIntervalExportTxs: Duration = Duration.ofDaysUnsafe(366)
-        // scalastyle:on magic.number
+        private val typesafeConfig         = ConfigFactory.load()
+        private val config: ExplorerConfig = ExplorerConfig.load(typesafeConfig)
+
+        val groupNum                           = config.groupNum
+        val maxTimeIntervalExportTxs: Duration = config.maxTimeInterval.exportTxs
+        val currencies                         = config.market.currencies
+        val tokensWithPrice                    = config.market.symbolName
 
         private val json = openApiJson(docs, dropAuth = false)
 


### PR DESCRIPTION
Resolves #512
 
The generated TS types are then: 
```ts
export enum TokensWithPrice {
  WETH = 'WETH',
  ALPH = 'ALPH',
  USDT = 'USDT',
  AYIN = 'AYIN',
  DAI = 'DAI',
  USDC = 'USDC',
  WBTC = 'WBTC'
}

export enum Currencies {
  Btc = 'btc',
  Usd = 'usd',
  Eur = 'eur',
  Chf = 'chf',
  Gbp = 'gbp',
  Idr = 'idr',
  Vnd = 'vnd',
  Rub = 'rub',
  Try = 'try',
  Cad = 'cad',
  Aud = 'aud'
}
```