### PR TITLE
Various low hanging

### DIFF
--- a/app/src/main/resources/application.conf
+++ b/app/src/main/resources/application.conf
@@ -106,6 +106,8 @@ explorer {
 }
 
 blockflow {
+    scheme = "http"
+    scheme = ${?BLOCKFLOW_SCHEME}
     host = "127.0.0.1"
     host = ${?BLOCKFLOW_HOST}
     port = 12973

--- a/app/src/main/scala/org/alephium/explorer/error/ExplorerError.scala
+++ b/app/src/main/scala/org/alephium/explorer/error/ExplorerError.scala
@@ -46,8 +46,8 @@ object ExplorerError {
 
   /** ****** Group: [[FatalSystemExit]] *******
     */
-  final case class UnreachableNode(cause: Throwable)
-      extends Exception(s"Could not reach node.", cause)
+  final case class NodeError(cause: Throwable)
+      extends Exception(s"Node error.", cause)
       with FatalSystemExit
 
   final case class NodeApiError(message: String)

--- a/app/src/main/scala/org/alephium/explorer/error/ExplorerError.scala
+++ b/app/src/main/scala/org/alephium/explorer/error/ExplorerError.scala
@@ -100,6 +100,14 @@ object ExplorerError {
       extends Exception(s"Invalid host: $host", cause)
       with ConfigError
 
+  final case class InvalidScheme(scheme: String)
+      extends Exception(s"Invalid scheme: $scheme")
+      with ConfigError
+
+  final case class InvalidUri(scheme: String, host: String, port: Int, cause: String)
+      extends Exception(s"Invalid Uri: $scheme$host:$port. Cause: $cause")
+      with ConfigError
+
   final case class InvalidNetworkId(networkId: Int)
       extends Exception(s"Invalid networkId: $networkId")
       with ConfigError

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/AppState.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/AppState.scala
@@ -42,7 +42,12 @@ sealed trait AppStateKey[V <: AppState] {
       gr: GetResult[V],
       ec: ExecutionContext
   ): DBActionR[Option[V]] =
-    sql"""SELECT value FROM app_state WHERE key = $key""".asAS[V].headOrNone
+    sql"""
+      SELECT value
+      FROM app_state
+      WHERE key = $key
+      LIMIT 1
+      """.asAS[V].headOrNone
 }
 
 object AppState {

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
@@ -33,7 +33,6 @@ import org.alephium.explorer.persistence.queries.OutputQueries.insertOutputs
 import org.alephium.explorer.persistence.queries.TransactionQueries._
 import org.alephium.explorer.persistence.schema._
 import org.alephium.explorer.persistence.schema.CustomGetResult._
-import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.explorer.util.SlickExplainUtil._
 import org.alephium.explorer.util.SlickUtil._
@@ -90,9 +89,7 @@ object BlockQueries extends StrictLogging {
   def getBlockEntryAction(
       hash: BlockHash
   )(implicit ec: ExecutionContext): DBActionR[Option[BlockEntry]] =
-    for {
-      headers <- BlockHeaderSchema.table.filter(_.hash === hash).result
-    } yield headers.headOption.map(_.toApi())
+    getBlockHeaderAction(hash).map(_.map(_.toApi()))
 
   def getBlockHeaderAction(hash: BlockHash): DBActionR[Option[BlockHeader]] =
     sql"""

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
@@ -373,7 +373,10 @@ object BlockQueries extends StrictLogging {
   ): DBActionSR[TimeStamp] = {
     sql"""
       SELECT block_timestamp FROM  block_headers
-      WHERE chain_from = $fromGroup AND chain_to = $toGroup AND block_timestamp > $after
+      WHERE chain_from = $fromGroup
+      AND chain_to = $toGroup
+      AND block_timestamp > $after
+      AND main_chain = true
       ORDER BY block_timestamp
     """.asAS[TimeStamp]
   }

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
@@ -72,6 +72,7 @@ object BlockQueries extends StrictLogging {
                 txs_count
          from #$block_headers
          where hash = $hash
+         LIMIT 1
          """.asASE[BlockEntryLite](blockEntryListGetResult).headOption
 
   /** For a given `BlockHash` returns its basic chain information */
@@ -82,6 +83,7 @@ object BlockQueries extends StrictLogging {
                 main_chain
          FROM block_headers
          WHERE hash = $hash
+         LIMIT 1
          """
       .asAS[(GroupIndex, GroupIndex, Boolean)]
       .headOption
@@ -96,6 +98,7 @@ object BlockQueries extends StrictLogging {
          SELECT *
          FROM #$block_headers
          WHERE hash = $hash
+         LIMIT 1
          """
       .asASE[BlockHeader](blockHeaderGetResult)
       .headOption
@@ -364,6 +367,7 @@ object BlockQueries extends StrictLogging {
     sql"""
       SELECT main_chain FROM block_headers
       WHERE hash = $blockHash
+      LIMIT 1
     """.asAS[Boolean].headOrNone
   }
   def getBlockTimes(

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
@@ -114,6 +114,7 @@ object TransactionQueries extends StrictLogging {
       FROM transactions
       WHERE hash = $txHash
       AND main_chain = true
+      LIMIT 1
     """.asASE[TransactionEntity](transactionEntityGetResult).headOption
 
   def getTransactionAction(

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomGetResult.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomGetResult.scala
@@ -260,6 +260,27 @@ object CustomGetResult {
         ghostUncles = result.<<?
       )
 
+  val transactionEntityGetResult: GetResult[TransactionEntity] =
+    (result: PositionedResult) =>
+      TransactionEntity(
+        hash = result.<<,
+        blockHash = result.<<,
+        timestamp = result.<<,
+        chainFrom = result.<<,
+        chainTo = result.<<,
+        version = result.<<,
+        networkId = result.<<,
+        scriptOpt = result.<<?,
+        gasAmount = result.<<,
+        gasPrice = result.<<,
+        order = result.<<,
+        mainChain = result.<<,
+        scriptExecutionOk = result.<<,
+        inputSignatures = result.<<?,
+        scriptSignatures = result.<<?,
+        coinbase = result.<<
+      )
+
   val mempoolTransactionGetResult: GetResult[MempoolTransactionEntity] =
     (result: PositionedResult) =>
       MempoolTransactionEntity(

--- a/app/src/main/scala/org/alephium/explorer/service/BlockFlowClient.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/BlockFlowClient.scala
@@ -164,7 +164,7 @@ object BlockFlowClient extends StrictLogging {
             Future.failed(NodeApiError(error.detail))
         }
         .recoverWith { error =>
-          Future.failed(UnreachableNode(error))
+          Future.failed(NodeError(error))
         }
     }
 

--- a/app/src/main/scala/org/alephium/explorer/service/HashrateService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/HashrateService.scala
@@ -101,6 +101,7 @@ case object HashrateService extends StrictLogging {
       FROM hashrates
       WHERE interval_type = $intervalType
       ORDER BY block_timestamp DESC
+      LIMIT 1
     """.asAS[TimeStamp].headOrNone
 
   private def findLatestHashrateAndStepBack(

--- a/app/src/main/scala/org/alephium/explorer/service/HashrateService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/HashrateService.scala
@@ -28,11 +28,11 @@ import slick.jdbc.PostgresProfile.api._
 import org.alephium.explorer.api.model.{Hashrate, IntervalType}
 import org.alephium.explorer.persistence._
 import org.alephium.explorer.persistence.DBRunner._
-import org.alephium.explorer.persistence.model.HashrateEntity
 import org.alephium.explorer.persistence.queries.HashrateQueries._
-import org.alephium.explorer.persistence.schema._
-import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
+import org.alephium.explorer.persistence.schema.CustomGetResult._
+import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.explorer.util.Scheduler
+import org.alephium.explorer.util.SlickUtil._
 import org.alephium.explorer.util.TimeUtil._
 import org.alephium.protocol.ALPH
 import org.alephium.util.{Duration, TimeStamp}
@@ -93,19 +93,22 @@ case object HashrateService extends StrictLogging {
       } yield ()
     )
 
-  private def findLatestHashrate(intervalType: IntervalType): DBActionR[Option[HashrateEntity]] =
-    HashrateSchema.table
-      .filter(_.intervalType === intervalType)
-      .sortBy(_.timestamp.desc)
-      .result
-      .headOption
+  private def findLatestHashrate(intervalType: IntervalType)(implicit
+      ec: ExecutionContext
+  ): DBActionR[Option[TimeStamp]] =
+    sql"""
+      SELECT block_timestamp
+      FROM hashrates
+      WHERE interval_type = $intervalType
+      ORDER BY block_timestamp DESC
+    """.asAS[TimeStamp].headOrNone
 
   private def findLatestHashrateAndStepBack(
       intervalType: IntervalType,
       computeStepBack: TimeStamp => TimeStamp
   )(implicit ec: ExecutionContext): DBActionR[TimeStamp] = {
     findLatestHashrate(intervalType).map(
-      _.map(h => computeStepBack(h.timestamp)).getOrElse(ALPH.LaunchTimestamp)
+      _.map(timestamp => computeStepBack(timestamp)).getOrElse(ALPH.LaunchTimestamp)
     )
   }
 

--- a/app/src/main/scala/org/alephium/explorer/service/TokenSupplyService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/TokenSupplyService.scala
@@ -229,6 +229,7 @@ case object TokenSupplyService extends TokenSupplyService with StrictLogging {
               FROM latest_blocks
               WHERE chain_from = ${chainIndex.from}
               AND chain_to = ${chainIndex.to}
+              LIMIT 1
             """.asAS[TimeStamp].headOrNone
         }
       )

--- a/app/src/test/scala/org/alephium/explorer/config/ExplorerConfigSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/config/ExplorerConfigSpec.scala
@@ -103,6 +103,28 @@ class ExplorerConfigSpec extends AlephiumSpec with ScalaCheckDrivenPropertyCheck
     }
   }
 
+  "validateScheme" should {
+    "pass validation" when {
+      "with suported scheme" in {
+        validateScheme("http").success.value is "http"
+        validateScheme("https").success.value is "https"
+      }
+    }
+
+    "fail validation" when {
+      "scheme isn't supported" in {
+        validateScheme("ftp").failure.exception is InvalidScheme("ftp")
+        validateScheme("ws").failure.exception is InvalidScheme("ws")
+        validateScheme("wss").failure.exception is InvalidScheme("wss")
+        validateScheme("file").failure.exception is InvalidScheme("file")
+
+        forAll(genStringOfLength(5)) { string =>
+          validateScheme(string).failure.exception is InvalidScheme(string)
+        }
+      }
+    }
+  }
+
   "validateNetworkId" should {
     "fail validation" when {
       "networkId is greater than Byte.MaxValue" in {

--- a/app/src/test/scala/org/alephium/explorer/service/BlockFlowClientSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/BlockFlowClientSpec.scala
@@ -64,7 +64,7 @@ class BlockFlowClientSpec extends AlephiumFutureSpec with DatabaseFixtureForAll 
       blockFlowClient
         .fetchBlock(group, blockHashGen.sample.get)
         .failed
-        .futureValue is a[ExplorerError.UnreachableNode]
+        .futureValue is a[ExplorerError.NodeError]
     }
 
     "succeed if `directCliqueAccess = false`" in {

--- a/app/src/test/scala/org/alephium/explorer/service/MarketServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/MarketServiceSpec.scala
@@ -18,8 +18,9 @@ package org.alephium.explorer.service
 
 import java.net.InetAddress
 
+import scala.util._
 import scala.collection.immutable.{ArraySeq, ListMap}
-import scala.concurrent.Future
+import scala.concurrent._
 
 import akka.testkit.SocketUtil
 import io.vertx.core.Vertx
@@ -45,6 +46,17 @@ class MarketServiceSpec extends AlephiumFutureSpec {
       marketService.getExchangeRates().isLeft is true
       marketService.getPriceChart(alph, "usd").isLeft is true
     }
+  }
+
+  "don't throw error when stopped while requesting" in new Fixture {
+
+    val promise = Promise[Any]()
+
+    marketService.start().futureValue
+    marketService.getTokenListRemote(0).onComplete(result => promise.complete(result))
+    marketService.stop().futureValue
+
+    Try(promise.future.futureValue).isFailure is true
   }
 
   "get prices, exchange rates and charts" in new Fixture {

--- a/app/src/test/scala/org/alephium/explorer/service/MarketServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/MarketServiceSpec.scala
@@ -18,9 +18,9 @@ package org.alephium.explorer.service
 
 import java.net.InetAddress
 
-import scala.util._
 import scala.collection.immutable.{ArraySeq, ListMap}
 import scala.concurrent._
+import scala.util._
 
 import akka.testkit.SocketUtil
 import io.vertx.core.Vertx
@@ -56,7 +56,9 @@ class MarketServiceSpec extends AlephiumFutureSpec {
     marketService.getTokenListRemote(0).onComplete(result => promise.complete(result))
     marketService.stop().futureValue
 
-    Try(promise.future.futureValue).isFailure is true
+    Try(promise.future.futureValue) is Success(
+      Left(s"Exception when sending request: GET http://${localhost.getHostAddress}:$tokenListPort")
+    )
   }
 
   "get prices, exchange rates and charts" in new Fixture {

--- a/app/src/test/scala/org/alephium/explorer/util/ExecutionContextUtilSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/util/ExecutionContextUtilSpec.scala
@@ -39,7 +39,7 @@ class ExecutionContextSpec extends AlephiumSpec with Eventually {
     val executionContext = ExecutionContextUtil.fromExecutor(ExecutionContext.global, exit())
 
     "exit on a fatal explorer error" in {
-      executionContext.reportFailure(new UnreachableNode(new Throwable("error")))
+      executionContext.reportFailure(new NodeError(new Throwable("error")))
       eventually(count.get() is 1)
     }
 


### PR DESCRIPTION
Regarding: Prevent `SttpBackend` to throw error on close
    
    When stopping the `MarketService`, we have to close the `SttpBackend`
    unfortunately we don't have much control over it and when it's closed
    while doing a request, it's throwing an error and we were logging that
    error.
    
    It's correct in a way, but it was confusing on the reason why the
    explorer-backend was stopping.
    
    For example if the node stop while the market service is updating its
    caches, an error was logged, saying the caches couldn't get updated.
    
    This was confusing and let user think the market service was the reason
    for the explorer-backend to stop.
    
    We are now making sure that if we catch an error while the service is
    stopped or not running, we don't throw the error.
    
    On the other hand if the service is running, we do want to log the
    error.


Resolves: https://github.com/alephium/explorer-backend/issues/481