### PR TITLE
Improve balance query

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/persistence/DBInitializer.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/DBInitializer.scala
@@ -113,6 +113,7 @@ object DBInitializer extends StrictLogging {
       _ <- OutputSchema.createMainChainIndex()
       _ <- TransactionPerAddressSchema.createIndexes()
       _ <- OutputSchema.createNonSpentIndex()
+      _ <- OutputSchema.createNonSpentOutputCoveringIndex()
       _ <- InputSchema.createOutputRefAddressNullIndex()
       _ <- TransactionPerTokenSchema.createIndexes()
       _ <- TokenPerAddressSchema.createIndexes()

--- a/app/src/main/scala/org/alephium/explorer/persistence/Migrations.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/Migrations.scala
@@ -103,7 +103,9 @@ object Migrations extends StrictLogging {
   private def migrations(implicit ec: ExecutionContext): Seq[DBActionAll[Unit]] = Seq(
     migration1,
     migration2,
-    migration3
+    migration3,
+    migration4,
+    migration5
   )
 
   def backgroundCoinbaseMigration()(implicit

--- a/app/src/main/scala/org/alephium/explorer/persistence/Migrations.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/Migrations.scala
@@ -36,7 +36,7 @@ import org.alephium.protocol.model.BlockHash
 @SuppressWarnings(Array("org.wartremover.warts.AnyVal"))
 object Migrations extends StrictLogging {
 
-  val latestVersion: MigrationVersion = MigrationVersion(5)
+  val latestVersion: MigrationVersion = MigrationVersion(4)
 
   def migration1(implicit ec: ExecutionContext): DBActionAll[Unit] = {
     // We retrigger the download of fungible and non-fungible tokens' metadata that have sub-category
@@ -91,21 +91,11 @@ object Migrations extends StrictLogging {
    */
   def migration4: DBActionAll[Unit] = DBIOAction.successful(())
 
-  def migration5(implicit ec: ExecutionContext): DBActionAll[Unit] = {
-    for {
-      _ <-
-        sqlu"""
-        CREATE INDEX IF NOT EXISTS idx_inputs_ref_address_main_chain_timestamp ON inputs (output_ref_address, main_chain, block_timestamp);
-        """
-    } yield ()
-  }
-
   private def migrations(implicit ec: ExecutionContext): Seq[DBActionAll[Unit]] = Seq(
     migration1,
     migration2,
     migration3,
-    migration4,
-    migration5
+    migration4
   )
 
   def backgroundCoinbaseMigration()(implicit

--- a/app/src/main/scala/org/alephium/explorer/persistence/dao/TransactionDao.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/dao/TransactionDao.scala
@@ -78,9 +78,10 @@ object TransactionDao {
     run(countAddressTransactions(address)).map(_.headOption.getOrElse(0))
 
   def getBalance(
-      address: Address
+      address: Address,
+      latestFinalizedTimestamp: TimeStamp
   )(implicit ec: ExecutionContext, dc: DatabaseConfig[PostgresProfile]): Future[(U256, U256)] =
-    run(getBalanceAction(address))
+    run(getBalanceAction(address, latestFinalizedTimestamp))
 
   def areAddressesActive(
       addresses: ArraySeq[Address]

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/OutputQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/OutputQueries.scala
@@ -421,15 +421,11 @@ object OutputQueries {
         AND key = $key
     """
 
-  def getBalanceActionOption(
-      address: Address
-  )(implicit ec: ExecutionContext): DBActionR[(Option[U256], Option[U256])] =
-    getBalanceUntilLockTime(
-      address = address,
-      lockTime = TimeStamp.now()
-    )
-
-  def getBalanceUntilLockTime(address: Address, lockTime: TimeStamp)(implicit
+  def getBalanceUntilLockTime(
+      address: Address,
+      lockTime: TimeStamp,
+      latestFinalizedTimestamp: TimeStamp
+  )(implicit
       ec: ExecutionContext
   ): DBActionR[(Option[U256], Option[U256])] =
     sql"""
@@ -442,6 +438,8 @@ object OutputQueries {
                LEFT JOIN inputs
                          ON outputs.key = inputs.output_ref_key
                              AND inputs.main_chain = true
+                             AND inputs.output_ref_address = $address
+                             AND inputs.block_timestamp > ${latestFinalizedTimestamp.millis}
       WHERE outputs.spent_finalized IS NULL
         AND outputs.address = $address
         AND outputs.main_chain = true

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
@@ -564,10 +564,13 @@ object TransactionQueries extends StrictLogging {
       ).asAS[Address]
     }
 
-  def getBalanceAction(address: Address)(implicit ec: ExecutionContext): DBActionR[(U256, U256)] =
+  def getBalanceAction(address: Address, latestFinalizedTimestamp: TimeStamp)(implicit
+      ec: ExecutionContext
+  ): DBActionR[(U256, U256)] =
     getBalanceUntilLockTime(
       address = address,
-      lockTime = TimeStamp.now()
+      lockTime = TimeStamp.now(),
+      latestFinalizedTimestamp = latestFinalizedTimestamp
     ) map { case (total, locked) =>
       (total.getOrElse(U256.Zero), locked.getOrElse(U256.Zero))
     }

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/InputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/InputSchema.scala
@@ -62,9 +62,6 @@ object InputSchema extends SchemaMainChain[InputEntity]("inputs") {
     def inputsBlockHashTxHashIdx: Index =
       index("inputs_tx_hash_block_hash_idx", (txHash, blockHash))
 
-    def idxInputsRefAddressMainChainTimestamp: Index =
-      index("idx_inputs_ref_address_main_chain_timestamp", (outputRefAddress, mainChain, timestamp))
-
     def * : ProvenShape[InputEntity] =
       (
         blockHash,
@@ -89,6 +86,11 @@ object InputSchema extends SchemaMainChain[InputEntity]("inputs") {
     sqlu"""CREATE INDEX IF NOT EXISTS inputs_output_ref_amount_null_idx
       ON #${name} (output_ref_tx_hash, output_ref_address, output_ref_amount, output_ref_tokens)
       WHERE output_ref_amount IS NULL"""
+
+  def createOutupRefAddressMainChainTimestampIndex(): DBActionW[Int] =
+    sqlu"""
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS inputs_ref_address_main_chain_timestamp_idx ON inputs (output_ref_address, main_chain, block_timestamp);
+    """
 
   val table: TableQuery[Inputs] = TableQuery[Inputs]
 }

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/InputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/InputSchema.scala
@@ -62,6 +62,9 @@ object InputSchema extends SchemaMainChain[InputEntity]("inputs") {
     def inputsBlockHashTxHashIdx: Index =
       index("inputs_tx_hash_block_hash_idx", (txHash, blockHash))
 
+    def idxInputsRefAddressMainChainTimestamp: Index =
+      index("idx_inputs_ref_address_main_chain_timestamp", (outputRefAddress, mainChain, timestamp))
+
     def * : ProvenShape[InputEntity] =
       (
         blockHash,

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/OutputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/OutputSchema.scala
@@ -92,8 +92,9 @@ object OutputSchema extends SchemaMainChain[OutputEntity]("outputs") {
 
   def createNonSpentOutputCoveringIndex(): DBActionW[Int] =
     sqlu"""
-      CREATE INDEX IF NOT EXISTS non_spent_output_covering_idx
-      ON #${name} (address, main_chain, spent_finalized, key, amount, lock_time)
+      CREATE INDEX non_spent_output_covering_include_idx
+      ON #${name} (address, main_chain, spent_finalized, key)
+      INCLUDE (amount, lock_time)
       WHERE spent_finalized IS NULL AND main_chain = true;
     """
   val table: TableQuery[Outputs] = TableQuery[Outputs]

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/OutputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/OutputSchema.scala
@@ -92,7 +92,7 @@ object OutputSchema extends SchemaMainChain[OutputEntity]("outputs") {
 
   def createNonSpentOutputCoveringIndex(): DBActionW[Int] =
     sqlu"""
-      CREATE INDEX non_spent_output_covering_include_idx
+      CREATE INDEX IF NOT EXISTS non_spent_output_covering_include_idx
       ON #${name} (address, main_chain, spent_finalized, key)
       INCLUDE (amount, lock_time)
       WHERE spent_finalized IS NULL AND main_chain = true;

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/OutputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/OutputSchema.scala
@@ -90,5 +90,11 @@ object OutputSchema extends SchemaMainChain[OutputEntity]("outputs") {
   def createNonSpentIndex(): DBActionW[Int] =
     sqlu"create unique index if not exists non_spent_output_idx on #${name} (address, main_chain, key, block_hash) where spent_finalized IS NULL;"
 
+  def createNonSpentOutputCoveringIndex(): DBActionW[Int] =
+    sqlu"""
+      CREATE INDEX IF NOT EXISTS non_spent_output_covering_idx
+      ON #${name} (address, main_chain, spent_finalized, key, amount, lock_time)
+      WHERE spent_finalized IS NULL AND main_chain = true;
+    """
   val table: TableQuery[Outputs] = TableQuery[Outputs]
 }

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/OutputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/OutputSchema.scala
@@ -92,7 +92,7 @@ object OutputSchema extends SchemaMainChain[OutputEntity]("outputs") {
 
   def createNonSpentOutputCoveringIndex(): DBActionW[Int] =
     sqlu"""
-      CREATE INDEX IF NOT EXISTS non_spent_output_covering_include_idx
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS non_spent_output_covering_include_idx
       ON #${name} (address, main_chain, spent_finalized, key)
       INCLUDE (amount, lock_time)
       WHERE spent_finalized IS NULL AND main_chain = true;

--- a/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
@@ -88,7 +88,8 @@ trait TransactionService {
   )(implicit ec: ExecutionContext, dc: DatabaseConfig[PostgresProfile]): Future[Int]
 
   def getBalance(
-      address: Address
+      address: Address,
+      latestFinalizedBlock: TimeStamp
   )(implicit ec: ExecutionContext, dc: DatabaseConfig[PostgresProfile]): Future[(U256, U256)]
 
   def getTotalNumber()(implicit cache: TransactionCache): Int
@@ -197,9 +198,10 @@ object TransactionService extends TransactionService {
     TransactionDao.getNumberByAddress(address)
 
   def getBalance(
-      address: Address
+      address: Address,
+      latestFinalizedBlock: TimeStamp
   )(implicit ec: ExecutionContext, dc: DatabaseConfig[PostgresProfile]): Future[(U256, U256)] =
-    TransactionDao.getBalance(address)
+    TransactionDao.getBalance(address, latestFinalizedBlock)
 
   def listMempoolTransactions(pagination: Pagination)(implicit
       ec: ExecutionContext,

--- a/app/src/test/scala/org/alephium/explorer/ExplorerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/ExplorerSpec.scala
@@ -396,7 +396,7 @@ trait ExplorerSpec
               tx.outputs.exists(_.address == address) || tx.inputs
                 .exists(_.address == Some(address))
             }
-          }.distinct
+          }
 
         val res = response.as[ArraySeq[Transaction]]
 

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/OutputQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/OutputQueriesSpec.scala
@@ -28,6 +28,7 @@ import org.alephium.explorer.persistence.queries.result.{OutputsFromTxQR, Output
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.explorer.persistence.schema.OutputSchema
 import org.alephium.explorer.util.SlickExplainUtil._
+import org.alephium.util.TimeStamp
 
 class OutputQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with DBRunner {
 
@@ -186,11 +187,14 @@ class OutputQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForEach w
     }
   }
 
-  "getBalanceActionOption" should {
+  "getBalanceAction" should {
     "return None" when {
       "address does not exist" in {
         val address = addressGen.sample getOrElse fail("Failed to sample address")
-        run(getBalanceActionOption(address)).futureValue is ((None, None))
+        run(getBalanceUntilLockTime(address, TimeStamp.now(), TimeStamp.now())).futureValue is ((
+          None,
+          None
+        ))
       }
     }
   }

--- a/app/src/test/scala/org/alephium/explorer/service/EmptyTransactionService.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/EmptyTransactionService.scala
@@ -87,7 +87,8 @@ trait EmptyTransactionService extends TransactionService {
   }
 
   override def getBalance(
-      address: Address
+      address: Address,
+      from: TimeStamp
   )(implicit ec: ExecutionContext, dc: DatabaseConfig[PostgresProfile]): Future[(U256, U256)] =
     Future.successful((U256.Zero, U256.Zero))
 

--- a/app/src/test/scala/org/alephium/explorer/service/HolderServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/HolderServiceSpec.scala
@@ -87,7 +87,7 @@ class HolderServiceSpec extends AlephiumActorSpecLike with DatabaseFixtureForEac
       val addresses = blocks.flatMap(_.transactions.flatMap(_.unsigned.fixedOutputs.map(_.address)))
 
       addresses.distinct.foreach { address =>
-        val (balance, _)  = TransactionDao.getBalance(address).futureValue
+        val (balance, _)  = TransactionDao.getBalance(address, TimeStamp.zero).futureValue
         val holderBalance = holders.find(_._1 == address).map(_._2).getOrElse(U256.Zero)
 
         balance is holderBalance

--- a/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
@@ -40,6 +40,7 @@ import org.alephium.explorer.GenCoreProtocol._
 import org.alephium.explorer.HttpFixture._
 import org.alephium.explorer.api.Json._
 import org.alephium.explorer.api.model._
+import org.alephium.explorer.cache.{BlockCache, TestBlockCache}
 import org.alephium.explorer.persistence.DatabaseFixtureForAll
 import org.alephium.explorer.service.{
   EmptyTokenService,
@@ -191,6 +192,8 @@ class AddressServerSpec()
         tokens.map(res => (res.tokenId, res.balance, res.lockedBalance))
       }
   }
+
+  implicit val blockCache: BlockCache = TestBlockCache()
 
   val server =
     new AddressServer(

--- a/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/DBBenchmark.scala
+++ b/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/DBBenchmark.scala
@@ -163,7 +163,10 @@ class DBBenchmark {
     import state.executionContext
 
     val _ =
-      state.db.runNow(TransactionQueries.getBalanceAction(state.address), requestTimeout)
+      state.db.runNow(
+        TransactionQueries.getBalanceAction(state.address, TimeStamp.zero),
+        requestTimeout
+      )
   }
 
   @Benchmark
@@ -188,7 +191,7 @@ class DBBenchmark {
 
     val _ = Await.result(
       for {
-        _ <- TransactionDao.getBalance(state.address)
+        _ <- TransactionDao.getBalance(state.address, TimeStamp.zero)
         _ <- TransactionDao.getNumberByAddress(state.address)
       } yield (),
       requestTimeout

--- a/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/AddressReadState.scala
+++ b/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/AddressReadState.scala
@@ -221,6 +221,7 @@ class AddressReadState(val db: DBExecutor)
         .andThen(OutputSchema.createMainChainIndex())
         .andThen(TransactionPerAddressSchema.createMainChainIndex())
         .andThen(OutputSchema.createNonSpentIndex())
+        .andThen(OutputSchema.createNonSpentOutputCoveringIndex())
 
     val _ = db.runNow(
       action = createTable,


### PR DESCRIPTION
The balance query was slow on addresses with a lot of unspent output.

Reducing the scope of the query with the address and the finalized timestamp + specific indexes improves a lot the query.

Here is some benchmarks, I made a lot of them but make a resume here

Example are done with some of our slowest addresses (extracted from the google cloud logs), they are in the top addresses in term of unspent output, around 150'000 of them. Queries were done on my local explorer backend. 

We have those various scenario:

1. Current state
2. With indexes
3. With indexes + new query

On the first query we see 1,2,3

![image](https://github.com/user-attachments/assets/a2993b4f-26c9-4ceb-869a-2ce4b72e0025)

On two next images, we see the query plan for 2 and 3 on two similar addresses
I was always shutting down pg and clearing caches to have a cold start.
We can see both new indexes being used and in the second case, the filtering on the indexes.

![image](https://github.com/user-attachments/assets/87f35b21-9a22-4cf9-a31e-199d9644836d)
![image](https://github.com/user-attachments/assets/d3ea3467-b018-42f1-8a69-a490997c4eb5)


Next image is 1 and 2

We can see the query plan of 1 being more complicated
![image](https://github.com/user-attachments/assets/0c7524e1-db9f-41bd-8696-35365fe0f43a)

 I also made a sanity check, took around 5K random addresses and compared my new endpoint with the production one, everything's fine.