### PR TITLE
Validate symbol and currency in market endpoints

### DIFF
--- a/app/src/test/scala/org/alephium/explorer/ExplorerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/ExplorerSpec.scala
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the library. If not, see <http://www.gnu.org/licenses/>.
 
+//scalastyle:off file.size.limit
 package org.alephium.explorer
 
 import java.net.InetAddress
@@ -403,6 +404,62 @@ trait ExplorerSpec
       Get(s"/blocks/${uncle.hash.toHexString}") check { response =>
         val res = response.as[BlockEntry]
         res.mainChain is false
+      }
+    }
+  }
+
+  "Market price endpoints" when {
+    "correctly return price" in {
+      val body = """["ALPH", "WETH"]"""
+      Post(s"/market/prices?currency=btc", body) check { response =>
+        val prices = response.as[ArraySeq[Option[Double]]]
+        prices.foreach(_.isDefined is true)
+        response.code is StatusCode.Ok
+      }
+    }
+
+    "ignore unknown symbol" in {
+      val body = """["ALPH", "yop", "nop"]"""
+      Post(s"/market/prices?currency=btc", body) check { response =>
+        val prices = response.as[ArraySeq[Option[Double]]]
+        prices.head.isDefined is true
+        prices.tail.foreach(_.isEmpty is true)
+        response.code is StatusCode.Ok
+      }
+    }
+
+    "return 404 when unknown currency" in {
+      forAll(hashGen) { currency =>
+        Post(s"/market/prices?currency=${currency}", "[]") check { response =>
+          response.code is StatusCode.NotFound
+        }
+      }
+    }
+  }
+
+  "Market chart endpoints" when {
+    "correctly return price charts" in {
+      List("ALPH", "WETH").map { symbol =>
+        Get(s"/market/prices/$symbol/charts?currency=btc") check { response =>
+          response.as[TimedPrices]
+          response.code is StatusCode.Ok
+        }
+      }
+    }
+
+    "return 404 when unknown currency" in {
+      forAll(hashGen) { currency =>
+        Get(s"/market/prices/ALPH/charts?currency=${currency}") check { response =>
+          response.code is StatusCode.NotFound
+        }
+      }
+    }
+
+    "return 404 when unknown symbol" in {
+      forAll(hashGen) { symbol =>
+        Get(s"/market/prices/$symbol/charts?currency=btc") check { response =>
+          response.code is StatusCode.NotFound
+        }
       }
     }
   }

--- a/app/src/test/scala/org/alephium/explorer/service/MarketServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/MarketServiceSpec.scala
@@ -41,9 +41,9 @@ class MarketServiceSpec extends AlephiumFutureSpec {
 
   "return error when not started" in new Fixture {
     eventually {
-      marketService.getPrices(marketConfig.symbolName.keys.toList, "btc").futureValue.isLeft is true
-      marketService.getExchangeRates().futureValue.isLeft is true
-      marketService.getPriceChart(alph, "usd").futureValue.isLeft is true
+      marketService.getPrices(marketConfig.symbolName.keys.toList, "btc").isLeft is true
+      marketService.getExchangeRates().isLeft is true
+      marketService.getPriceChart(alph, "usd").isLeft is true
     }
   }
 
@@ -53,7 +53,7 @@ class MarketServiceSpec extends AlephiumFutureSpec {
 
     eventually {
       val prices =
-        marketService.getPrices(marketConfig.symbolName.keys.toList, "btc").futureValue.rightValue
+        marketService.getPrices(marketConfig.symbolName.keys.toList, "btc").rightValue
 
       prices.length is marketConfig.symbolName.length
 
@@ -64,10 +64,10 @@ class MarketServiceSpec extends AlephiumFutureSpec {
     eventually {
       marketConfig.currencies.foreach { currency =>
         val prices =
-          marketService.getPrices(ArraySeq(alph, usdt), currency).futureValue.rightValue
+          marketService.getPrices(ArraySeq(alph, usdt), currency).rightValue
 
         val exchangeRate =
-          marketService.getExchangeRates().futureValue.rightValue.find(_.currency == currency).get
+          marketService.getExchangeRates().rightValue.find(_.currency == currency).get
 
         prices(0) is Some(alphPrice * exchangeRate.value)
         prices(1) is Some(usdtPrice * exchangeRate.value)
@@ -75,25 +75,25 @@ class MarketServiceSpec extends AlephiumFutureSpec {
     }
 
     eventually {
-      val prices = marketService.getPrices(ArraySeq("ALPH", "EMPTY"), "chf").futureValue.rightValue
+      val prices = marketService.getPrices(ArraySeq("ALPH", "EMPTY"), "chf").rightValue
 
       prices.length is 2
       prices(1) is None
     }
 
     eventually {
-      val exchangeRates = marketService.getExchangeRates().futureValue.rightValue
+      val exchangeRates = marketService.getExchangeRates().rightValue
       exchangeRates.map(_.currency).toSet is marketConfig.currencies.toSet
     }
 
     eventually {
-      val btcChart = marketService.getPriceChart(alph, "btc").futureValue.rightValue
+      val btcChart = marketService.getPriceChart(alph, "btc").rightValue
 
       marketConfig.currencies.foreach { currency =>
         val chart =
-          marketService.getPriceChart(alph, currency).futureValue.rightValue
+          marketService.getPriceChart(alph, currency).rightValue
         val exchangeRate =
-          marketService.getExchangeRates().futureValue.rightValue.find(_.currency == currency).get
+          marketService.getExchangeRates().rightValue.find(_.currency == currency).get
 
         chart.timestamps.length is chart.prices.length
         chart.timestamps is btcChart.timestamps
@@ -110,16 +110,8 @@ class MarketServiceSpec extends AlephiumFutureSpec {
     val usdt = "USDT"
 
     val marketConfig = ExplorerConfig.Market(
-      ListMap(
-        "ALPH" -> "alephium",
-        "USDC" -> "usd-coin",
-        "USDT" -> "tether",
-        "WBTC" -> "wrapped-bitcoin",
-        "WETH" -> "weth",
-        "DAI"  -> "dai",
-        "AYIN" -> "ayin"
-      ),
-      ArraySeq("btc", "usd", "eur", "chf", "gbp", "idr", "vnd", "rub", "try", "cad", "aud"),
+      MarketServiceSpec.symbolNames,
+      MarketServiceSpec.currencies,
       s"http://${localhost.getHostAddress()}:$port",
       marketChartDays = 366
     )
@@ -139,6 +131,18 @@ object MarketServiceSpec {
 
   val alphPrice = 2.013e-5
   val usdtPrice = 2.392e-5
+
+  val symbolNames = ListMap(
+    "ALPH" -> "alephium",
+    "USDC" -> "usd-coin",
+    "USDT" -> "tether",
+    "WBTC" -> "wrapped-bitcoin",
+    "WETH" -> "weth",
+    "DAI"  -> "dai",
+    "AYIN" -> "ayin"
+  )
+  val currencies =
+    ArraySeq("btc", "usd", "eur", "chf", "gbp", "idr", "vnd", "rub", "try", "cad", "aud")
 
   class CoingeckoMock(
       uri: InetAddress,


### PR DESCRIPTION
This avoid returning a `5xx` when someone query an unknown symbol or currency