### PR TITLE
Add indexes for groupless address columns

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/persistence/DBInitializer.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/DBInitializer.scala
@@ -135,8 +135,11 @@ object DBInitializer extends StrictLogging {
   ): Future[Unit] = {
     logger.info("Create Background Indexes")
     run(for {
-      _ <- OutputSchema.createNonSpentOutputCoveringIndex()
-      _ <- InputSchema.createOutupRefAddressMainChainTimestampIndex()
+      _ <- OutputSchema.createConcurrentIndexes()
+      _ <- InputSchema.createConcurrentIndexes()
+      _ <- TokenOutputSchema.createConcurrentIndexes()
+      _ <- TransactionPerAddressSchema.createConcurrentIndexes()
+      _ <- TokenPerAddressSchema.createConcurrentIndexes()
     } yield {
       logger.info("Background Indexes created")
     })

--- a/app/src/main/scala/org/alephium/explorer/persistence/Migrations.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/Migrations.scala
@@ -177,8 +177,15 @@ object Migrations extends StrictLogging {
    * Those indexes will be re-created concurrently while including the `groupless_address` column
    */
   def migration7(implicit ec: ExecutionContext): DBActionAll[Unit] = {
-    // Renamed and modified to `non_spent_output_groupless_covering_include_idx`
-    sqlu"DROP INDEX IF EXISTS non_spent_output_group_covering_include_idx".map(_ => ())
+    for {
+      // Renamed and modified to `non_spent_output_groupless_covering_include_idx`
+      _ <- sqlu"DROP INDEX IF EXISTS non_spent_output_group_covering_include_idx"
+      _ <- addAddressLikeColumn("uoutputs", "groupless_address")
+      _ <- addAddressLikeColumn("uinputs", "groupless_address")
+    } yield {
+      ()
+    }
+
   }
 
   private def migrations(implicit

--- a/app/src/main/scala/org/alephium/explorer/persistence/Migrations.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/Migrations.scala
@@ -39,7 +39,7 @@ import org.alephium.util.TimeStamp
 @SuppressWarnings(Array("org.wartremover.warts.AnyVal"))
 object Migrations extends StrictLogging {
 
-  val latestVersion: MigrationVersion = MigrationVersion(6)
+  val latestVersion: MigrationVersion = MigrationVersion(7)
 
   def migration1(implicit ec: ExecutionContext): DBActionAll[Unit] = {
     // We retrigger the download of fungible and non-fungible tokens' metadata that have sub-category
@@ -173,6 +173,14 @@ object Migrations extends StrictLogging {
       }
     }
 
+  /*
+   * Those indexes will be re-created concurrently while including the `groupless_address` column
+   */
+  def migration7(implicit ec: ExecutionContext): DBActionAll[Unit] = {
+    // Renamed and modified to `non_spent_output_groupless_covering_include_idx`
+    sqlu"DROP INDEX IF EXISTS non_spent_output_group_covering_include_idx".map(_ => ())
+  }
+
   private def migrations(implicit
       explorerConfig: ExplorerConfig,
       ec: ExecutionContext
@@ -182,7 +190,8 @@ object Migrations extends StrictLogging {
     migration3,
     migration4,
     migration5,
-    migration6
+    migration6,
+    migration7
   )
 
   def backgroundCoinbaseMigration()(implicit

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/MempoolTransactionEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/MempoolTransactionEntity.scala
@@ -19,6 +19,7 @@ package org.alephium.explorer.persistence.model
 import scala.collection.immutable.ArraySeq
 
 import org.alephium.explorer.api.model.{AssetOutput, ContractOutput, MempoolTransaction}
+import org.alephium.explorer.util.AddressUtil
 import org.alephium.protocol.model.{GroupIndex, TransactionId}
 import org.alephium.util.{TimeStamp, U256}
 
@@ -51,6 +52,7 @@ object MempoolTransactionEntity {
           input.outputRef.key,
           input.unlockScript,
           input.address,
+          input.address.flatMap(AddressUtil.convertToGrouplessAddress),
           order
         )
       },
@@ -69,6 +71,7 @@ object MempoolTransactionEntity {
           output.key,
           output.attoAlphAmount,
           output.address,
+          AddressUtil.convertToGrouplessAddress(output.address),
           output.tokens,
           lockTime,
           message,

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/UInputEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/UInputEntity.scala
@@ -20,7 +20,7 @@ import akka.util.ByteString
 
 import org.alephium.explorer.api.model.{Input, OutputRef}
 import org.alephium.protocol.Hash
-import org.alephium.protocol.model.Address
+import org.alephium.protocol.model.{Address, AddressLike}
 import org.alephium.protocol.model.TransactionId
 
 final case class UInputEntity(
@@ -29,6 +29,7 @@ final case class UInputEntity(
     outputRefKey: Hash,
     unlockScript: Option[ByteString],
     address: Option[Address],
+    grouplessAddress: Option[AddressLike],
     uinputOrder: Int
 ) {
   val toApi: Input = Input(

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/UOutputEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/UOutputEntity.scala
@@ -22,7 +22,7 @@ import akka.util.ByteString
 
 import org.alephium.explorer.api.model.{AssetOutput, Token}
 import org.alephium.protocol.Hash
-import org.alephium.protocol.model.{Address, TransactionId}
+import org.alephium.protocol.model.{Address, AddressLike, TransactionId}
 import org.alephium.util.{TimeStamp, U256}
 
 final case class UOutputEntity(
@@ -31,6 +31,7 @@ final case class UOutputEntity(
     key: Hash,
     amount: U256,
     address: Address,
+    grouplessAddress: Option[AddressLike],
     tokens: Option[ArraySeq[Token]],
     lockTime: Option[TimeStamp],
     message: Option[ByteString],

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/MempoolQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/MempoolQueries.scala
@@ -111,6 +111,7 @@ object MempoolQueries {
                   key,
                   amount,
                   address,
+                  groupless_address,
                   tokens,
                   lock_time,
                   message,
@@ -145,6 +146,7 @@ object MempoolQueries {
                   output_ref_key,
                   unlock_script,
                   address,
+                  groupless_address,
                   uinput_order
            FROM uinputs
            WHERE tx_hash IN $params
@@ -185,6 +187,7 @@ object MempoolQueries {
                 key,
                 amount,
                 address,
+                groupless_address,
                 tokens,
                 lock_time,
                 message,
@@ -202,6 +205,7 @@ object MempoolQueries {
                 output_ref_key,
                 unlock_script,
                 address,
+                groupless_address,
                 uinput_order
          FROM uinputs
          WHERE tx_hash = $hash

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
@@ -171,8 +171,8 @@ object TransactionQueries extends StrictLogging {
       FROM transaction_per_addresses
       WHERE main_chain = true
       AND #${addressColumn(address)} = $address
+      ORDER BY block_timestamp DESC, tx_order
     """
-      .concat(sql"""ORDER BY block_timestamp DESC, tx_order """)
       .paginate(pagination)
       .asAS[TxByAddressQR]
   }

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomGetResult.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomGetResult.scala
@@ -313,6 +313,7 @@ object CustomGetResult {
         outputRefKey = result.<<,
         unlockScript = result.<<?,
         address = result.<<?,
+        grouplessAddress = result.<<?,
         uinputOrder = result.<<
       )
 
@@ -324,6 +325,7 @@ object CustomGetResult {
         key = result.<<,
         amount = result.<<,
         address = result.<<,
+        grouplessAddress = result.<<?,
         tokens = result.<<?,
         lockTime = result.<<?,
         message = result.<<?,

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenOutputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenOutputSchema.scala
@@ -101,9 +101,9 @@ object TokenOutputSchema extends SchemaMainChain[TokenOutputEntity]("token_outpu
 
   def createNonSpentGrouplessIndex(): DBActionW[Int] =
     sqlu"""
-      CREATE UNIQUE INDEX IF NOT EXISTS token_non_spent_output_groupless_idx
+      CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS token_non_spent_output_groupless_idx
       ON #${name} (token, groupless_address, main_chain, key, block_hash)
-      WHERE spent_finalized IS NULL;
+      WHERE spent_finalized IS NULL
       AND groupless_address IS NOT NULL;
     """
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenOutputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenOutputSchema.scala
@@ -16,6 +16,8 @@
 
 package org.alephium.explorer.persistence.schema
 
+import scala.concurrent.ExecutionContext
+
 import akka.util.ByteString
 import slick.jdbc.PostgresProfile.api._
 import slick.lifted.{Index, PrimaryKey, ProvenShape}
@@ -84,8 +86,26 @@ object TokenOutputSchema extends SchemaMainChain[TokenOutputEntity]("token_outpu
         .<>((TokenOutputEntity.apply _).tupled, TokenOutputEntity.unapply)
   }
 
-  val createNonSpentIndex: DBActionW[Int] =
-    sqlu"create unique index if not exists non_spent_output_idx on #${name} (address, main_chain, key, block_hash) where spent_finalized IS NULL;"
+  def createConcurrentIndexes()(implicit ec: ExecutionContext): DBActionW[Unit] =
+    for {
+      _ <- createNonSpentIndex()
+      _ <- createNonSpentGrouplessIndex()
+    } yield ()
+
+  def createNonSpentIndex(): DBActionW[Int] =
+    sqlu"""
+      CREATE UNIQUE INDEX IF NOT EXISTS token_non_spent_output_idx
+      ON #${name} (token, address, main_chain, key, block_hash)
+      WHERE spent_finalized IS NULL;
+    """
+
+  def createNonSpentGrouplessIndex(): DBActionW[Int] =
+    sqlu"""
+      CREATE UNIQUE INDEX IF NOT EXISTS token_non_spent_output_groupless_idx
+      ON #${name} (token, groupless_address, main_chain, key, block_hash)
+      WHERE spent_finalized IS NULL;
+      AND groupless_address IS NOT NULL;
+    """
 
   val table: TableQuery[TokenOutputs] = TableQuery[TokenOutputs]
 }

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenTxPerAddressSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenTxPerAddressSchema.scala
@@ -62,10 +62,10 @@ object TokenPerAddressSchema
 
   def createConcurrentIndexes()(implicit ec: ExecutionContext): DBActionW[Unit] =
     for {
-      _ <- createGrouplessAddressTimestampIndex()
+      _ <- createTokenGrouplessAddressIndex()
     } yield ()
 
-  def createGrouplessAddressTimestampIndex(): DBActionW[Int] =
+  def createTokenGrouplessAddressIndex(): DBActionW[Int] =
     sqlu"""
       CREATE INDEX token_tx_per_address_token_groupless_address_idx
       ON token_tx_per_addresses (token, groupless_address)

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenTxPerAddressSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenTxPerAddressSchema.scala
@@ -16,9 +16,12 @@
 
 package org.alephium.explorer.persistence.schema
 
+import scala.concurrent.ExecutionContext
+
 import slick.jdbc.PostgresProfile.api._
 import slick.lifted.{Index, PrimaryKey, ProvenShape}
 
+import org.alephium.explorer.persistence.DBActionW
 import org.alephium.explorer.persistence.model.TokenTxPerAddressEntity
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.protocol.model.{Address, AddressLike, BlockHash, TokenId, TransactionId}
@@ -56,6 +59,18 @@ object TokenPerAddressSchema
       CommonIndex.blockTimestampTxOrderIndex(this),
       CommonIndex.timestampIndex(this)
     )
+
+  def createConcurrentIndexes()(implicit ec: ExecutionContext): DBActionW[Unit] =
+    for {
+      _ <- createGrouplessAddressTimestampIndex()
+    } yield ()
+
+  def createGrouplessAddressTimestampIndex(): DBActionW[Int] =
+    sqlu"""
+      CREATE INDEX token_tx_per_address_token_groupless_address_idx
+      ON token_tx_per_addresses (token, groupless_address)
+      WHERE groupless_address IS NOT NULL;
+    """
 
   val table: TableQuery[TokenPerAddresses] = TableQuery[TokenPerAddresses]
 }

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionPerAddressSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionPerAddressSchema.scala
@@ -16,9 +16,12 @@
 
 package org.alephium.explorer.persistence.schema
 
+import scala.concurrent.ExecutionContext
+
 import slick.jdbc.PostgresProfile.api._
 import slick.lifted.{Index, PrimaryKey, ProvenShape}
 
+import org.alephium.explorer.persistence.DBActionW
 import org.alephium.explorer.persistence.model.TransactionPerAddressEntity
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.protocol.model.{Address, AddressLike, BlockHash, TransactionId}
@@ -57,6 +60,18 @@ object TransactionPerAddressSchema
       CommonIndex.blockTimestampTxOrderIndex(this),
       CommonIndex.timestampIndex(this)
     )
+
+  def createConcurrentIndexes()(implicit ec: ExecutionContext): DBActionW[Unit] =
+    for {
+      _ <- createGrouplessAddressTimestampIndex()
+    } yield ()
+
+  def createGrouplessAddressTimestampIndex(): DBActionW[Int] =
+    sqlu"""
+      CREATE INDEX txs_per_address_groupless_address_timestamp_idx
+      ON transaction_per_addresses (groupless_address, block_timestamp)
+      WHERE groupless_address IS NOT NULL;
+    """
 
   val table: TableQuery[TransactionPerAddresses] = TableQuery[TransactionPerAddresses]
 }

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionPerAddressSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionPerAddressSchema.scala
@@ -68,7 +68,7 @@ object TransactionPerAddressSchema
 
   def createGrouplessAddressTimestampIndex(): DBActionW[Int] =
     sqlu"""
-      CREATE INDEX txs_per_address_groupless_address_timestamp_idx
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS txs_per_address_groupless_address_timestamp_idx
       ON transaction_per_addresses (groupless_address, block_timestamp)
       WHERE groupless_address IS NOT NULL;
     """

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/UInputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/UInputSchema.scala
@@ -23,7 +23,7 @@ import slick.lifted.{Index, PrimaryKey, ProvenShape}
 import org.alephium.explorer.persistence.model.UInputEntity
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.protocol.Hash
-import org.alephium.protocol.model.{Address, TransactionId}
+import org.alephium.protocol.model.{Address, AddressLike, TransactionId}
 
 object UInputSchema extends Schema[UInputEntity]("uinputs") {
 
@@ -33,7 +33,9 @@ object UInputSchema extends Schema[UInputEntity]("uinputs") {
     def outputRefKey: Rep[Hash]               = column[Hash]("output_ref_key", O.SqlType("BYTEA"))
     def unlockScript: Rep[Option[ByteString]] = column[Option[ByteString]]("unlock_script")
     def address: Rep[Option[Address]]         = column[Option[Address]]("address")
-    def uinputOrder: Rep[Int]                 = column[Int]("uinput_order")
+    def grouplessAddress: Rep[Option[AddressLike]] =
+      column[Option[AddressLike]]("groupless_address")
+    def uinputOrder: Rep[Int] = column[Int]("uinput_order")
 
     def pk: PrimaryKey = primaryKey("uinputs_pk", (outputRefKey, txHash))
 
@@ -41,7 +43,7 @@ object UInputSchema extends Schema[UInputEntity]("uinputs") {
     def uinputsP2pkhAddressIdx: Index = index("uinputs_address_idx", address)
 
     def * : ProvenShape[UInputEntity] =
-      (txHash, hint, outputRefKey, unlockScript, address, uinputOrder)
+      (txHash, hint, outputRefKey, unlockScript, address, grouplessAddress, uinputOrder)
         .<>((UInputEntity.apply _).tupled, UInputEntity.unapply)
   }
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/UOutputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/UOutputSchema.scala
@@ -26,7 +26,7 @@ import org.alephium.explorer.api.model.Token
 import org.alephium.explorer.persistence.model.UOutputEntity
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.protocol.Hash
-import org.alephium.protocol.model.{Address, TransactionId}
+import org.alephium.protocol.model.{Address, AddressLike, TransactionId}
 import org.alephium.util.{TimeStamp, U256}
 
 object UOutputSchema extends Schema[UOutputEntity]("uoutputs") {
@@ -37,7 +37,9 @@ object UOutputSchema extends Schema[UOutputEntity]("uoutputs") {
     def key: Rep[Hash]             = column[Hash]("key", O.SqlType("BYTEA"))
     def amount: Rep[U256] =
       column[U256]("amount", O.SqlType("DECIMAL(80,0)")) // U256.MaxValue has 78 digits
-    def address: Rep[Address]                = column[Address]("address")
+    def address: Rep[Address] = column[Address]("address")
+    def grouplessAddress: Rep[Option[AddressLike]] =
+      column[Option[AddressLike]]("groupless_address")
     def tokens: Rep[Option[ArraySeq[Token]]] = column[Option[ArraySeq[Token]]]("tokens")
     def lockTime: Rep[Option[TimeStamp]]     = column[Option[TimeStamp]]("lock_time")
     def message: Rep[Option[ByteString]]     = column[Option[ByteString]]("message")
@@ -48,7 +50,18 @@ object UOutputSchema extends Schema[UOutputEntity]("uoutputs") {
     def txHashIdx: Index = index("uoutputs_tx_hash_idx", txHash)
 
     def * : ProvenShape[UOutputEntity] =
-      (txHash, hint, key, amount, address, tokens, lockTime, message, uoutputOrder)
+      (
+        txHash,
+        hint,
+        key,
+        amount,
+        address,
+        grouplessAddress,
+        tokens,
+        lockTime,
+        message,
+        uoutputOrder
+      )
         .<>((UOutputEntity.apply _).tupled, UOutputEntity.unapply)
   }
 

--- a/app/src/main/scala/org/alephium/explorer/util/AddressUtil.scala
+++ b/app/src/main/scala/org/alephium/explorer/util/AddressUtil.scala
@@ -1,0 +1,34 @@
+// Copyright 2018 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+package org.alephium.explorer.util
+
+import org.alephium.protocol.model.{Address, AddressLike}
+import org.alephium.protocol.vm.LockupScript
+
+object AddressUtil {
+
+  def convertToGrouplessAddress(address: Address): Option[AddressLike] =
+    address match {
+      case Address.Asset(lockup) =>
+        lockup match {
+          case LockupScript.P2PK(pk, _) =>
+            Some(AddressLike(LockupScript.HalfDecodedP2PK(pk)))
+          case _ => None
+        }
+      case _ => None
+    }
+}

--- a/app/src/test/scala/org/alephium/explorer/GenDBModel.scala
+++ b/app/src/test/scala/org/alephium/explorer/GenDBModel.scala
@@ -32,6 +32,7 @@ import org.alephium.explorer.GenCoreUtil._
 import org.alephium.explorer.api.model.Height
 import org.alephium.explorer.persistence.model._
 import org.alephium.explorer.service.BlockFlowClient
+import org.alephium.explorer.util.AddressUtil
 import org.alephium.protocol.ALPH
 import org.alephium.protocol.model.{Address, BlockHash, ChainIndex, GroupIndex, TransactionId}
 import org.alephium.util.{AVector, TimeStamp}
@@ -71,7 +72,7 @@ object GenDBModel {
         hint = hint,
         key = key,
         amount = amount,
-        grouplessAddress = Some(address),
+        grouplessAddress = AddressUtil.convertToGrouplessAddress(address),
         address = address,
         tokens = tokens,
         mainChain = mainChain,
@@ -115,6 +116,7 @@ object GenDBModel {
       key = key,
       amount = amount,
       address = address,
+      grouplessAddress = AddressUtil.convertToGrouplessAddress(address),
       tokens = tokens,
       lockTime = if (outputType == OutputEntity.Asset) lockTime else None,
       message = if (outputType == OutputEntity.Asset) message else None,
@@ -166,6 +168,7 @@ object GenDBModel {
       outputRefKey,
       unlockScript,
       address,
+      grouplessAddress = address.flatMap(AddressUtil.convertToGrouplessAddress),
       uinputOrder
     )
 
@@ -195,7 +198,7 @@ object GenDBModel {
       coinbase  <- Arbitrary.arbitrary[Boolean]
     } yield TransactionPerAddressEntity(
       address = address,
-      grouplessAddress = Some(address),
+      grouplessAddress = AddressUtil.convertToGrouplessAddress(address),
       hash = hash,
       blockHash = blockHash,
       timestamp = timestamp,
@@ -236,7 +239,7 @@ object GenDBModel {
       token     <- tokenIdGen
     } yield TokenTxPerAddressEntity(
       address = address,
-      grouplessAddress = Some(address),
+      grouplessAddress = AddressUtil.convertToGrouplessAddress(address),
       hash = hash,
       blockHash = blockHash,
       timestamp = timestamp,

--- a/app/src/test/scala/org/alephium/explorer/persistence/dao/BlockDaoSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/dao/BlockDaoSpec.scala
@@ -38,6 +38,7 @@ import org.alephium.explorer.persistence.queries.InputUpdateQueries
 import org.alephium.explorer.persistence.schema._
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.explorer.service.BlockFlowClient
+import org.alephium.explorer.util.AddressUtil
 import org.alephium.explorer.util.TestUtils._
 import org.alephium.json.Json._
 import org.alephium.protocol.config.GroupConfig
@@ -283,7 +284,7 @@ class BlockDaoSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with D
       TransactionPerAddressEntity(
         hash = output.txHash,
         address = output.address,
-        grouplessAddress = Some(output.address),
+        grouplessAddress = AddressUtil.convertToGrouplessAddress(output.address),
         blockHash = output.blockHash,
         timestamp = output.timestamp,
         txOrder = input.txOrder,

--- a/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/AddressReadState.scala
+++ b/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/AddressReadState.scala
@@ -224,8 +224,12 @@ class AddressReadState(val db: DBExecutor)
         .andThen(InputSchema.createMainChainIndex())
         .andThen(OutputSchema.createMainChainIndex())
         .andThen(TransactionPerAddressSchema.createMainChainIndex())
-        .andThen(OutputSchema.createNonSpentIndex())
-        .andThen(OutputSchema.createNonSpentOutputCoveringIndex())
+        .andThen(OutputSchema.createConcurrentIndexes())
+        .andThen(InputSchema.createConcurrentIndexes())
+        .andThen(TokenOutputSchema.createConcurrentIndexes())
+        .andThen(InputSchema.createConcurrentIndexes())
+        .andThen(TransactionPerAddressSchema.createConcurrentIndexes())
+        .andThen(TokenPerAddressSchema.createConcurrentIndexes())
 
     val _ = db.runNow(
       action = createTable,


### PR DESCRIPTION
A migration is needed to drop a index that has a wrong name + it was indexing the `address` field too while it only need `groupless_address`