### PR TITLE
Jvm metrics

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/Metrics.scala
+++ b/app/src/main/scala/org/alephium/explorer/Metrics.scala
@@ -19,14 +19,8 @@ package org.alephium.explorer
 import scala.concurrent.Future
 
 import io.prometheus.metrics.model.registry.PrometheusRegistry
-import io.vertx.ext.web._
-import sttp.monad.MonadError
-import sttp.tapir._
-import sttp.tapir.server.ServerEndpoint
 import sttp.tapir.server.metrics.MetricLabels
 import sttp.tapir.server.metrics.prometheus.PrometheusMetrics
-import sttp.tapir.server.metrics.prometheus.PrometheusMetrics._
-import sttp.tapir.server.vertx.VertxFutureServerInterpreter
 
 object Metrics {
   val defaultRegistry: PrometheusRegistry = PrometheusRegistry.defaultRegistry
@@ -38,22 +32,6 @@ object Metrics {
       PrometheusMetrics.requestTotal(defaultRegistry, namespace, MetricLabels.Default),
       PrometheusMetrics.requestDuration(defaultRegistry, namespace, MetricLabels.Default),
       PrometheusMetrics.requestActive(defaultRegistry, namespace, MetricLabels.Default)
-    )
-  )
-
-  /** Endpoint to expose the metrics
-    *
-    * @param callback
-    *   a block of code to execute before serving the metrics, for example to reload
-    */
-  def endpoint(callback: => Unit): Router => Route = VertxFutureServerInterpreter().route(
-    ServerEndpoint.public(
-      sttp.tapir.endpoint.get.in(prometheus.endpointPrefix).out(plainBody[PrometheusRegistry]),
-      (monad: MonadError[Future]) =>
-        (_: Unit) => {
-          callback
-          monad.eval(Right(defaultRegistry): Either[Unit, PrometheusRegistry])
-        }
     )
   )
 }

--- a/app/src/main/scala/org/alephium/explorer/api/MetricsEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/MetricsEndpoints.scala
@@ -1,0 +1,30 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.api
+
+import sttp.tapir._
+
+import org.alephium.api.alphPlainTextBody
+
+trait MetricsEndpoints extends BaseEndpoint with QueryParams {
+
+  val metrics: BaseEndpoint[Unit, String] =
+    baseEndpoint
+      .in("metrics")
+      .out(alphPlainTextBody)
+      .summary("Exports all prometheus metrics")
+}

--- a/app/src/main/scala/org/alephium/explorer/web/MetricsServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/MetricsServer.scala
@@ -16,22 +16,45 @@
 
 package org.alephium.explorer.web
 
-import scala.collection.immutable.ArraySeq
-import scala.concurrent.ExecutionContext
+import java.io.StringWriter
 
+import scala.collection.immutable.ArraySeq
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Using
+
+import io.prometheus.client.CollectorRegistry
+import io.prometheus.client.exporter.common.TextFormat
 import io.prometheus.metrics.core.metrics.Gauge
 import io.vertx.ext.web._
+import sttp.tapir.server.metrics.prometheus.PrometheusMetrics.prometheusRegistryCodec
 
 import org.alephium.explorer.Metrics
+import org.alephium.explorer.api.MetricsEndpoints
 import org.alephium.explorer.cache.MetricCache
+import org.alephium.util.discard
 
 class MetricsServer(cache: MetricCache)(implicit
     val executionContext: ExecutionContext
-) extends Server {
+) extends Server
+    with MetricsEndpoints {
 
   val routes: ArraySeq[Router => Route] =
     ArraySeq(
-      Metrics.endpoint(reloadMetrics())
+      route(metrics.serverLogicSuccess[Future] { _ =>
+        Future.successful {
+          // Reload metrics cache on request
+          discard(reloadMetrics())
+          Using(new StringWriter()) { writer =>
+            // Scrape metrics from CollectorRegistry (jvm)
+            TextFormat.write004(writer, CollectorRegistry.defaultRegistry.metricFamilySamples())
+            // Scrape  metrics from PrometheusRegistry (tapir, HikariCP, etc.)
+            writer.write(prometheusRegistryCodec.encode(Metrics.defaultRegistry))
+            writer.toString
+          }.getOrElse("")
+
+        }
+
+      })
     )
 
   def reloadMetrics(): Unit = {

--- a/app/src/main/scala/org/alephium/explorer/web/MetricsServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/MetricsServer.scala
@@ -35,13 +35,13 @@ class MetricsServer(cache: MetricCache)(implicit
     )
 
   def reloadMetrics(): Unit = {
-    MetricServer.fungibleCountGauge.set(cache.getFungibleCount().toDouble)
-    MetricServer.nftCountGauge.set(cache.getNFTCount().toDouble)
-    MetricServer.eventCountGauge.set(cache.getEventCount().toDouble)
+    MetricsServer.fungibleCountGauge.set(cache.getFungibleCount().toDouble)
+    MetricsServer.nftCountGauge.set(cache.getNFTCount().toDouble)
+    MetricsServer.eventCountGauge.set(cache.getEventCount().toDouble)
   }
 }
 
-object MetricServer {
+object MetricsServer {
   val fungibleCountGauge: Gauge = Gauge
     .builder()
     .name(

--- a/build.sbt
+++ b/build.sbt
@@ -194,6 +194,7 @@ lazy val app = mainProject("app")
       slickHikaricp,
       postgresql,
       prometheusSimpleClient,
+      prometheusSimpleClientCommon,
       prometheusSimpleClientHotspot,
       tapirPrometheusMetrics,
       micrometerCore,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -77,6 +77,8 @@ object Dependencies {
   lazy val slickHikaricp = "com.typesafe.slick" %% "slick-hikaricp" % Version.slick
 
   lazy val prometheusSimpleClient = "io.prometheus" % "simpleclient" % Version.prometheus
+  lazy val prometheusSimpleClientCommon =
+    "io.prometheus" % "simpleclient_common" % Version.prometheus
   lazy val prometheusSimpleClientHotspot =
     "io.prometheus" % "simpleclient_hotspot" % Version.prometheus
   lazy val tapirPrometheusMetrics =


### PR DESCRIPTION
Resolves: https://github.com/alephium/explorer-backend/issues/565

They are actually two different registries and `DefaultExports.initialize`
write to `CollectorRegistry` while tapir and HikariCP are writting to
`PrometheusRegistry`.

Only the second one was exposed through the metrics endpoint.