### PR TITLE
[WIP] Fix chart price conversion

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/service/MarketService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/MarketService.scala
@@ -50,7 +50,6 @@ trait MarketService {
 }
 
 object MarketService extends StrictLogging {
-  val baseCurrency: String = "usd"
 
   object Impl {
     def default(marketConfig: ExplorerConfig.Market)(implicit
@@ -297,7 +296,7 @@ object MarketService extends StrictLogging {
     ): Future[Either[String, ArraySeq[(TimeStamp, Double)]]] = {
       logger.debug(s"Query coingecko `/coins/$id/market_chart`, nb of attempts $retried")
       request(
-        uri"$coingeckoBaseUri/coins/$id/market_chart?vs_currency=$baseCurrency&days=${marketConfig.marketChartDays}"
+        uri"$coingeckoBaseUri/coins/$id/market_chart?vs_currency=btc&days=${marketConfig.marketChartDays}"
       ) { response =>
         handleChartResponse(id, response, retried)
       }


### PR DESCRIPTION
while migrating to mobula, the base currency value was changed to `usd` as it's the one used by mobula, but then we didn't use anymore this value and we were requesting the chart price from coingecko in `usd`, but we were expecting charts to be in `btc`.

Before the fix the alph price in usd:

![image](https://github.com/user-attachments/assets/3bd2ca0e-2033-4d1b-903d-db12285bbe5a)

after the fix 

![image](https://github.com/user-attachments/assets/c861d77c-e698-44a9-9fa9-721f0453ed3b)
