### PR TITLE
Optimize transaction cache

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/persistence/model/AppState.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/AppState.scala
@@ -67,6 +67,7 @@ object AppState {
       case LastFinalizedInputTime(value) => (LastFinalizedInputTime, serialize(value))
       case MigrationVersion(value)       => (MigrationVersion, serialize(value))
       case LastHoldersUpdate(value)      => (LastHoldersUpdate, serialize(value))
+      case FinalizedTxCount(value)       => (FinalizedTxCount, serialize(value))
     }
 
   object LastFinalizedInputTime extends AppStateKey[LastFinalizedInputTime] {
@@ -95,6 +96,15 @@ object AppState {
   }
 
   final case class LastHoldersUpdate(time: TimeStamp) extends AppState
+
+  object FinalizedTxCount extends AppStateKey[FinalizedTxCount] {
+    val key = "finalized_tx_count"
+
+    def apply(bytes: ByteString): Either[SerdeError, FinalizedTxCount] =
+      deserialize[Int](bytes).map(FinalizedTxCount(_))
+  }
+
+  final case class FinalizedTxCount(count: Int) extends AppState
 
   /** All the keys */
   def keys(): Array[AppStateKey[_]] =

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
@@ -38,6 +38,7 @@ import org.alephium.protocol.ALPH
 import org.alephium.protocol.model.{Address, BlockHash, TransactionId}
 import org.alephium.util.{TimeStamp, U256}
 
+// scalastyle:off number.of.methods
 object TransactionQueries extends StrictLogging {
 
   @SuppressWarnings(Array("org.wartremover.warts.PublicInference"))
@@ -169,6 +170,14 @@ object TransactionQueries extends StrictLogging {
       .paginate(pagination)
       .asAS[TxByAddressQR]
   }
+
+  def countTxsAfter(time: TimeStamp): DBActionR[Int] =
+    sql"""
+        SELECT COUNT(*)
+        FROM transactions
+        WHERE block_timestamp > $time
+        AND main_chain = true
+        """.as[Int].head
 
   /** Get transactions for a list of addresses
     *

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomGetResult.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomGetResult.scala
@@ -432,4 +432,11 @@ object CustomGetResult {
         case Left(error)  => throw error
         case Right(value) => value
       }
+
+  implicit val finalizedTxCountGetResult: GetResult[AppState.FinalizedTxCount] =
+    (result: PositionedResult) =>
+      AppState.FinalizedTxCount(ByteString.fromArrayUnsafe(result.nextBytes())) match {
+        case Left(error)  => throw error
+        case Right(value) => value
+      }
 }

--- a/app/src/main/scala/org/alephium/explorer/service/FinalizerService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/FinalizerService.scala
@@ -29,7 +29,7 @@ import slick.jdbc.PostgresProfile.api._
 import org.alephium.explorer.foldFutures
 import org.alephium.explorer.persistence._
 import org.alephium.explorer.persistence.DBRunner._
-import org.alephium.explorer.persistence.model.AppState.LastFinalizedInputTime
+import org.alephium.explorer.persistence.model.AppState._
 import org.alephium.explorer.persistence.queries.AppStateQueries
 import org.alephium.explorer.persistence.schema.CustomGetResult._
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
@@ -44,6 +44,8 @@ import org.alephium.util.{Duration, TimeStamp}
  */
 
 case object FinalizerService extends StrictLogging {
+
+  final private case class UpdateResult(nbOfOutputs: Int, nbOfTransactions: Int)
 
   // scalastyle:off magic.number
   val finalizationDuration: Duration = Duration.ofSecondsUnsafe(6500)
@@ -85,7 +87,22 @@ case object FinalizerService extends StrictLogging {
       executionContext: ExecutionContext,
       databaseConfig: DatabaseConfig[PostgresProfile]
   ): Future[Unit] = {
+    run(getFinalizedTxCountOrCount(start)).flatMap { txsCount =>
+      finalizeOutputsFromToWithCount(start, end, step, txsCount)
+    }
+  }
+
+  def finalizeOutputsFromToWithCount(
+      start: TimeStamp,
+      end: TimeStamp,
+      step: Duration,
+      txsCount: Int
+  )(implicit
+      executionContext: ExecutionContext,
+      databaseConfig: DatabaseConfig[PostgresProfile]
+  ): Future[Unit] = {
     var updateCounter = 0
+    var txsCounter    = txsCount
     logger.debug(s"Updating outputs")
     val timeRanges =
       TimeUtil.buildTimestampRange(start, end, step)
@@ -94,12 +111,14 @@ case object FinalizerService extends StrictLogging {
       run(
         (
           for {
-            nb <- updateOutputs(from, to)
-            _  <- updateLastFinalizedInputTime(to)
-          } yield nb
+            updateResult <- updateOutputs(from, to)
+            _            <- updateLastFinalizedInputTime(to)
+            _            <- updateFinalizedTxCount(txsCounter + updateResult.nbOfTransactions)
+          } yield updateResult
         ).transactionally
-      ).map { nb =>
-        updateCounter = updateCounter + nb
+      ).map { updateResult =>
+        txsCounter = txsCounter + updateResult.nbOfTransactions
+        updateCounter = updateCounter + updateResult.nbOfOutputs
         logger.debug(s"$updateCounter outputs updated")
       }
     }.map(_ => logger.debug(s"Outputs updated"))
@@ -110,12 +129,14 @@ case object FinalizerService extends StrictLogging {
    */
   private def updateOutputs(from: TimeStamp, to: TimeStamp)(implicit
       ec: ExecutionContext
-  ): DBActionR[Int] =
+  ): DBActionR[UpdateResult] =
     for {
       txs    <- findTransactions(from, to)
       inputs <- findInputs(txs)
       nb     <- updateOutputsWithInputs(inputs)
-    } yield nb
+    } yield {
+      UpdateResult(nb, txs.length)
+    }
 
   /*
    * Search for transactions within the specified time range.
@@ -208,6 +229,14 @@ case object FinalizerService extends StrictLogging {
       AND main_chain = true
     """
 
+  def getFinalizedTxCountOrCount(upTo: TimeStamp)(implicit
+      executionContext: ExecutionContext
+  ): DBActionR[Int] =
+    AppStateQueries.get(FinalizedTxCount).flatMap {
+      case Some(FinalizedTxCount(count)) => DBIOAction.successful(count)
+      case None                          => countTxsUpTo(upTo)
+    }
+
   def getStartEndTime()(implicit
       executionContext: ExecutionContext
   ): DBActionR[Option[(TimeStamp, TimeStamp)]] = {
@@ -245,6 +274,14 @@ case object FinalizerService extends StrictLogging {
       FROM latest_blocks
     """.asAS[TimeStamp].headOrNone
 
+  private def countTxsUpTo(time: TimeStamp): DBActionR[Int] =
+    sql"""
+        SELECT COUNT(*)
+        FROM transactions
+        WHERE block_timestamp < $time
+        AND main_chain = true
+        """.as[Int].head
+
   private def getLastFinalizedInputTime()(implicit
       executionContext: ExecutionContext
   ): DBActionR[Option[TimeStamp]] =
@@ -252,4 +289,7 @@ case object FinalizerService extends StrictLogging {
 
   private def updateLastFinalizedInputTime(time: TimeStamp) =
     AppStateQueries.insertOrUpdate(LastFinalizedInputTime(time))
+
+  private def updateFinalizedTxCount(txCount: Int) =
+    AppStateQueries.insertOrUpdate(FinalizedTxCount(txCount))
 }

--- a/app/src/test/scala/org/alephium/explorer/cache/TestTransactionCache.scala
+++ b/app/src/test/scala/org/alephium/explorer/cache/TestTransactionCache.scala
@@ -1,0 +1,40 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.cache
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+import slick.basic.DatabaseConfig
+import slick.jdbc.PostgresProfile
+
+import org.alephium.explorer.config.BootMode
+import org.alephium.explorer.persistence.Database
+
+object TestTransactionCache {
+
+  /** @return
+    *   Test instance of [[TransactionCache]] for faster cache reloads than configured periods in
+    *   `application.conf`
+    */
+  def apply()(implicit
+      ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile]
+  ): TransactionCache =
+    TransactionCache(new Database(BootMode.ReadWrite), reloadAfter = 1.seconds)
+
+}

--- a/app/src/test/scala/org/alephium/explorer/service/FinalizerServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/FinalizerServiceSpec.scala
@@ -86,7 +86,7 @@ class FinalizerServiceSpec extends AlephiumFutureSpec with DatabaseFixtureForEac
 
     val Some((start3, _)) = run(FinalizerService.getStartEndTime()).futureValue
 
-    start3 is blockHeader2.timestamp
+    start3 is blockHeader2.timestamp.plusMillisUnsafe(1)
   }
 
   trait Fixture {


### PR DESCRIPTION
Previously in our `TransactionCache` every 10 minutes we were re-counting every txs in database, not optimal...

In this PR, we take advantage of the `FinalizerService`, which is grabbing every 10min every txs that needs to be finalized.
Here is the workflow:

* We keep in our `AppState` table the current count of finalized txs.
* When we finalize new txs, we add their count to the `finalized_tx_count` in `app_state`
* The `TransactionCache` is first reading the `finalized_tx_count` and only count txs that aren't finalized.

With this solution, whatever the number of transactions, the cache will only count a very small set of transactions. 