### PR TITLE
Improve post addresses transactions

### DIFF
--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -5472,6 +5472,28 @@
         "parameters": [
           {
             "schema": {
+              "format": "int64",
+              "type": "integer",
+              "minimum": "0"
+            },
+            "in": "query",
+            "name": "fromTs",
+            "description": "inclusive",
+            "required": false
+          },
+          {
+            "schema": {
+              "format": "int64",
+              "type": "integer",
+              "minimum": "0"
+            },
+            "in": "query",
+            "name": "toTs",
+            "description": "exclusive",
+            "required": false
+          },
+          {
+            "schema": {
               "format": "int32",
               "type": "integer",
               "minimum": "1"

--- a/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
@@ -31,7 +31,7 @@ import org.alephium.explorer.api.EndpointExamples._
 import org.alephium.explorer.api.model._
 import org.alephium.protocol.PublicKey
 import org.alephium.protocol.model.{Address, TokenId}
-import org.alephium.util.Duration
+import org.alephium.util.{Duration, TimeStamp}
 
 // scalastyle:off magic.number
 trait AddressesEndpoints extends BaseEndpoint with QueryParams {
@@ -73,14 +73,16 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
       .out(jsonBody[ArraySeq[Transaction]])
       .description("List transactions of a given address")
 
-  lazy val getTransactionsByAddresses
-      : BaseEndpoint[(ArraySeq[Address], Pagination), ArraySeq[Transaction]] =
+  // format: off
+  lazy val getTransactionsByAddresses: BaseEndpoint[(ArraySeq[Address], Option[TimeStamp], Option[TimeStamp], Pagination), ArraySeq[Transaction]] =
     baseAddressesEndpoint.post
       .in(arrayBody[Address]("addresses", maxSizeAddresses))
       .in("transactions")
+      .in(optionalTimeIntervalQuery)
       .in(pagination)
       .out(jsonBody[ArraySeq[Transaction]])
       .description("List transactions for given addresses")
+  // format: on
 
   val getTransactionsByAddressTimeRanged
       : BaseEndpoint[(Address, TimeInterval, Pagination), ArraySeq[Transaction]] =

--- a/app/src/main/scala/org/alephium/explorer/api/QueryParams.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/QueryParams.scala
@@ -97,6 +97,17 @@ trait QueryParams extends TapirCodecs {
         }
       })
 
+  val optionalTimeIntervalQuery: EndpointInput[(Option[TimeStamp], Option[TimeStamp])] =
+    query[Option[TimeStamp]]("fromTs")
+      .description("inclusive")
+      .and(query[Option[TimeStamp]]("toTs").description("exclusive"))
+      .validate(Validator.custom {
+        case (Some(fromTs), Some(toTs)) if fromTs >= toTs =>
+          ValidationResult.Invalid(s"`fromTs` must be before `toTs`")
+        case _ =>
+          ValidationResult.Valid
+      })
+
   val intervalTypeQuery: EndpointInput[IntervalType] =
     query[IntervalType]("interval-type")
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/dao/TransactionDao.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/dao/TransactionDao.scala
@@ -42,11 +42,16 @@ object TransactionDao {
   ): Future[ArraySeq[Transaction]] =
     run(getTransactionsByAddress(address, pagination))
 
-  def getByAddresses(addresses: ArraySeq[Address], pagination: Pagination)(implicit
+  def getByAddresses(
+      addresses: ArraySeq[Address],
+      fromTime: Option[TimeStamp],
+      toTime: Option[TimeStamp],
+      pagination: Pagination
+  )(implicit
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]
   ): Future[ArraySeq[Transaction]] =
-    run(getTransactionsByAddresses(addresses, pagination))
+    run(getTransactionsByAddresses(addresses, fromTime, toTime, pagination))
 
   def getByAddressTimeRanged(
       address: Address,

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
@@ -196,7 +196,7 @@ object TransactionQueries extends StrictLogging {
 
       val query =
         s"""
-           SELECT ${TxByAddressQR.selectFields}
+           SELECT DISTINCT ${TxByAddressQR.selectFields}
            FROM transaction_per_addresses
            WHERE main_chain = true
              AND address IN $placeholder

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
@@ -182,11 +182,17 @@ object TransactionQueries extends StrictLogging {
     *   Page number (starting from 0)
     * @param limit
     *   Maximum rows
+    * @param fromTs
+    *   From TimeStamp of the time-range (inclusive)
+    * @param toTs
+    *   To TimeStamp of the time-range (exclusive)
     * @return
     *   Paginated transactions
     */
   def getTxHashesByAddressesQuery(
       addresses: ArraySeq[Address],
+      fromTs: Option[TimeStamp],
+      toTs: Option[TimeStamp],
       pagination: Pagination
   ): DBActionSR[TxByAddressQR] =
     if (addresses.isEmpty) {
@@ -200,6 +206,8 @@ object TransactionQueries extends StrictLogging {
            FROM transaction_per_addresses
            WHERE main_chain = true
              AND address IN $placeholder
+             ${fromTs.map(ts => s"AND block_timestamp >= ${ts.millis}").getOrElse("")}
+             ${toTs.map(ts => s"AND block_timestamp < ${ts.millis}").getOrElse("")}
            ORDER BY block_timestamp DESC, tx_order
            """
 
@@ -273,11 +281,16 @@ object TransactionQueries extends StrictLogging {
     } yield txs
   }
 
-  def getTransactionsByAddresses(addresses: ArraySeq[Address], pagination: Pagination)(implicit
+  def getTransactionsByAddresses(
+      addresses: ArraySeq[Address],
+      fromTime: Option[TimeStamp],
+      toTime: Option[TimeStamp],
+      pagination: Pagination
+  )(implicit
       ec: ExecutionContext
   ): DBActionR[ArraySeq[Transaction]] = {
     for {
-      txHashesTs <- getTxHashesByAddressesQuery(addresses, pagination)
+      txHashesTs <- getTxHashesByAddressesQuery(addresses, fromTime, toTime, pagination)
       txs        <- getTransactions(txHashesTs)
     } yield txs
   }

--- a/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
@@ -68,7 +68,12 @@ trait TransactionService {
       dc: DatabaseConfig[PostgresProfile]
   ): Future[Option[TransactionInfo]]
 
-  def getTransactionsByAddresses(addresses: ArraySeq[Address], pagination: Pagination)(implicit
+  def getTransactionsByAddresses(
+      addresses: ArraySeq[Address],
+      fromTime: Option[TimeStamp],
+      toTime: Option[TimeStamp],
+      pagination: Pagination
+  )(implicit
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]
   ): Future[ArraySeq[Transaction]]
@@ -168,11 +173,16 @@ object TransactionService extends TransactionService {
   ): Future[Option[TransactionInfo]] =
     TransactionDao.getLatestTransactionInfoByAddress(address)
 
-  def getTransactionsByAddresses(addresses: ArraySeq[Address], pagination: Pagination)(implicit
+  def getTransactionsByAddresses(
+      addresses: ArraySeq[Address],
+      fromTime: Option[TimeStamp],
+      toTime: Option[TimeStamp],
+      pagination: Pagination
+  )(implicit
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]
   ): Future[ArraySeq[Transaction]] =
-    TransactionDao.getByAddresses(addresses, pagination)
+    TransactionDao.getByAddresses(addresses, fromTime, toTime, pagination)
 
   def listMempoolTransactionsByAddress(address: Address)(implicit
       ec: ExecutionContext,

--- a/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
@@ -63,9 +63,10 @@ class AddressServer(
         transactionService
           .getTransactionsByAddress(address, pagination)
       }),
-      route(getTransactionsByAddresses.serverLogicSuccess[Future] { case (addresses, pagination) =>
-        transactionService
-          .getTransactionsByAddresses(addresses, pagination)
+      route(getTransactionsByAddresses.serverLogicSuccess[Future] {
+        case (addresses, fromTsOpt, toTsOpt, pagination) =>
+          transactionService
+            .getTransactionsByAddresses(addresses, fromTsOpt, toTsOpt, pagination)
       }),
       route(getTransactionsByAddressTimeRanged.serverLogicSuccess[Future] {
         case (address, timeInterval, pagination) =>

--- a/app/src/test/scala/org/alephium/explorer/service/EmptyTransactionService.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/EmptyTransactionService.scala
@@ -51,8 +51,12 @@ trait EmptyTransactionService extends TransactionService {
   ): Future[ArraySeq[Transaction]] =
     Future.successful(ArraySeq.empty)
 
-  override def getTransactionsByAddresses(addresses: ArraySeq[Address], pagination: Pagination)(
-      implicit
+  override def getTransactionsByAddresses(
+      addresses: ArraySeq[Address],
+      fromTs: Option[TimeStamp],
+      toTs: Option[TimeStamp],
+      pagination: Pagination
+  )(implicit
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]
   ): Future[ArraySeq[Transaction]] =


### PR DESCRIPTION
`POST /addresses/transactions` was returning duplicate tx if multiple addresses of to the body share some common tx.

We also added `fromTs` and `toTs` optional query params to that endpoint to ease the pagination work. 