### PR TITLE
Add non-coinbase txs count in the history endpoint

### DIFF
--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -6689,17 +6689,19 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/TimedCount"
+                    "$ref": "#/components/schemas/TimedTxCount"
                   }
                 },
                 "example": [
                   {
                     "timestamp": 1611041396892,
-                    "totalCountAllChains": 10000000
+                    "totalCountAllChains": 10000000,
+                    "nonCoinbaseCountAllChains": 800
                   },
                   {
                     "timestamp": 1611041396892,
-                    "totalCountAllChains": 10000000
+                    "totalCountAllChains": 10000000,
+                    "nonCoinbaseCountAllChains": 800
                   }
                 ]
               }
@@ -6833,7 +6835,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/PerChainTimedCount"
+                    "$ref": "#/components/schemas/PerChainTimedTxCount"
                   }
                 },
                 "example": [
@@ -6843,12 +6845,14 @@
                       {
                         "chainFrom": 1,
                         "chainTo": 2,
-                        "count": 10000000
+                        "count": 10000000,
+                        "nonCoinbaseCount": 800
                       },
                       {
                         "chainFrom": 1,
                         "chainTo": 2,
-                        "count": 10000000
+                        "count": 10000000,
+                        "nonCoinbaseCount": 800
                       }
                     ]
                   },
@@ -6858,12 +6862,14 @@
                       {
                         "chainFrom": 1,
                         "chainTo": 2,
-                        "count": 10000000
+                        "count": 10000000,
+                        "nonCoinbaseCount": 800
                       },
                       {
                         "chainFrom": 1,
                         "chainTo": 2,
-                        "count": 10000000
+                        "count": 10000000,
+                        "nonCoinbaseCount": 800
                       }
                     ]
                   }
@@ -9407,29 +9413,6 @@
           }
         }
       },
-      "PerChainCount": {
-        "title": "PerChainCount",
-        "type": "object",
-        "required": [
-          "chainFrom",
-          "chainTo",
-          "count"
-        ],
-        "properties": {
-          "chainFrom": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "chainTo": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "count": {
-            "type": "integer",
-            "format": "int64"
-          }
-        }
-      },
       "PerChainDuration": {
         "title": "PerChainDuration",
         "type": "object",
@@ -9486,8 +9469,8 @@
           }
         }
       },
-      "PerChainTimedCount": {
-        "title": "PerChainTimedCount",
+      "PerChainTimedTxCount": {
+        "title": "PerChainTimedTxCount",
         "type": "object",
         "required": [
           "timestamp"
@@ -9500,8 +9483,35 @@
           "totalCountPerChain": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/PerChainCount"
+              "$ref": "#/components/schemas/PerChainTxCount"
             }
+          }
+        }
+      },
+      "PerChainTxCount": {
+        "title": "PerChainTxCount",
+        "type": "object",
+        "required": [
+          "chainFrom",
+          "chainTo",
+          "count"
+        ],
+        "properties": {
+          "chainFrom": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "chainTo": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "count": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "nonCoinbaseCount": {
+            "type": "integer",
+            "format": "int64"
           }
         }
       },
@@ -9564,24 +9574,6 @@
           }
         }
       },
-      "TimedCount": {
-        "title": "TimedCount",
-        "type": "object",
-        "required": [
-          "timestamp",
-          "totalCountAllChains"
-        ],
-        "properties": {
-          "timestamp": {
-            "type": "integer",
-            "format": "int64"
-          },
-          "totalCountAllChains": {
-            "type": "integer",
-            "format": "int64"
-          }
-        }
-      },
       "TimedPrices": {
         "title": "TimedPrices",
         "type": "object",
@@ -9599,6 +9591,28 @@
               "type": "number",
               "format": "double"
             }
+          }
+        }
+      },
+      "TimedTxCount": {
+        "title": "TimedTxCount",
+        "type": "object",
+        "required": [
+          "timestamp",
+          "totalCountAllChains"
+        ],
+        "properties": {
+          "timestamp": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "totalCountAllChains": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "nonCoinbaseCountAllChains": {
+            "type": "integer",
+            "format": "int64"
           }
         }
       },

