### PR TITLE
Sync with WebSocket

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/ExplorerState.scala
+++ b/app/src/main/scala/org/alephium/explorer/ExplorerState.scala
@@ -25,6 +25,7 @@ import slick.jdbc.PostgresProfile
 
 import org.alephium.explorer.cache.{BlockCache, MetricCache, TransactionCache}
 import org.alephium.explorer.config.{BootMode, ExplorerConfig}
+import org.alephium.explorer.config.ExplorerConfig.Consensus
 import org.alephium.explorer.persistence.Database
 import org.alephium.explorer.service._
 import org.alephium.explorer.util.Scheduler
@@ -45,6 +46,8 @@ sealed trait ExplorerState extends Service with StrictLogging {
 
   lazy val database: Database =
     new Database(config.bootMode)(executionContext, databaseConfig)
+
+  implicit lazy val consensus: Consensus = config.consensus
 
   implicit lazy val blockCache: BlockCache =
     BlockCache(

--- a/app/src/main/scala/org/alephium/explorer/SyncServices.scala
+++ b/app/src/main/scala/org/alephium/explorer/SyncServices.scala
@@ -32,6 +32,7 @@ import org.alephium.api.model.{ChainParams, PeerAddress}
 import org.alephium.explorer.RichAVector._
 import org.alephium.explorer.cache.BlockCache
 import org.alephium.explorer.config.{BootMode, ExplorerConfig}
+import org.alephium.explorer.config.ExplorerConfig.Consensus
 import org.alephium.explorer.error.ExplorerError._
 import org.alephium.explorer.service._
 import org.alephium.explorer.util.Scheduler
@@ -46,6 +47,7 @@ object SyncServices extends StrictLogging {
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile],
       blockFlowClient: BlockFlowClient,
+      consensus: Consensus,
       blockCache: BlockCache,
       groupSetting: GroupSetting
   ): Future[Unit] =
@@ -88,6 +90,7 @@ object SyncServices extends StrictLogging {
       dc: DatabaseConfig[PostgresProfile],
       blockFlowClient: BlockFlowClient,
       blockCache: BlockCache,
+      consensus: Consensus,
       groupSetting: GroupSetting
   ): Future[Unit] =
     Future.fromTry {

--- a/app/src/main/scala/org/alephium/explorer/error/ExplorerError.scala
+++ b/app/src/main/scala/org/alephium/explorer/error/ExplorerError.scala
@@ -88,6 +88,12 @@ object ExplorerError {
       extends Exception(s"Cannot parse config file: $file", exception)
       with ConfigError
 
+  final case class WebSocketError(cause: Throwable)
+      extends Exception(s"WebSocket error. $cause")
+      with ExplorerError
+
+  /** ****** Group: [[ConfigError]] *******
+    */
   final case class InvalidGroupNumber(groupNum: Int)
       extends Exception(s"Invalid groupNum: $groupNum. It should be > 0")
       with ConfigError

--- a/app/src/main/scala/org/alephium/explorer/service/WebSocketSyncService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/WebSocketSyncService.scala
@@ -1,0 +1,228 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.service
+
+import scala.collection.immutable.ArraySeq
+import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.util._
+
+import com.typesafe.scalalogging.StrictLogging
+import io.vertx.core.AbstractVerticle
+import io.vertx.core.Vertx
+import io.vertx.core.eventbus.Message
+import io.vertx.core.http.WebSocket
+import slick.basic.DatabaseConfig
+import slick.jdbc.PostgresProfile
+
+import org.alephium.api
+import org.alephium.explorer.GroupSetting
+import org.alephium.explorer.cache.BlockCache
+import org.alephium.explorer.config.ExplorerConfig.Consensus
+import org.alephium.explorer.persistence.model.BlockEntityWithEvents
+import org.alephium.explorer.persistence.queries.InputUpdateQueries
+import org.alephium.json.Json._
+import org.alephium.rpc.model.JsonRPC.Notification
+import org.alephium.util.{discard, Duration, TimeStamp}
+import org.alephium.ws._
+import org.alephium.ws.WsClient.KeepAlive
+import org.alephium.ws.WsParams.WsNotificationParams._
+import org.alephium.ws.WsUtils._
+
+@SuppressWarnings(
+  Array(
+    "org.wartremover.warts.NonUnitStatements",
+    "org.wartremover.warts.Var",
+    "org.wartremover.warts.DefaultArguments"
+  )
+)
+case object WebSocketSyncService extends StrictLogging {
+
+  val maybeApiKey: Option[api.model.ApiKey] = None
+
+  private val batchAddress = "blocks.batch"
+
+// scalastyle:off parameter.number
+  def sync(stopPromise: Promise[Unit], host: String, port: Int, flushInterval: Duration)(implicit
+      ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile],
+      blockFlowClient: BlockFlowClient,
+      consensus: Consensus,
+      cache: BlockCache,
+      groupSetting: GroupSetting
+  ): Unit = {
+
+    val vertx: Vertx = Vertx.vertx()
+
+    val wsClient = WsClient(vertx)
+
+    def closeHandler(client: ClientWs, deploymentId: String): WebSocket = {
+      client.underlying.closeHandler { _ =>
+        logger.info("WebSocket connection closed")
+        vertx.undeploy(deploymentId)
+        stopPromise.trySuccess(())
+        ()
+      }
+    }
+
+    // format: off
+    (for {
+      client <- wsClient.connect(port, host)(notif => handleNotification(notif, vertx))(handleKeepAlive)
+      blockBatching = new BlockBatchingVerticle(batchAddress, flushInterval, inserts, client)
+      deploymentId <- vertx.deployVerticle(blockBatching).asScala
+      _ = closeHandler(client, deploymentId)
+      _ <- client.subscribeToBlock(0)
+    } yield ())
+      .onComplete {
+        case Success(_) =>
+          logger.info("WebSocket syncing started")
+        case Failure(exception) =>
+          logger.error("WebSocket syncing failed", exception)
+          stopPromise.trySuccess(())
+          ()
+      }
+    // format: on
+  }
+
+  def handleNotification(notification: Notification, vertx: Vertx): Unit = {
+    notification.method match {
+      case "subscription" =>
+        discard(vertx.eventBus().send(batchAddress, writeBinary(notification.params)))
+      case _ =>
+        // TODO Should we support error notification?
+        ()
+    }
+  }
+
+  def handleKeepAlive(keepAlive: KeepAlive): Unit = {
+    // TODO: do we want to do something with this?
+    //       I think ping are anyway automatcially handled by the vertx client
+    logger.debug(s"Keep alive: ${keepAlive}")
+  }
+
+  def inserts(blockAndEvents: ArraySeq[BlockEntityWithEvents])(implicit
+      ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile],
+      blockFlowClient: BlockFlowClient,
+      cache: BlockCache,
+      groupSetting: GroupSetting
+  ): Future[Unit] =
+    for {
+      _ <- BlockFlowSyncService.insertBlocks(blockAndEvents)
+      _ <- dc.db.run(InputUpdateQueries.updateInputs())
+    } yield (())
+
+  /*
+   * This verticle is used to batch the blocks received from the websocket
+   * and insert them into the database after every flushInterval.
+   * Verticles are equivalent to akka actors
+   */
+  @SuppressWarnings(Array("org.wartremover.warts.MutableDataStructures"))
+  private class BlockBatchingVerticle(
+      address: String,
+      flushInterval: Duration,
+      insertBlocksToDb: ArraySeq[BlockEntityWithEvents] => Future[Unit],
+      client: ClientWs
+  )(implicit
+      ec: ExecutionContext,
+      consensus: Consensus,
+      groupSetting: GroupSetting
+  ) extends AbstractVerticle {
+
+    /*
+     * Passing this delay, the websocket syincg will stop and go back to regular sync.
+     * This is to prevent the case where the websocket become too slow for some reason.
+     */
+
+    // TODO: this should be configurable
+    // scalastyle:off magic.number
+    private val delayAllowed = Duration.ofSecondsUnsafe(30L)
+    // scalastyle:on magic.number
+
+    /*
+     * Vertx vertices are equivalent to akka actors
+     * So message are process in a single thread and
+     * with the security of `pending` we are safe
+     * to use mutable data structure
+     */
+    private var buffer  = ArrayBuffer.empty[BlockEntityWithEvents]
+    private var pending = false
+
+    override def start(): Unit = {
+      discard(this.vertx.eventBus().consumer[Array[Byte]](address, handleBlock))
+      discard(this.vertx.setPeriodic(flushInterval.millis, _ => flush()))
+    }
+
+    private def handleBlock(msg: Message[Array[Byte]]): Unit = {
+      handleJsonMessage(readBinary[ujson.Value](msg.body())).foreach { blockAndEvents =>
+        buffer += blockAndEvents
+      }
+    }
+
+    private def handleJsonMessage(notification: ujson.Value): Option[BlockEntityWithEvents] = {
+      Try(read[WsParams.WsNotificationParams](notification)).toEither match {
+        case Left(exception) =>
+          logger.error(s"Failed to parse notification: $notification", exception)
+          None
+        case Right(params) =>
+          params match {
+            case WsParams.WsBlockNotificationParams(_, protocolBlockAndEvents) =>
+              val blockAndEvents =
+                BlockFlowClient.blockAndEventsToEntities(protocolBlockAndEvents)
+
+              validateBlockAndEvents(blockAndEvents)
+
+              Some(blockAndEvents)
+            case other =>
+              logger.error(s"Expected block notification, got: $other")
+              None
+          }
+      }
+    }
+
+    private def flush(): Unit = {
+      if (buffer.nonEmpty && !pending) {
+        val batch = ArraySeq.from(buffer)
+        buffer = ArrayBuffer.empty
+        pending = true
+
+        insertBlocksToDb(batch).onComplete { result =>
+          pending = false
+
+          result.failed.foreach { ex =>
+            logger.error(s"DB insert failed: ${ex.getMessage}")
+            // Resume to normal sync
+            client.close()
+          }
+        }
+      }
+    }
+
+    private def validateBlockAndEvents(
+        blockAndEvents: BlockEntityWithEvents
+    ): Unit = {
+      if (
+        (TimeStamp.now() -- blockAndEvents.block.timestamp)
+          .map(_ > delayAllowed)
+          .getOrElse(true)
+      ) {
+        logger.error("WebSocket message is to old")
+        discard(client.close())
+      }
+    }
+  }
+}

--- a/app/src/test/scala/org/alephium/explorer/ExplorerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/ExplorerSpec.scala
@@ -575,7 +575,7 @@ object ExplorerSpec {
 
     val cliqueId = CliqueId.generate
 
-    private val peer = model.PeerAddress(address, port, 0, 0)
+    private val peer = model.PeerAddress(address, port, 0)
 
     def fetchHashesAtHeight(
         from: GroupIndex,

--- a/app/src/test/scala/org/alephium/explorer/GenCoreApi.scala
+++ b/app/src/test/scala/org/alephium/explorer/GenCoreApi.scala
@@ -65,12 +65,10 @@ object GenCoreApi {
     for {
       address      <- genInetAddress
       restPort     <- genPortNum
-      wsPort       <- genPortNum
       minerApiPort <- genPortNum
     } yield PeerAddress(
       address = address,
       restPort = restPort,
-      wsPort = wsPort,
       minerApiPort = minerApiPort
     )
 

--- a/app/src/test/scala/org/alephium/explorer/service/BlockFlowClientSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/BlockFlowClientSpec.scala
@@ -170,7 +170,7 @@ object BlockFlowClientSpec extends ScalaFutures with IntegrationPatience {
     val cliqueId = CliqueId.generate
 
     private val peer =
-      model.PeerAddress(localhost, SocketUtil.temporaryLocalPort(SocketUtil.Both), 0, 0)
+      model.PeerAddress(localhost, SocketUtil.temporaryLocalPort(SocketUtil.Both), 0)
 
     private val vertx  = Vertx.vertx()
     private val router = Router.router(vertx)

--- a/build.sbt
+++ b/build.sbt
@@ -166,6 +166,7 @@ lazy val app = mainProject("app")
       alephiumUtil,
       alephiumProtocol,
       alephiumApi,
+      alephiumWs,
       alephiumCrypto,
       alephiumJson,
       rxJava,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@
 import sbt._
 
 object Version {
-  lazy val common = "3.11.0"
+  lazy val common = "3.12.7+97-eccb34cf+20250430-1522-SNAPSHOT"
 
   lazy val akka       = "2.6.20"
   lazy val rxJava     = "3.1.8"
@@ -39,6 +39,7 @@ object Dependencies {
   lazy val alephiumJson     = "org.alephium" %% "alephium-json"     % Version.common
   lazy val alephiumHttp     = "org.alephium" %% "alephium-http"     % Version.common
   lazy val alephiumConf     = "org.alephium" %% "alephium-conf"     % Version.common
+  lazy val alephiumWs       = "org.alephium" %% "alephium-ws"       % Version.common
 
   lazy val vertx       = "io.vertx" % "vertx-core"     % Version.vertx
   lazy val vertxRxJava = "io.vertx" % "vertx-rx-java3" % Version.vertx


### PR DESCRIPTION
Update of https://github.com/alephium/explorer-backend/pull/478 using the new websocket of full node and the `WsClient`
This PR needs the latest version of [that node PR](https://github.com/alephium/dev-alephium/pull/1099)

the strategy stay the same:

* Sync with `BlockFlowSyncService` as usual
* Once we are up-to-date: latest block is less than 30s old we move to
  websocket syncing
* If some blocks are missed between the last sync and the opening of the websocket, it will eventually recover them
  as we always make sure the parents are downloaded before inserting new blocks.
* If websocket messages are late: > 30s old, we close the websocket and
  move back to http syncing. This can happen in case of network issue,
  this is safer as we could suddenly receive lots of message through the
  websocket and the DB can't follow (happen once in my tests)
* If the websocket close for anyreason we also move back to http
  syncing.

The main idea is to always rely and fall back on our BlockFlowSyncService which is well tested in production.

I tried various edge cases, like cutting my network etc.

Still require some testing and extracting some config values