### PR TITLE
Fix sub-contracts endpoint returning duplicate

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/ContractQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/ContractQueries.scala
@@ -141,10 +141,14 @@ object ContractQueries {
   def getSubContractsQuery(parent: Address, pagination: Pagination): DBActionSR[Address] = {
     sql"""
       SELECT contract
-      FROM contracts
-      WHERE parent = $parent
+      FROM (
+        SELECT DISTINCT ON (contract) contract, creation_timestamp, creation_event_order
+        FROM contracts
+        WHERE parent = $parent
+        ORDER BY contract, creation_timestamp DESC, creation_event_order
+      ) AS distinct_contracts
       ORDER BY creation_timestamp DESC, creation_event_order
-      """
+    """
       .paginate(pagination)
       .asASE[Address](addressGetResult)
   }


### PR DESCRIPTION
Fixes: https://github.com/alephium/explorer-backend/issues/560

In database we can have multiple entry for a same contract, if it was destroyed and recreated, that's why we had duplicated values