--- a/app/src/main/scala/org/alephium/explorer/api/ChartsEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/ChartsEndpoints.scala
@@ -24,7 +24,7 @@ import sttp.tapir.generic.auto._
 import org.alephium.api.Endpoints.jsonBody
 import org.alephium.api.model.TimeInterval
 import org.alephium.explorer.api.EndpointExamples._
-import org.alephium.explorer.api.model.{Hashrate, IntervalType, PerChainTimedCount, TimedCount}
+import org.alephium.explorer.api.model.{Hashrate, IntervalType, PerChainTimedTxCount, TimedTxCount}
 
 // scalastyle:off magic.number
 trait ChartsEndpoints extends BaseEndpoint with QueryParams {
@@ -45,21 +45,22 @@ trait ChartsEndpoints extends BaseEndpoint with QueryParams {
       .description(s"`interval-type` query param: $intervalTypes")
       .summary("Get hashrate chart in H/s")
 
-  val getAllChainsTxCount: BaseEndpoint[(TimeInterval, IntervalType), ArraySeq[TimedCount]] =
+  val getAllChainsTxCount: BaseEndpoint[(TimeInterval, IntervalType), ArraySeq[TimedTxCount]] =
     chartsEndpoint.get
       .in("transactions-count")
       .in(timeIntervalQuery)
       .in(intervalTypeQuery)
-      .out(jsonBody[ArraySeq[TimedCount]])
+      .out(jsonBody[ArraySeq[TimedTxCount]])
       .description(s"`interval-type` query param: ${intervalTypes}")
       .summary("Get transaction count history")
 
-  val getPerChainTxCount: BaseEndpoint[(TimeInterval, IntervalType), ArraySeq[PerChainTimedCount]] =
+  val getPerChainTxCount
+      : BaseEndpoint[(TimeInterval, IntervalType), ArraySeq[PerChainTimedTxCount]] =
     chartsEndpoint.get
       .in("transactions-count-per-chain")
       .in(timeIntervalQuery)
       .in(intervalTypeQuery)
-      .out(jsonBody[ArraySeq[PerChainTimedCount]])
+      .out(jsonBody[ArraySeq[PerChainTimedTxCount]])
       .description(s"`interval-type` query param: ${intervalTypes}")
       .summary("Get transaction count history per chain")
 }

--- a/app/src/main/scala/org/alephium/explorer/api/EndpointExamples.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/EndpointExamples.scala
@@ -271,10 +271,11 @@ object EndpointExamples extends EndpointsExamples {
       value = BigDecimal(HashRate.a128EhPerSecond.value)
     )
 
-  private val timedCount =
-    TimedCount(
+  private val txCount =
+    TimedTxCount(
       timestamp = ts,
-      totalCountAllChains = 10000000
+      totalCountAllChains = 10000000,
+      nonCoinbaseCountAllChains = Some(800)
     )
 
   private val timedPrice =
@@ -284,14 +285,15 @@ object EndpointExamples extends EndpointsExamples {
     )
 
   private val perChainCount =
-    PerChainCount(
+    PerChainTxCount(
       chainFrom = 1,
       chainTo = 2,
-      count = 10000000
+      count = 10000000,
+      nonCoinbaseCount = Some(800)
     )
 
   private val perChainTimedCount =
-    PerChainTimedCount(
+    PerChainTimedTxCount(
       timestamp = ts,
       totalCountPerChain = ArraySeq(perChainCount, perChainCount)
     )
@@ -422,13 +424,13 @@ object EndpointExamples extends EndpointsExamples {
   implicit val hashrateExample: List[Example[ArraySeq[Hashrate]]] =
     simpleExample(ArraySeq(hashRate, hashRate))
 
-  implicit val timedCountExample: List[Example[ArraySeq[TimedCount]]] =
-    simpleExample(ArraySeq(timedCount, timedCount))
+  implicit val timedCountExample: List[Example[ArraySeq[TimedTxCount]]] =
+    simpleExample(ArraySeq(txCount, txCount))
 
   implicit val timedPriceExample: List[Example[TimedPrices]] =
     simpleExample(timedPrice)
 
-  implicit val perChainTimedCountExample: List[Example[ArraySeq[PerChainTimedCount]]] =
+  implicit val perChainTimedCountExample: List[Example[ArraySeq[PerChainTimedTxCount]]] =
     simpleExample(ArraySeq(perChainTimedCount, perChainTimedCount))
 
   implicit val explorerInfoExample: List[Example[ExplorerInfo]] =

--- a/app/src/main/scala/org/alephium/explorer/api/model/PerChainTimedTxCount.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/PerChainTimedTxCount.scala
@@ -16,16 +16,18 @@
 
 package org.alephium.explorer.api.model
 
+import scala.collection.immutable.ArraySeq
+
 import org.alephium.api.UtilJson.{timestampReader, timestampWriter}
 import org.alephium.json.Json._
 import org.alephium.util.TimeStamp
 
 @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
-final case class TimedCount(
+final case class PerChainTimedTxCount(
     timestamp: TimeStamp,
-    totalCountAllChains: Long
+    totalCountPerChain: ArraySeq[PerChainTxCount]
 )
 
-object TimedCount {
-  implicit val readWriter: ReadWriter[TimedCount] = macroRW
+object PerChainTimedTxCount {
+  implicit val readWriter: ReadWriter[PerChainTimedTxCount] = macroRW
 }

--- a/app/src/main/scala/org/alephium/explorer/api/model/PerChainTxCount.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/PerChainTxCount.scala
@@ -16,18 +16,16 @@
 
 package org.alephium.explorer.api.model
 
-import scala.collection.immutable.ArraySeq
-
-import org.alephium.api.UtilJson.{timestampReader, timestampWriter}
 import org.alephium.json.Json._
-import org.alephium.util.TimeStamp
 
 @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
-final case class PerChainTimedCount(
-    timestamp: TimeStamp,
-    totalCountPerChain: ArraySeq[PerChainCount]
+final case class PerChainTxCount(
+    chainFrom: Int,
+    chainTo: Int,
+    count: Long,
+    nonCoinbaseCount: Option[Long]
 )
 
-object PerChainTimedCount {
-  implicit val readWriter: ReadWriter[PerChainTimedCount] = macroRW
+object PerChainTxCount {
+  implicit val readWriter: ReadWriter[PerChainTxCount] = macroRW
 }

--- a/app/src/main/scala/org/alephium/explorer/api/model/TimedTxCount.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/TimedTxCount.scala
@@ -16,15 +16,17 @@
 
 package org.alephium.explorer.api.model
 
+import org.alephium.api.UtilJson.{timestampReader, timestampWriter}
 import org.alephium.json.Json._
+import org.alephium.util.TimeStamp
 
 @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
-final case class PerChainCount(
-    chainFrom: Int,
-    chainTo: Int,
-    count: Long
+final case class TimedTxCount(
+    timestamp: TimeStamp,
+    totalCountAllChains: Long,
+    nonCoinbaseCountAllChains: Option[Long]
 )
 
-object PerChainCount {
-  implicit val readWriter: ReadWriter[PerChainCount] = macroRW
+object TimedTxCount {
+  implicit val readWriter: ReadWriter[TimedTxCount] = macroRW
 }

--- a/app/src/main/scala/org/alephium/explorer/persistence/Migrations.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/Migrations.scala
@@ -36,7 +36,7 @@ import org.alephium.protocol.model.BlockHash
 @SuppressWarnings(Array("org.wartremover.warts.AnyVal"))
 object Migrations extends StrictLogging {
 
-  val latestVersion: MigrationVersion = MigrationVersion(4)
+  val latestVersion: MigrationVersion = MigrationVersion(5)
 
   def migration1(implicit ec: ExecutionContext): DBActionAll[Unit] = {
     // We retrigger the download of fungible and non-fungible tokens' metadata that have sub-category
@@ -91,11 +91,20 @@ object Migrations extends StrictLogging {
    */
   def migration4: DBActionAll[Unit] = DBIOAction.successful(())
 
+  def migration5(implicit ec: ExecutionContext): DBActionAll[Unit] =
+    for {
+      _ <- sqlu"""
+        ALTER TABLE transactions_history
+        ADD COLUMN non_coinbase_value BIGINT
+      """
+    } yield ()
+
   private def migrations(implicit ec: ExecutionContext): Seq[DBActionAll[Unit]] = Seq(
     migration1,
     migration2,
     migration3,
-    migration4
+    migration4,
+    migration5
   )
 
   def backgroundCoinbaseMigration()(implicit

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/TransactionHistoryEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/TransactionHistoryEntity.scala
@@ -25,5 +25,6 @@ final case class TransactionHistoryEntity(
     chainFrom: GroupIndex,
     chainTo: GroupIndex,
     count: Long,
+    nonCoinbaseCount: Option[Long],
     intervalType: IntervalType
 )

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionHistorySchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionHistorySchema.scala
@@ -28,11 +28,12 @@ import org.alephium.util.TimeStamp
 object TransactionHistorySchema extends Schema[TransactionHistoryEntity]("transactions_history") {
 
   class TransactionsHistories(tag: Tag) extends Table[TransactionHistoryEntity](tag, name) {
-    def timestamp: Rep[TimeStamp]       = column[TimeStamp]("timestamp")
-    def chainFrom: Rep[GroupIndex]      = column[GroupIndex]("chain_from")
-    def chainTo: Rep[GroupIndex]        = column[GroupIndex]("chain_to")
-    def count: Rep[Long]                = column[Long]("value")
-    def intervalType: Rep[IntervalType] = column[IntervalType]("interval_type")
+    def timestamp: Rep[TimeStamp]           = column[TimeStamp]("timestamp")
+    def chainFrom: Rep[GroupIndex]          = column[GroupIndex]("chain_from")
+    def chainTo: Rep[GroupIndex]            = column[GroupIndex]("chain_to")
+    def count: Rep[Long]                    = column[Long]("value")
+    def nonCoinbaseCount: Rep[Option[Long]] = column[Option[Long]]("non_coinbase_value")
+    def intervalType: Rep[IntervalType]     = column[IntervalType]("interval_type")
 
     def pk: PrimaryKey =
       primaryKey("transactions_history_pk", (intervalType, timestamp, chainFrom, chainTo))
@@ -40,7 +41,7 @@ object TransactionHistorySchema extends Schema[TransactionHistoryEntity]("transa
     def timestampIdx: Index    = index("transactions_history_timestamp_idx", timestamp)
 
     def * : ProvenShape[TransactionHistoryEntity] =
-      (timestamp, chainFrom, chainTo, count, intervalType)
+      (timestamp, chainFrom, chainTo, count, nonCoinbaseCount, intervalType)
         .<>((TransactionHistoryEntity.apply _).tupled, TransactionHistoryEntity.unapply)
   }
 

--- a/app/src/main/scala/org/alephium/explorer/web/ChartsServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/ChartsServer.scala
@@ -27,7 +27,7 @@ import sttp.model.StatusCode
 import org.alephium.api.ApiError
 import org.alephium.api.model.TimeInterval
 import org.alephium.explorer.api.ChartsEndpoints
-import org.alephium.explorer.api.model.{IntervalType, TimedCount}
+import org.alephium.explorer.api.model.{IntervalType, TimedTxCount}
 import org.alephium.explorer.config.ExplorerConfig
 import org.alephium.explorer.service.{HashrateService, TransactionHistoryService}
 
@@ -51,8 +51,8 @@ class ChartsServer(
           TransactionHistoryService
             .getAllChains(timeInterval.from, timeInterval.to, interval)
             .map { seq =>
-              seq.map { case (timestamp, count) =>
-                TimedCount(timestamp, count)
+              seq.map { case (timestamp, count, nonCoinbaseCount) =>
+                TimedTxCount(timestamp, count, nonCoinbaseCount)
               }
             }
         }


### PR DESCRIPTION
Those values are nice to have in order to see the real sent transactions over the coinbase ones.

Not really sure about the all `nonCoinbase` naming, but it's at least very explicit.

No extra queries are needed and we keep the same performance of the previous optimization. 

We'll just need to decide if we want to reset the past month of history to re trigger the computation and have the non-coinbase count.

![image](https://github.com/user-attachments/assets/125053f8-ba63-4baf-8b49-e7d9781e71bd)
