### PR TITLE
Support more std-interfaces

### DIFF
--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -468,11 +468,15 @@
         "type": "object",
         "title": "NFT",
         "properties": {
+          "id": {
+            "type": "string"
+          },
           "type": {
             "type": "string"
           }
         },
         "required": [
+          "id",
           "type"
         ]
       },
@@ -962,11 +966,15 @@
         "type": "object",
         "title": "FungibleToken",
         "properties": {
+          "id": {
+            "type": "string"
+          },
           "type": {
             "type": "string"
           }
         },
         "required": [
+          "id",
           "type"
         ]
       },
@@ -2142,6 +2150,8 @@
                 },
                 "example": [
                   {
+                    "interfaceId": "000101",
+                    "category": "0001",
                     "stdInterfaceId": "fungible",
                     "token": "7b3efc0a1c4bc54e7398811f7e474e461a9c00cbc951f33b886a5f207c820ef2"
                   }
@@ -2235,6 +2245,8 @@
                 },
                 "example": [
                   {
+                    "interfaceId": "000101",
+                    "category": "0001",
                     "stdInterfaceId": "fungible",
                     "token": "7b3efc0a1c4bc54e7398811f7e474e461a9c00cbc951f33b886a5f207c820ef2"
                   }

--- a/app/src/main/scala/org/alephium/explorer/api/EndpointExamples.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/EndpointExamples.scala
@@ -439,7 +439,7 @@ object EndpointExamples extends EndpointsExamples {
     simpleExample(ArraySeq(logbackValue))
 
   implicit val stdInterfaceIdExample: List[Example[TokenStdInterfaceId]] =
-    simpleExample(StdInterfaceId.FungibleToken)
+    simpleExample(StdInterfaceId.FungibleToken.default)
 
   implicit val fungibleTokenMetadataExample: List[Example[FungibleTokenMetadata]] =
     simpleExample(FungibleTokenMetadata(token, "TK", "Token", U256.One))
@@ -454,7 +454,16 @@ object EndpointExamples extends EndpointsExamples {
     simpleExample(ArraySeq(NFTCollectionMetadata(addressContract, "collection://uri")))
 
   implicit val tokenInfosExample: List[Example[ArraySeq[TokenInfo]]] =
-    simpleExample(ArraySeq(TokenInfo(token, Some(StdInterfaceId.FungibleToken))))
+    simpleExample(
+      ArraySeq(
+        TokenInfo(
+          token,
+          Some(StdInterfaceId.FungibleToken.default),
+          Some(StdInterfaceId.FungibleToken("000101").id),
+          Some(StdInterfaceId.FungibleToken.default.category)
+        )
+      )
+    )
 
   implicit val amountHistory: List[Example[AmountHistory]] =
     simpleExample(AmountHistory(ArraySeq(TimedAmount(ts, U256.One.v))))

--- a/app/src/main/scala/org/alephium/explorer/api/model/StdInterfaceId.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/StdInterfaceId.scala
@@ -32,10 +32,15 @@ sealed trait TokenStdInterfaceId extends StdInterfaceId
 
 object StdInterfaceId {
 
-  case object FungibleToken extends TokenStdInterfaceId {
-    val value: String    = "fungible"
-    val id: String       = "0001"
-    val category: String = "0001"
+  final case class FungibleToken(id: String) extends TokenStdInterfaceId {
+    val value: String    = FungibleToken.value
+    val category: String = FungibleToken.category
+  }
+
+  object FungibleToken {
+    val category: String       = "0001"
+    val value: String          = "fungible"
+    val default: FungibleToken = FungibleToken(category)
   }
 
   case object NFTCollection extends StdInterfaceId {
@@ -50,10 +55,15 @@ object StdInterfaceId {
     val category: String = "0002"
   }
 
-  case object NFT extends TokenStdInterfaceId {
+  final case class NFT(id: String) extends TokenStdInterfaceId {
+    val value: String    = NFT.value
+    val category: String = NFT.category
+  }
+
+  object NFT {
     val value: String    = "non-fungible"
-    val id: String       = "0003"
     val category: String = "0003"
+    val default: NFT     = NFT(category)
   }
 
   final case class Unknown(id: String) extends TokenStdInterfaceId {
@@ -69,20 +79,20 @@ object StdInterfaceId {
 
   def from(code: String): StdInterfaceId =
     code match {
-      case "0001"   => FungibleToken
-      case "0002"   => NFTCollection
-      case "0003"   => NFT
-      case "000201" => NFTCollectionWithRoyalty
-      case ""       => NonStandard
-      case unknown  => Unknown(unknown)
+      case id if id.startsWith(FungibleToken.category) => FungibleToken(id)
+      case id if id.startsWith(NFT.category)           => NFT(id)
+      case NFTCollection.id                            => NFTCollection
+      case NFTCollectionWithRoyalty.id                 => NFTCollectionWithRoyalty
+      case ""                                          => NonStandard
+      case unknown                                     => Unknown(unknown)
     }
 
   def validate(str: String): Option[StdInterfaceId] =
     str match {
-      case FungibleToken.value            => Some(FungibleToken)
+      case FungibleToken.value            => Some(FungibleToken.default)
       case NFTCollection.value            => Some(NFTCollection)
       case NFTCollectionWithRoyalty.value => Some(NFTCollectionWithRoyalty)
-      case NFT.value                      => Some(NFT)
+      case NFT.value                      => Some(NFT.default)
       case NonStandard.value              => Some(NonStandard)
       case ""                             => Some(NonStandard)
       case other =>
@@ -123,7 +133,7 @@ object StdInterfaceId {
     )
   )
   val stdInterfaceIds: Seq[StdInterfaceId] =
-    Seq(FungibleToken, NFTCollection, NFTCollectionWithRoyalty, NFT, NonStandard)
+    Seq(FungibleToken.default, NFTCollection, NFTCollectionWithRoyalty, NFT.default, NonStandard)
 
   @SuppressWarnings(
     Array(
@@ -132,7 +142,8 @@ object StdInterfaceId {
       "org.wartremover.warts.Serializable"
     )
   )
-  val tokenStdInterfaceIds: Seq[TokenStdInterfaceId] = Seq(FungibleToken, NFT, NonStandard)
+  val tokenStdInterfaceIds: Seq[TokenStdInterfaceId] =
+    Seq(FungibleToken.default, NFT.default, NonStandard)
 
   val schema: Schema[StdInterfaceId] = Schema.string
     .name(Schema.SName("StdInterfaceId"))

--- a/app/src/main/scala/org/alephium/explorer/api/model/TokenInfo.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/TokenInfo.scala
@@ -23,7 +23,12 @@ import org.alephium.explorer.api.Schemas.tokenIdSchema
 import org.alephium.json.Json._
 import org.alephium.protocol.model.TokenId
 
-final case class TokenInfo(token: TokenId, stdInterfaceId: Option[TokenStdInterfaceId])
+final case class TokenInfo(
+    token: TokenId,
+    stdInterfaceId: Option[TokenStdInterfaceId],
+    interfaceId: Option[String],
+    category: Option[String]
+)
 
 object TokenInfo {
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/Migrations.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/Migrations.scala
@@ -31,9 +31,21 @@ import org.alephium.explorer.persistence.schema.CustomGetResult._
 @SuppressWarnings(Array("org.wartremover.warts.AnyVal"))
 object Migrations extends StrictLogging {
 
-  val latestVersion: MigrationVersion = MigrationVersion(0)
+  val latestVersion: MigrationVersion = MigrationVersion(1)
 
-  private val migrations: Seq[DBActionAll[Unit]] = Seq()
+  def migration1(implicit ec: ExecutionContext): DBActionAll[Unit] = {
+    // We retrigger the download of fungible and non-fungible tokens' metadata that have sub-category
+    for {
+      _ <-
+        sqlu"""UPDATE token_info SET interface_id = NULL WHERE category = '0001' AND interface_id != '0001'"""
+      _ <-
+        sqlu"""UPDATE token_info SET interface_id = NULL WHERE category = '0003' AND interface_id != '0003'"""
+    } yield ()
+  }
+
+  private def migrations(implicit ec: ExecutionContext): Seq[DBActionAll[Unit]] = Seq(
+    migration1
+  )
 
   def migrationsQuery(
       versionOpt: Option[MigrationVersion]

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/TokenInfoEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/TokenInfoEntity.scala
@@ -26,14 +26,19 @@ final case class TokenInfoEntity(
     category: Option[String],
     interfaceId: Option[InterfaceIdEntity]
 ) {
-  def toApi(): TokenInfo =
-    TokenInfo(
-      token,
+  def toApi(): TokenInfo = {
+    val stdInterfaceId =
       interfaceId.map(
         _.toApi match {
           case tokenInterface: TokenStdInterfaceId => tokenInterface
           case other                               => StdInterfaceId.Unknown(other.id)
         }
       )
+    TokenInfo(
+      token,
+      stdInterfaceId,
+      stdInterfaceId.map(_.id),
+      stdInterfaceId.map(_.category)
     )
+  }
 }

--- a/app/src/test/scala/org/alephium/explorer/GenApiModel.scala
+++ b/app/src/test/scala/org/alephium/explorer/GenApiModel.scala
@@ -347,10 +347,10 @@ object GenApiModel extends ImplicitConversions {
   val stdInterfaceIdGen: Gen[StdInterfaceId] =
     Gen.oneOf(
       ArraySeq(
-        StdInterfaceId.FungibleToken,
+        StdInterfaceId.FungibleToken.default,
         StdInterfaceId.NFTCollection,
         StdInterfaceId.NFTCollectionWithRoyalty,
-        StdInterfaceId.NFT,
+        StdInterfaceId.NFT.default,
         StdInterfaceId.Unknown("1234"),
         StdInterfaceId.NonStandard
       )
@@ -366,8 +366,8 @@ object GenApiModel extends ImplicitConversions {
   val tokenInterfaceIdGen: Gen[StdInterfaceId] =
     Gen.oneOf(
       ArraySeq(
-        StdInterfaceId.FungibleToken,
-        StdInterfaceId.NFT,
+        StdInterfaceId.FungibleToken.default,
+        StdInterfaceId.NFT.default,
         StdInterfaceId.NonStandard
       )
     )


### PR DESCRIPTION
We now support all sub-categories of fungible and non-fungible tokens.

We added some details to the token info model.

Some sample of the metadata of the new nfts:

```
[
  {
    "id": "6edf83ae037e737df3d38d9ad372cd7bf30081c7e113c57a88018627ca13eb00",
    "tokenUri": "data:application/json,{\"name\":\"CryptocurrencyInvestment\"}",
    "collectionId": "6ed2028d263833ada7d8ac87b4478278f2e58e09ddbe819e623b17ba9e6cae00",
    "nftIndex": "171"
  },
  {
    "id": "292edbb29c0ef0fc2f9d8a3e75bdca8c8f0c52d18900694b206262908692a000",
    "tokenUri": "data:application/json,{\"name\":\"cryptopope\"}",
    "collectionId": "6ed2028d263833ada7d8ac87b4478278f2e58e09ddbe819e623b17ba9e6cae00",
    "nftIndex": "15"
  },
  {
    "id": "e5a5c88d739f9a3ba6283cf7a1eaab469ec5bd76c123caefe11254c4b62add00",
    "tokenUri": "data:application/json,{\"name\":\"charizard\"}",
    "collectionId": "6ed2028d263833ada7d8ac87b4478278f2e58e09ddbe819e623b17ba9e6cae00",
    "nftIndex": "41"
  }
]
```

The new token info model looks like this:

```
[
  {
    "token": "bb3768cd6265394e6b1f1a465549106446025b1ef1e0565d144a5f73e8034400",
    "stdInterfaceId": "non-fungible",
    "interfaceId": "000301",
    "category": "0003"
  }
]
```
