### PR TITLE
Amount history openapi

### DIFF
--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -1421,7 +1421,10 @@
           "amountHistory": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/TimedAmount"
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         }
@@ -1519,24 +1522,6 @@
         },
         "required": [
           "token"
-        ]
-      },
-      "TimedAmount": {
-        "type": "object",
-        "title": "TimedAmount",
-        "properties": {
-          "amount": {
-            "format": "bigint",
-            "type": "string"
-          },
-          "timestamp": {
-            "format": "int64",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "timestamp",
-          "amount"
         ]
       },
       "NotFound": {

--- a/app/src/main/scala/org/alephium/explorer/api/model/AmountHistory.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/AmountHistory.scala
@@ -18,6 +18,8 @@ package org.alephium.explorer.api.model
 
 import scala.collection.immutable.ArraySeq
 
+import sttp.tapir.Schema
+
 import org.alephium.json.Json._
 
 @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
@@ -27,4 +29,5 @@ final case class AmountHistory(
 
 object AmountHistory {
   implicit val readWriter: ReadWriter[AmountHistory] = macroRW[AmountHistory]
+  implicit val schema: Schema[AmountHistory]         = Schema.derived[AmountHistory]
 }

--- a/app/src/main/scala/org/alephium/explorer/api/model/TimedAmount.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/TimedAmount.scala
@@ -18,6 +18,10 @@ package org.alephium.explorer.api.model
 
 import java.math.BigInteger
 
+import scala.collection.immutable.ArraySeq
+
+import sttp.tapir.{Schema, SchemaType}
+
 import org.alephium.api.UtilJson._
 import org.alephium.json.Json._
 import org.alephium.util.TimeStamp
@@ -32,5 +36,9 @@ object TimedAmount {
   implicit val readWriter: ReadWriter[TimedAmount] = readwriter[(TimeStamp, BigInteger)].bimap(
     timedAmount => (timedAmount.timestamp, timedAmount.amount),
     { case (time, amount) => TimedAmount(time, amount) }
+  )
+  implicit val schema: Schema[TimedAmount] = Schema(
+    schemaType =
+      SchemaType.SArray[TimedAmount, Any](Schema.string)(t => ArraySeq(t.timestamp, t.amount))
   )
 }

--- a/app/src/main/scala/org/alephium/explorer/api/model/Transaction.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/Transaction.scala
@@ -23,7 +23,6 @@ import scala.collection.immutable.ArraySeq
 import akka.util.ByteString
 import sttp.tapir.Schema
 
-import org.alephium.api.{model => protocol}
 import org.alephium.api.TapirSchemas._
 import org.alephium.api.UtilJson._
 import org.alephium.explorer.api.Json._

--- a/app/src/main/scala/org/alephium/explorer/service/BlockFlowClient.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/BlockFlowClient.scala
@@ -49,7 +49,6 @@ import org.alephium.explorer.error.ExplorerError._
 import org.alephium.explorer.persistence.model._
 import org.alephium.explorer.util.InputAddressUtil
 import org.alephium.http.EndpointSender
-import org.alephium.protocol
 import org.alephium.protocol.config.GroupConfig
 import org.alephium.protocol.mining.HashRate
 import org.alephium.protocol.model.{
@@ -58,12 +57,10 @@ import org.alephium.protocol.model.{
   ChainIndex,
   ContractId,
   GroupIndex,
-  Hint,
   Target,
   TokenId,
   TransactionId
 }
-import org.alephium.protocol.vm.LockupScript
 import org.alephium.util.{AVector, Hex, Service, TimeStamp, U256}
 
 trait BlockFlowClient extends Service {

--- a/build.sbt
+++ b/build.sbt
@@ -128,6 +128,7 @@ val commonSettings = Seq(
     "-Xlint:stars-align",
     "-Xlint:type-parameter-shadow",
     "-Xlint:nonlocal-return",
+    "-Xfatal-warnings",
     "-Ywarn-dead-code",
     "-Ywarn-extra-implicit",
     "-Ywarn-numeric-widen",


### PR DESCRIPTION
Fixes: https://github.com/alephium/alephium-frontend/pull/680

the generated TS api is then: 
![image](https://github.com/alephium/explorer-backend/assets/2979182/a44bc111-c1a8-4940-9dca-4a04bc1695bf)

the data in array is actually `[ timestamp, string]`, but we can't represent such thing, so I checked with FE team and using string is all good.