### PR TITLE
Remove unnecessary `DISTINCT`

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
@@ -165,7 +165,7 @@ object TransactionQueries extends StrictLogging {
       pagination: Pagination
   ): DBActionSR[TxByAddressQR] = {
     sql"""
-      SELECT DISTINCT #${TxByAddressQR.selectFields}
+      SELECT #${TxByAddressQR.selectFields}
       FROM transaction_per_addresses
       WHERE main_chain = true AND address = $address
       ORDER BY block_timestamp DESC, tx_order


### PR DESCRIPTION
Now that we fixed the coinbase value and as we are querying for only 1 address, we will already receive a distinct set of transactions.