### PR TITLE
Update node to v3.15.1

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
@@ -26,11 +26,11 @@ import sttp.tapir.generic.auto._
 import sttp.tapir.server.vertx.streams.VertxStreams
 
 import org.alephium.api.Endpoints.jsonBody
-import org.alephium.api.model.TimeInterval
+import org.alephium.api.model.{Address => ApiAddress, TimeInterval}
 import org.alephium.explorer.api.EndpointExamples._
 import org.alephium.explorer.api.model._
 import org.alephium.protocol.PublicKey
-import org.alephium.protocol.model.{AddressLike, TokenId}
+import org.alephium.protocol.model.TokenId
 import org.alephium.util.{Duration, TimeStamp}
 
 // scalastyle:off magic.number
@@ -52,19 +52,19 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
 
   private val addressesLikeEndpoint =
     baseAddressesEndpoint
-      .in(path[AddressLike]("address")(Codecs.explorerAddressLikeTapirCodec))
+      .in(path[ApiAddress]("address")(Codecs.explorerAddressTapirCodec))
 
   private val addressesLikeTokensEndpoint =
     baseAddressesEndpoint
-      .in(path[AddressLike]("address")(Codecs.explorerAddressLikeTapirCodec))
+      .in(path[ApiAddress]("address")(Codecs.explorerAddressTapirCodec))
       .in("tokens")
 
-  val getAddressInfo: BaseEndpoint[AddressLike, AddressInfo] =
+  val getAddressInfo: BaseEndpoint[ApiAddress, AddressInfo] =
     addressesLikeEndpoint.get
       .out(jsonBody[AddressInfo])
       .summary("Get address information")
 
-  val getTransactionsByAddress: BaseEndpoint[(AddressLike, Pagination), ArraySeq[Transaction]] =
+  val getTransactionsByAddress: BaseEndpoint[(ApiAddress, Pagination), ArraySeq[Transaction]] =
     addressesLikeEndpoint.get
       .in("transactions")
       .in(pagination)
@@ -72,16 +72,16 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
       .summary("List transactions of a given address")
 
   // format: off
-  lazy val getTransactionsByAddresses: BaseEndpoint[(ArraySeq[AddressLike], Option[TimeStamp], Option[TimeStamp], Pagination), ArraySeq[Transaction]] =
+  lazy val getTransactionsByAddresses: BaseEndpoint[(ArraySeq[ApiAddress], Option[TimeStamp], Option[TimeStamp], Pagination), ArraySeq[Transaction]] =
     baseAddressesEndpoint.post
-      .in(arrayBody[AddressLike]("addresses", maxSizeAddresses))
+      .in(arrayBody[ApiAddress]("addresses", maxSizeAddresses))
       .in("transactions")
       .in(optionalTimeIntervalQuery)
       .in(pagination)
       .out(jsonBody[ArraySeq[Transaction]])
       .summary("List transactions for given addresses")
 
-  val getTransactionsByAddressTimeRanged: BaseEndpoint[(AddressLike, TimeInterval, Pagination), ArraySeq[Transaction]] =
+  val getTransactionsByAddressTimeRanged: BaseEndpoint[(ApiAddress, TimeInterval, Pagination), ArraySeq[Transaction]] =
     addressesLikeEndpoint.get
       .in("timeranged-transactions")
       .in(timeIntervalQuery)
@@ -90,39 +90,39 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
       .summary("List transactions of a given address within a time-range")
   // format: on
 
-  val getTotalTransactionsByAddress: BaseEndpoint[AddressLike, Int] =
+  val getTotalTransactionsByAddress: BaseEndpoint[ApiAddress, Int] =
     addressesLikeEndpoint.get
       .in("total-transactions")
       .out(jsonBody[Int])
       .summary("Get total transactions of a given address")
 
-  val getLatestTransactionInfo: BaseEndpoint[AddressLike, TransactionInfo] =
+  val getLatestTransactionInfo: BaseEndpoint[ApiAddress, TransactionInfo] =
     addressesLikeEndpoint.get
       .in("latest-transaction")
       .out(jsonBody[TransactionInfo])
       .summary("Get latest transaction information of a given address")
 
-  val addressMempoolTransactions: BaseEndpoint[AddressLike, ArraySeq[MempoolTransaction]] =
+  val addressMempoolTransactions: BaseEndpoint[ApiAddress, ArraySeq[MempoolTransaction]] =
     addressesLikeEndpoint.get
       .in("mempool")
       .in("transactions")
       .out(jsonBody[ArraySeq[MempoolTransaction]])
       .summary("List mempool transactions of a given address")
 
-  val getAddressBalance: BaseEndpoint[AddressLike, AddressBalance] =
+  val getAddressBalance: BaseEndpoint[ApiAddress, AddressBalance] =
     addressesLikeEndpoint.get
       .in("balance")
       .out(jsonBody[AddressBalance])
       .summary("Get address balance")
 
-  val listAddressTokens: BaseEndpoint[(AddressLike, Pagination), ArraySeq[TokenId]] =
+  val listAddressTokens: BaseEndpoint[(ApiAddress, Pagination), ArraySeq[TokenId]] =
     addressesLikeTokensEndpoint.get
       .out(jsonBody[ArraySeq[TokenId]])
       .in(paginator(limit = 100))
       .summary("List address tokens")
       .deprecated()
 
-  val getAddressTokenBalance: BaseEndpoint[(AddressLike, TokenId), AddressTokenBalance] =
+  val getAddressTokenBalance: BaseEndpoint[(ApiAddress, TokenId), AddressTokenBalance] =
     addressesLikeTokensEndpoint.get
       .in(path[TokenId]("token_id"))
       .in("balance")
@@ -130,7 +130,7 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
       .summary("Get address balance of given token")
 
   val listAddressTokensBalance
-      : BaseEndpoint[(AddressLike, Pagination), ArraySeq[AddressTokenBalance]] =
+      : BaseEndpoint[(ApiAddress, Pagination), ArraySeq[AddressTokenBalance]] =
     addressesLikeEndpoint.get
       .in("tokens-balance")
       .in(pagination)
@@ -138,7 +138,7 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
       .summary("Get address tokens with balance")
 
   val listAddressTokenTransactions
-      : BaseEndpoint[(AddressLike, TokenId, Pagination), ArraySeq[Transaction]] =
+      : BaseEndpoint[(ApiAddress, TokenId, Pagination), ArraySeq[Transaction]] =
     addressesLikeTokensEndpoint.get
       .in(path[TokenId]("token_id"))
       .in("transactions")
@@ -146,17 +146,17 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
       .out(jsonBody[ArraySeq[Transaction]])
       .summary("List address tokens")
 
-  lazy val areAddressesActive: BaseEndpoint[ArraySeq[AddressLike], ArraySeq[Boolean]] =
+  lazy val areAddressesActive: BaseEndpoint[ArraySeq[ApiAddress], ArraySeq[Boolean]] =
     baseAddressesEndpoint
       .tag("Addresses")
       .in("used")
       .post
-      .in(arrayBody[AddressLike]("addresses", maxSizeAddresses))
+      .in(arrayBody[ApiAddress]("addresses", maxSizeAddresses))
       .out(jsonBody[ArraySeq[Boolean]])
       .summary("Are the addresses used (at least 1 transaction)")
 
   lazy val exportTransactionsCsvByAddress
-      : BaseEndpoint[(AddressLike, TimeInterval), (String, ReadStream[Buffer])] =
+      : BaseEndpoint[(ApiAddress, TimeInterval), (String, ReadStream[Buffer])] =
     addressesLikeEndpoint.get
       .in("export-transactions")
       .in("csv")
@@ -165,7 +165,7 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
       .out(streamTextBody(VertxStreams)(TextCsv()))
 
   val getAddressAmountHistory
-      : BaseEndpoint[(AddressLike, TimeInterval, IntervalType), AmountHistory] =
+      : BaseEndpoint[(ApiAddress, TimeInterval, IntervalType), AmountHistory] =
     addressesLikeEndpoint.get
       .in("amount-history")
       .in(timeIntervalQuery)
@@ -173,7 +173,7 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
       .out(jsonBody[AmountHistory])
       .deprecated()
 
-  val getPublicKey: BaseEndpoint[AddressLike, PublicKey] =
+  val getPublicKey: BaseEndpoint[ApiAddress, PublicKey] =
     addressesLikeEndpoint.get
       .in("public-key")
       .out(jsonBody[PublicKey])

--- a/app/src/main/scala/org/alephium/explorer/api/Codecs.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/Codecs.scala
@@ -23,22 +23,22 @@ import sttp.tapir.Codec.PlainCodec
 import upickle.core.Abort
 
 import org.alephium.api.TapirCodecs
+import org.alephium.api.model.{Address => ApiAddress}
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.config.Default
 import org.alephium.json.Json._
 import org.alephium.protocol.config.GroupConfig
-import org.alephium.protocol.model.AddressLike
 
 object Codecs extends TapirCodecs {
 
   implicit val groupConfig: GroupConfig = Default.groupConfig
 
-  implicit val grouplessAddressRW: ReadWriter[AddressLike] = readwriter[String].bimap(
+  implicit val grouplessAddressRW: ReadWriter[ApiAddress] = readwriter[String].bimap(
     _.toBase58,
-    input => AddressLike.fromBase58(input).getOrElse(throw Abort(s"Cannot parse address: $input"))
+    input => ApiAddress.fromBase58(input).getOrElse(throw Abort(s"Cannot parse Address: $input"))
   )
 
-  implicit val explorerAddressLikeTapirCodec: PlainCodec[AddressLike] = fromJson[AddressLike]
+  implicit val explorerAddressTapirCodec: PlainCodec[ApiAddress] = fromJson[ApiAddress]
 
   @SuppressWarnings(
     Array(

--- a/app/src/main/scala/org/alephium/explorer/api/EndpointExamples.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/EndpointExamples.scala
@@ -22,19 +22,12 @@ import akka.util.ByteString
 import sttp.tapir.EndpointIO.Example
 
 import org.alephium.api.EndpointsExamples
-import org.alephium.api.model.{Amount, ValBool}
+import org.alephium.api.model.{Address => ApiAddress, Amount, ValBool}
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.persistence.queries.ExplainResult
 import org.alephium.protocol.{ALPH, PublicKey}
 import org.alephium.protocol.mining.HashRate
-import org.alephium.protocol.model.{
-  Address,
-  AddressLike,
-  BlockHash,
-  ContractId,
-  GroupIndex,
-  TokenId
-}
+import org.alephium.protocol.model.{Address, BlockHash, ContractId, GroupIndex, TokenId}
 import org.alephium.util.{Hex, U256}
 
 /** Contains OpenAPI Examples.
@@ -63,12 +56,12 @@ object EndpointExamples extends EndpointsExamples {
 
   private val address1Str: String = "1AujpupFP4KWeZvqA7itsHY9cLJmx4qTzojVZrg8W9y9n"
   private val address1: Address =
-    Address.fromBase58(address1Str).get
+    Address.fromBase58(address1Str).toOption.get
 
   private val address2: Address =
-    Address.fromBase58("22fnZLkZJUSyhXgboirmJktWkEBRk1pV8L6gfpc53hvVM").get
+    Address.fromBase58("22fnZLkZJUSyhXgboirmJktWkEBRk1pV8L6gfpc53hvVM").toOption.get
 
-  private val grouplessAddress: AddressLike = AddressLike.fromBase58(address1Str).get
+  private val grouplessAddress: ApiAddress = ApiAddress.fromBase58(address1Str).toOption.get
 
   private val contract =
     ContractId
@@ -79,7 +72,8 @@ object EndpointExamples extends EndpointsExamples {
     contract
   )
 
-  private val addressAsset: Address.Asset = Address.asset(address1.toBase58).get
+  private val addressAsset: Address.Asset =
+    Address.asset(address1.toBase58).toOption.get
 
   private val groupIndex1: GroupIndex = new GroupIndex(1)
   private val groupIndex2: GroupIndex = new GroupIndex(2)
@@ -366,7 +360,8 @@ object EndpointExamples extends EndpointsExamples {
 
   /** Examples
     */
-  implicit val grouplessAddressArray: List[Example[ArraySeq[AddressLike]]] =
+
+  implicit val grouplessAddressArray2: List[Example[ArraySeq[ApiAddress]]] =
     simpleExample(ArraySeq(grouplessAddress))
 
   implicit val blockEntryLiteExample: List[Example[BlockEntryLite]] =

--- a/app/src/main/scala/org/alephium/explorer/api/QueryParams.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/QueryParams.scala
@@ -22,7 +22,6 @@ import sttp.tapir.CodecFormat.TextPlain
 import org.alephium.api.TapirCodecs
 import org.alephium.api.model.TimeInterval
 import org.alephium.explorer.api.Codecs._
-import org.alephium.explorer.api.Schemas._
 import org.alephium.explorer.api.model._
 import org.alephium.protocol.model.TokenId
 import org.alephium.util.{Duration, TimeStamp}

--- a/app/src/main/scala/org/alephium/explorer/api/Schemas.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/Schemas.scala
@@ -26,5 +26,4 @@ object Schemas {
   implicit val configuration: Configuration = Configuration.default.withDiscriminator("type")
 
   implicit val contractIdSchema: Schema[ContractId] = TapirSchemas.hashSchema.as[ContractId]
-  implicit val tokenIdSchema: Schema[TokenId]       = TapirSchemas.hashSchema.as[TokenId]
 }

--- a/app/src/main/scala/org/alephium/explorer/api/TokensEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/TokensEndpoints.scala
@@ -23,7 +23,6 @@ import sttp.tapir.generic.auto._
 
 import org.alephium.api.Endpoints.jsonBody
 import org.alephium.explorer.api.EndpointExamples._
-import org.alephium.explorer.api.Schemas.tokenIdSchema
 import org.alephium.explorer.api.model._
 import org.alephium.protocol.model.{Address, TokenId}
 

--- a/app/src/main/scala/org/alephium/explorer/api/model/TokenInfo.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/TokenInfo.scala
@@ -18,8 +18,8 @@ package org.alephium.explorer.api.model
 
 import sttp.tapir._
 
+import org.alephium.api.TapirSchemas.tokenIdSchema
 import org.alephium.explorer.api.Json._
-import org.alephium.explorer.api.Schemas.tokenIdSchema
 import org.alephium.json.Json._
 import org.alephium.protocol.model.TokenId
 

--- a/app/src/main/scala/org/alephium/explorer/api/model/Transaction.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/Transaction.scala
@@ -25,11 +25,12 @@ import sttp.tapir.Schema
 
 import org.alephium.api.TapirSchemas._
 import org.alephium.api.UtilJson._
+import org.alephium.api.model.{Address => ApiAddress}
 import org.alephium.explorer.api.Json._
 import org.alephium.explorer.util.UtxoUtil
 import org.alephium.json.Json._
 import org.alephium.protocol.ALPH
-import org.alephium.protocol.model.{Address, AddressLike, BlockHash, TokenId, TransactionId}
+import org.alephium.protocol.model.{Address, BlockHash, TokenId, TransactionId}
 import org.alephium.util.{TimeStamp, U256}
 import org.alephium.util.AVector
 
@@ -49,7 +50,7 @@ final case class Transaction(
     scriptSignatures: ArraySeq[ByteString],
     coinbase: Boolean
 ) {
-  def toCsv(address: AddressLike, metadata: Map[TokenId, FungibleTokenMetadata]): String = {
+  def toCsv(address: ApiAddress, metadata: Map[TokenId, FungibleTokenMetadata]): String = {
     val dateTime      = Instant.ofEpochMilli(timestamp.millis)
     val fromAddresses = UtxoUtil.fromAddresses(inputs)
     val toAddresses =

--- a/app/src/main/scala/org/alephium/explorer/persistence/dao/MempoolDao.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/dao/MempoolDao.scala
@@ -24,6 +24,7 @@ import slick.dbio.DBIOAction
 import slick.jdbc.PostgresProfile
 import slick.jdbc.PostgresProfile.api._
 
+import org.alephium.api.model.{Address => ApiAddress}
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.persistence._
 import org.alephium.explorer.persistence.DBRunner._
@@ -31,7 +32,7 @@ import org.alephium.explorer.persistence.model._
 import org.alephium.explorer.persistence.queries.MempoolQueries._
 import org.alephium.explorer.persistence.schema._
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
-import org.alephium.protocol.model.{AddressLike, TransactionId}
+import org.alephium.protocol.model.TransactionId
 
 trait MempoolDao {
 
@@ -45,7 +46,7 @@ trait MempoolDao {
       databaseConfig: DatabaseConfig[PostgresProfile]
   ): Future[ArraySeq[MempoolTransaction]]
 
-  def listByAddress(address: AddressLike)(implicit
+  def listByAddress(address: ApiAddress)(implicit
       executionContext: ExecutionContext,
       databaseConfig: DatabaseConfig[PostgresProfile]
   ): Future[ArraySeq[MempoolTransaction]]
@@ -124,7 +125,7 @@ object MempoolDao extends MempoolDao {
       }
     })
   }
-  def listByAddress(address: AddressLike)(implicit
+  def listByAddress(address: ApiAddress)(implicit
       executionContext: ExecutionContext,
       databaseConfig: DatabaseConfig[PostgresProfile]
   ): Future[ArraySeq[MempoolTransaction]] = {

--- a/app/src/main/scala/org/alephium/explorer/persistence/dao/TransactionDao.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/dao/TransactionDao.scala
@@ -22,10 +22,12 @@ import scala.concurrent.{ExecutionContext, Future}
 import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
 
+import org.alephium.api.model.{Address => ApiAddress}
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.persistence.DBRunner._
 import org.alephium.explorer.persistence.queries.TransactionQueries._
-import org.alephium.protocol.model.{AddressLike, TransactionId}
+import org.alephium.protocol.config.GroupConfig
+import org.alephium.protocol.model.TransactionId
 import org.alephium.util.{TimeStamp, U256}
 
 object TransactionDao {
@@ -36,14 +38,14 @@ object TransactionDao {
   ): Future[Option[Transaction]] =
     run(getTransactionAction(hash))
 
-  def getByAddress(address: AddressLike, pagination: Pagination)(implicit
+  def getByAddress(address: ApiAddress, pagination: Pagination)(implicit
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]
   ): Future[ArraySeq[Transaction]] =
     run(getTransactionsByAddress(address, pagination))
 
   def getByAddresses(
-      addresses: ArraySeq[AddressLike],
+      addresses: ArraySeq[ApiAddress],
       fromTime: Option[TimeStamp],
       toTime: Option[TimeStamp],
       pagination: Pagination
@@ -54,7 +56,7 @@ object TransactionDao {
     run(getTransactionsByAddresses(addresses, fromTime, toTime, pagination))
 
   def getByAddressTimeRanged(
-      address: AddressLike,
+      address: ApiAddress,
       fromTime: TimeStamp,
       toTime: TimeStamp,
       pagination: Pagination
@@ -64,7 +66,7 @@ object TransactionDao {
   ): Future[ArraySeq[Transaction]] =
     run(getTransactionsByAddressTimeRanged(address, fromTime, toTime, pagination))
 
-  def getLatestTransactionInfoByAddress(address: AddressLike)(implicit
+  def getLatestTransactionInfoByAddress(address: ApiAddress)(implicit
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]
   ): Future[Option[TransactionInfo]] =
@@ -73,18 +75,22 @@ object TransactionDao {
     }))
 
   def getNumberByAddress(
-      address: AddressLike
+      address: ApiAddress
   )(implicit ec: ExecutionContext, dc: DatabaseConfig[PostgresProfile]): Future[Int] =
     run(countAddressTransactions(address)).map(_.headOption.getOrElse(0))
 
   def getBalance(
-      address: AddressLike,
+      address: ApiAddress,
       latestFinalizedTimestamp: TimeStamp
   )(implicit ec: ExecutionContext, dc: DatabaseConfig[PostgresProfile]): Future[(U256, U256)] =
     run(getBalanceAction(address, latestFinalizedTimestamp))
 
   def areAddressesActive(
-      addresses: ArraySeq[AddressLike]
-  )(implicit ec: ExecutionContext, dc: DatabaseConfig[PostgresProfile]): Future[ArraySeq[Boolean]] =
+      addresses: ArraySeq[ApiAddress]
+  )(implicit
+      ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile],
+      groupConfig: GroupConfig
+  ): Future[ArraySeq[Boolean]] =
     run(areAddressesActiveAction(addresses))
 }

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/GrouplessAddress.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/GrouplessAddress.scala
@@ -16,16 +16,12 @@
 
 package org.alephium.explorer.persistence.model
 
-import org.alephium.protocol.model.{Address, BlockHash, TokenId, TransactionId}
-import org.alephium.util.TimeStamp
+import org.alephium.api.model.{Address => ApiAddress}
+import org.alephium.protocol.config.GroupConfig
 
-final case class TokenTxPerAddressEntity(
-    address: Address,
-    grouplessAddress: Option[GrouplessAddress],
-    hash: TransactionId,
-    blockHash: BlockHash,
-    timestamp: TimeStamp,
-    txOrder: Int,
-    mainChain: Boolean,
-    token: TokenId
-)
+final case class GrouplessAddress(
+    lockupScript: ApiAddress.HalfDecodedLockupScript
+) {
+
+  def toBase58(implicit config: GroupConfig): String = ApiAddress(lockupScript).toBase58
+}

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/InputEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/InputEntity.scala
@@ -22,7 +22,7 @@ import akka.util.ByteString
 
 import org.alephium.explorer.api.model.{Input, OutputRef, Token}
 import org.alephium.protocol.Hash
-import org.alephium.protocol.model.{Address, AddressLike, BlockHash, TransactionId}
+import org.alephium.protocol.model.{Address, BlockHash, TransactionId}
 import org.alephium.util.{TimeStamp, U256}
 
 trait InputEntityLike {
@@ -31,7 +31,7 @@ trait InputEntityLike {
   def unlockScript: Option[ByteString]
   def outputRefTxHash: Option[TransactionId]
   def outputRefAddress: Option[Address]
-  def outputRefAddressLike: Option[AddressLike]
+  def outputRefGrouplessAddress: Option[GrouplessAddress]
   def outputRefAmount: Option[U256]
   def outputRefTokens: Option[ArraySeq[Token]]
   def contractInput: Boolean
@@ -60,7 +60,7 @@ final case class InputEntity(
     txOrder: Int,
     outputRefTxHash: Option[TransactionId],
     outputRefAddress: Option[Address],
-    outputRefAddressLike: Option[AddressLike],
+    outputRefGrouplessAddress: Option[GrouplessAddress],
     outputRefAmount: Option[U256],
     outputRefTokens: Option[ArraySeq[Token]], // None if empty list
     contractInput: Boolean

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/OutputEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/OutputEntity.scala
@@ -22,7 +22,7 @@ import akka.util.ByteString
 
 import org.alephium.explorer.api.model.{AssetOutput, ContractOutput, Output, Token}
 import org.alephium.protocol.Hash
-import org.alephium.protocol.model.{Address, AddressLike, BlockHash, TransactionId}
+import org.alephium.protocol.model.{Address, BlockHash, TransactionId}
 import org.alephium.util.{TimeStamp, U256}
 trait OutputEntityLike {
 
@@ -31,7 +31,7 @@ trait OutputEntityLike {
   def key: Hash
   def amount: U256
   def address: Address
-  def grouplessAddress: Option[AddressLike]
+  def grouplessAddress: Option[GrouplessAddress]
   def tokens: Option[ArraySeq[Token]]
   def lockTime: Option[TimeStamp]
   def message: Option[ByteString]
@@ -75,7 +75,7 @@ final case class OutputEntity(
     key: Hash,
     amount: U256,
     address: Address,
-    grouplessAddress: Option[AddressLike],
+    grouplessAddress: Option[GrouplessAddress],
     tokens: Option[ArraySeq[Token]], // None if empty list
     mainChain: Boolean,
     lockTime: Option[TimeStamp],

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/TokenOutputEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/TokenOutputEntity.scala
@@ -19,7 +19,7 @@ package org.alephium.explorer.persistence.model
 import akka.util.ByteString
 
 import org.alephium.protocol.Hash
-import org.alephium.protocol.model.{Address, AddressLike, BlockHash, TokenId, TransactionId}
+import org.alephium.protocol.model.{Address, BlockHash, TokenId, TransactionId}
 import org.alephium.util.{TimeStamp, U256}
 
 final case class TokenOutputEntity(
@@ -32,7 +32,7 @@ final case class TokenOutputEntity(
     token: TokenId,
     amount: U256,
     address: Address,
-    grouplessAddress: Option[AddressLike],
+    grouplessAddress: Option[GrouplessAddress],
     mainChain: Boolean,
     lockTime: Option[TimeStamp],
     message: Option[ByteString],

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/TransactionPerAddressEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/TransactionPerAddressEntity.scala
@@ -16,12 +16,12 @@
 
 package org.alephium.explorer.persistence.model
 
-import org.alephium.protocol.model.{Address, AddressLike, BlockHash, TransactionId}
+import org.alephium.protocol.model.{Address, BlockHash, TransactionId}
 import org.alephium.util.TimeStamp
 
 final case class TransactionPerAddressEntity(
     address: Address,
-    grouplessAddress: Option[AddressLike],
+    grouplessAddress: Option[GrouplessAddress],
     hash: TransactionId,
     blockHash: BlockHash,
     timestamp: TimeStamp,

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/UInputEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/UInputEntity.scala
@@ -20,7 +20,7 @@ import akka.util.ByteString
 
 import org.alephium.explorer.api.model.{Input, OutputRef}
 import org.alephium.protocol.Hash
-import org.alephium.protocol.model.{Address, AddressLike}
+import org.alephium.protocol.model.Address
 import org.alephium.protocol.model.TransactionId
 
 final case class UInputEntity(
@@ -29,7 +29,7 @@ final case class UInputEntity(
     outputRefKey: Hash,
     unlockScript: Option[ByteString],
     address: Option[Address],
-    grouplessAddress: Option[AddressLike],
+    grouplessAddress: Option[GrouplessAddress],
     uinputOrder: Int
 ) {
   val toApi: Input = Input(

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/UOutputEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/UOutputEntity.scala
@@ -22,7 +22,7 @@ import akka.util.ByteString
 
 import org.alephium.explorer.api.model.{AssetOutput, Token}
 import org.alephium.protocol.Hash
-import org.alephium.protocol.model.{Address, AddressLike, TransactionId}
+import org.alephium.protocol.model.{Address, TransactionId}
 import org.alephium.util.{TimeStamp, U256}
 
 final case class UOutputEntity(
@@ -31,7 +31,7 @@ final case class UOutputEntity(
     key: Hash,
     amount: U256,
     address: Address,
-    grouplessAddress: Option[AddressLike],
+    grouplessAddress: Option[GrouplessAddress],
     tokens: Option[ArraySeq[Token]],
     lockTime: Option[TimeStamp],
     message: Option[ByteString],

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/InputQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/InputQueries.scala
@@ -24,6 +24,7 @@ import slick.dbio.DBIOAction
 import slick.jdbc._
 import slick.jdbc.PostgresProfile.api._
 
+import org.alephium.api.model.{Address => ApiAddress}
 import org.alephium.explorer.persistence._
 import org.alephium.explorer.persistence.model._
 import org.alephium.explorer.persistence.queries.result.{InputsFromTxQR, InputsQR}
@@ -31,7 +32,7 @@ import org.alephium.explorer.persistence.schema.CustomGetResult._
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.explorer.util.SlickExplainUtil._
 import org.alephium.explorer.util.SlickUtil._
-import org.alephium.protocol.model.{AddressLike, BlockHash, TransactionId}
+import org.alephium.protocol.model.{BlockHash, TransactionId}
 
 object InputQueries {
 
@@ -75,7 +76,7 @@ object InputQueries {
             params >> input.txOrder
             params >> input.outputRefTxHash
             params >> input.outputRefAddress
-            params >> input.outputRefAddressLike
+            params >> input.outputRefGrouplessAddress
             params >> input.outputRefAmount
             params >> input.contractInput
           }
@@ -153,7 +154,7 @@ object InputQueries {
         ORDER BY block_timestamp #${if (ascendingOrder) "" else "DESC"}
     """.asASE[InputEntity](inputGetResult)
 
-  def getUnlockScript(address: AddressLike)(implicit
+  def getUnlockScript(address: ApiAddress)(implicit
       ec: ExecutionContext
   ): DBActionR[Option[ByteString]] = {
     sql"""

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/InputUpdateQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/InputUpdateQueries.scala
@@ -25,9 +25,10 @@ import slick.jdbc.PostgresProfile.api._
 
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.persistence._
+import org.alephium.explorer.persistence.model.GrouplessAddress
 import org.alephium.explorer.persistence.schema.CustomGetResult._
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
-import org.alephium.protocol.model.{Address, AddressLike, BlockHash, TransactionId}
+import org.alephium.protocol.model.{Address, BlockHash, TransactionId}
 import org.alephium.util._
 
 object InputUpdateQueries {
@@ -35,7 +36,7 @@ object InputUpdateQueries {
   private type UpdateReturn =
     (
         Address,
-        Option[AddressLike],
+        Option[GrouplessAddress],
         Option[ArraySeq[Token]],
         TransactionId,
         BlockHash,

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/MempoolQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/MempoolQueries.scala
@@ -22,13 +22,14 @@ import slick.dbio.DBIOAction
 import slick.jdbc.{PositionedParameters, SetParameter, SQLActionBuilder}
 import slick.jdbc.PostgresProfile.api._
 
+import org.alephium.api.model.{Address => ApiAddress}
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.persistence._
 import org.alephium.explorer.persistence.model._
 import org.alephium.explorer.persistence.schema.CustomGetResult._
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.explorer.util.SlickUtil._
-import org.alephium.protocol.model.{AddressLike, TransactionId}
+import org.alephium.protocol.model.TransactionId
 
 object MempoolQueries {
 
@@ -56,7 +57,7 @@ object MempoolQueries {
       .asASE[MempoolTransactionEntity](mempoolTransactionGetResult)
   }
 
-  def listUTXHashesByAddress(address: AddressLike): DBActionSR[TransactionId] = {
+  def listUTXHashesByAddress(address: ApiAddress): DBActionSR[TransactionId] = {
     sql"""
       SELECT tx_hash
       FROM uinputs

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/OutputQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/OutputQueries.scala
@@ -23,6 +23,7 @@ import slick.dbio.DBIOAction
 import slick.jdbc.{PositionedParameters, SetParameter, SQLActionBuilder}
 import slick.jdbc.PostgresProfile.api._
 
+import org.alephium.api.model.{Address => ApiAddress}
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.persistence._
 import org.alephium.explorer.persistence.model._
@@ -32,8 +33,7 @@ import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.explorer.util.SlickExplainUtil._
 import org.alephium.explorer.util.SlickUtil._
 import org.alephium.protocol.Hash
-import org.alephium.protocol.model.{AddressLike, BlockHash, TransactionId}
-import org.alephium.protocol.vm.LockupScript
+import org.alephium.protocol.model.{BlockHash, TransactionId}
 import org.alephium.util.{TimeStamp, U256}
 
 object OutputQueries {
@@ -435,14 +435,14 @@ object OutputQueries {
     """
 
   def getBalanceUntilLockTime(
-      address: AddressLike,
+      address: ApiAddress,
       lockTime: TimeStamp,
       latestFinalizedTimestamp: TimeStamp
   )(implicit
       ec: ExecutionContext
   ): DBActionR[(Option[U256], Option[U256])] = {
-    val (ouptupAddressColumn, inputAddressColumn) = address.lockupScriptResult match {
-      case LockupScript.HalfDecodedP2PK(_) =>
+    val (ouptupAddressColumn, inputAddressColumn) = address.lockupScript match {
+      case _: ApiAddress.HalfDecodedLockupScript =>
         ("groupless_address", "output_ref_groupless_address")
       case _ =>
         ("address", "output_ref_address")

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/result/InputsFromTxQR.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/result/InputsFromTxQR.scala
@@ -22,10 +22,10 @@ import akka.util.ByteString
 import slick.jdbc.{GetResult, PositionedResult}
 
 import org.alephium.explorer.api.model._
-import org.alephium.explorer.persistence.model.InputEntityLike
+import org.alephium.explorer.persistence.model.{GrouplessAddress, InputEntityLike}
 import org.alephium.explorer.persistence.schema.CustomGetResult._
 import org.alephium.protocol.Hash
-import org.alephium.protocol.model.{Address, AddressLike, TransactionId}
+import org.alephium.protocol.model.{Address, TransactionId}
 import org.alephium.util.U256
 
 object InputsFromTxQR {
@@ -55,7 +55,7 @@ object InputsFromTxQR {
         unlockScript = result.<<?,
         outputRefTxHash = result.<<?,
         outputRefAddress = result.<<?,
-        outputRefAddressLike = result.<<?,
+        outputRefGrouplessAddress = result.<<?,
         outputRefAmount = result.<<?,
         outputRefTokens = result.<<?,
         contractInput = result.<<
@@ -71,7 +71,7 @@ final case class InputsFromTxQR(
     unlockScript: Option[ByteString],
     outputRefTxHash: Option[TransactionId],
     outputRefAddress: Option[Address],
-    outputRefAddressLike: Option[AddressLike],
+    outputRefGrouplessAddress: Option[GrouplessAddress],
     outputRefAmount: Option[U256],
     outputRefTokens: Option[ArraySeq[Token]],
     contractInput: Boolean

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/result/InputsQR.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/result/InputsQR.scala
@@ -22,10 +22,10 @@ import akka.util.ByteString
 import slick.jdbc.{GetResult, PositionedResult}
 
 import org.alephium.explorer.api.model._
-import org.alephium.explorer.persistence.model.InputEntityLike
+import org.alephium.explorer.persistence.model.{GrouplessAddress, InputEntityLike}
 import org.alephium.explorer.persistence.schema.CustomGetResult._
 import org.alephium.protocol.Hash
-import org.alephium.protocol.model.{Address, AddressLike, TransactionId}
+import org.alephium.protocol.model.{Address, TransactionId}
 import org.alephium.util.U256
 
 object InputsQR {
@@ -51,7 +51,7 @@ object InputsQR {
         unlockScript = result.<<?,
         outputRefTxHash = result.<<?,
         outputRefAddress = result.<<?,
-        outputRefAddressLike = result.<<?,
+        outputRefGrouplessAddress = result.<<?,
         outputRefAmount = result.<<?,
         outputRefTokens = result.<<?,
         contractInput = result.<<
@@ -65,7 +65,7 @@ final case class InputsQR(
     unlockScript: Option[ByteString],
     outputRefTxHash: Option[TransactionId],
     outputRefAddress: Option[Address],
-    outputRefAddressLike: Option[AddressLike],
+    outputRefGrouplessAddress: Option[GrouplessAddress],
     outputRefAmount: Option[U256],
     outputRefTokens: Option[ArraySeq[Token]],
     contractInput: Boolean

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/result/OutputsFromTxQR.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/result/OutputsFromTxQR.scala
@@ -22,10 +22,10 @@ import akka.util.ByteString
 import slick.jdbc.{GetResult, PositionedResult}
 
 import org.alephium.explorer.api.model._
-import org.alephium.explorer.persistence.model.{OutputEntity, OutputEntityLike}
+import org.alephium.explorer.persistence.model.{GrouplessAddress, OutputEntity, OutputEntityLike}
 import org.alephium.explorer.persistence.schema.CustomGetResult._
 import org.alephium.protocol.Hash
-import org.alephium.protocol.model.{Address, AddressLike, TransactionId}
+import org.alephium.protocol.model.{Address, TransactionId}
 import org.alephium.util.{TimeStamp, U256}
 object OutputsFromTxQR {
 
@@ -60,7 +60,7 @@ final case class OutputsFromTxQR(
     key: Hash,
     amount: U256,
     address: Address,
-    grouplessAddress: Option[AddressLike],
+    grouplessAddress: Option[GrouplessAddress],
     tokens: Option[ArraySeq[Token]],
     lockTime: Option[TimeStamp],
     message: Option[ByteString],

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/result/OutputsQR.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/result/OutputsQR.scala
@@ -22,10 +22,10 @@ import akka.util.ByteString
 import slick.jdbc.{GetResult, PositionedResult}
 
 import org.alephium.explorer.api.model._
-import org.alephium.explorer.persistence.model.{OutputEntity, OutputEntityLike}
+import org.alephium.explorer.persistence.model.{GrouplessAddress, OutputEntity, OutputEntityLike}
 import org.alephium.explorer.persistence.schema.CustomGetResult._
 import org.alephium.protocol.Hash
-import org.alephium.protocol.model.{Address, AddressLike, TransactionId}
+import org.alephium.protocol.model.{Address, TransactionId}
 import org.alephium.util.{TimeStamp, U256}
 
 object OutputsQR {
@@ -57,7 +57,7 @@ final case class OutputsQR(
     key: Hash,
     amount: U256,
     address: Address,
-    grouplessAddress: Option[AddressLike],
+    grouplessAddress: Option[GrouplessAddress],
     tokens: Option[ArraySeq[Token]],
     lockTime: Option[TimeStamp],
     message: Option[ByteString],

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomSetParameter.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomSetParameter.scala
@@ -23,10 +23,11 @@ import scala.collection.immutable.ArraySeq
 import akka.util.ByteString
 import slick.jdbc.{PositionedParameters, SetParameter}
 
+import org.alephium.api.model.{Address => ApiAddress}
 import org.alephium.api.model.Val
 import org.alephium.explorer.api.Json._
 import org.alephium.explorer.api.model._
-import org.alephium.explorer.persistence.model.{InterfaceIdEntity, OutputEntity}
+import org.alephium.explorer.persistence.model.{GrouplessAddress, InterfaceIdEntity, OutputEntity}
 import org.alephium.json.Json._
 import org.alephium.protocol.Hash
 import org.alephium.protocol.model._
@@ -111,8 +112,13 @@ object CustomSetParameter {
       params setString input.toBase58
   }
 
-  implicit object AddressLikeSetParameter extends SetParameter[AddressLike] {
-    override def apply(input: AddressLike, params: PositionedParameters): Unit =
+  implicit object ApiAddressSetParameter extends SetParameter[ApiAddress] {
+    override def apply(input: ApiAddress, params: PositionedParameters): Unit =
+      params setString input.toBase58
+  }
+
+  implicit object GrouplessAddressSetParameter extends SetParameter[GrouplessAddress] {
+    override def apply(input: GrouplessAddress, params: PositionedParameters): Unit =
       params setString input.toBase58
   }
 
@@ -127,11 +133,23 @@ object CustomSetParameter {
       }
   }
 
-  implicit object OptionAddressLikeSetParameter extends SetParameter[Option[AddressLike]] {
-    override def apply(option: Option[AddressLike], params: PositionedParameters): Unit =
+  implicit object OptionApiAddressSetParameter extends SetParameter[Option[ApiAddress]] {
+    override def apply(option: Option[ApiAddress], params: PositionedParameters): Unit =
       option match {
         case Some(address) =>
-          AddressLikeSetParameter(address, params)
+          ApiAddressSetParameter(address, params)
+
+        case None =>
+          params setStringOption None
+      }
+  }
+
+  implicit object OptionGrouplessAddressSetParameter
+      extends SetParameter[Option[GrouplessAddress]] {
+    override def apply(option: Option[GrouplessAddress], params: PositionedParameters): Unit =
+      option match {
+        case Some(address) =>
+          GrouplessAddressSetParameter(address, params)
 
         case None =>
           params setStringOption None

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/InputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/InputSchema.scala
@@ -25,10 +25,10 @@ import slick.lifted.{Index, PrimaryKey, ProvenShape}
 
 import org.alephium.explorer.api.model.{Token}
 import org.alephium.explorer.persistence.DBActionW
-import org.alephium.explorer.persistence.model.InputEntity
+import org.alephium.explorer.persistence.model.{GrouplessAddress, InputEntity}
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.protocol.Hash
-import org.alephium.protocol.model.{Address, AddressLike, BlockHash, TransactionId}
+import org.alephium.protocol.model.{Address, BlockHash, TransactionId}
 import org.alephium.util.{TimeStamp, U256}
 
 object InputSchema extends SchemaMainChain[InputEntity]("inputs") {
@@ -46,8 +46,8 @@ object InputSchema extends SchemaMainChain[InputEntity]("inputs") {
     def outputRefTxHash: Rep[Option[TransactionId]] =
       column[Option[TransactionId]]("output_ref_tx_hash")
     def outputRefAddress: Rep[Option[Address]] = column[Option[Address]]("output_ref_address")
-    def outputRefAddressLike: Rep[Option[AddressLike]] =
-      column[Option[AddressLike]]("output_ref_groupless_address")
+    def outputRefGrouplessAddress: Rep[Option[GrouplessAddress]] =
+      column[Option[GrouplessAddress]]("output_ref_groupless_address")
     def outputRefAmount: Rep[Option[U256]] =
       column[Option[U256]](
         "output_ref_amount",
@@ -78,7 +78,7 @@ object InputSchema extends SchemaMainChain[InputEntity]("inputs") {
         txOrder,
         outputRefTxHash,
         outputRefAddress,
-        outputRefAddressLike,
+        outputRefGrouplessAddress,
         outputRefAmount,
         outputRefTokens,
         contractInput

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/OutputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/OutputSchema.scala
@@ -25,10 +25,10 @@ import slick.lifted.{Index, PrimaryKey, ProvenShape}
 
 import org.alephium.explorer.api.model.{Token}
 import org.alephium.explorer.persistence.DBActionW
-import org.alephium.explorer.persistence.model.OutputEntity
+import org.alephium.explorer.persistence.model.{GrouplessAddress, OutputEntity}
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.protocol.Hash
-import org.alephium.protocol.model.{Address, AddressLike, BlockHash, TransactionId}
+import org.alephium.protocol.model.{Address, BlockHash, TransactionId}
 import org.alephium.util.{TimeStamp, U256}
 
 object OutputSchema extends SchemaMainChain[OutputEntity]("outputs") {
@@ -43,8 +43,8 @@ object OutputSchema extends SchemaMainChain[OutputEntity]("outputs") {
     def amount: Rep[U256] =
       column[U256]("amount", O.SqlType("DECIMAL(80,0)")) // U256.MaxValue has 78 digits
     def address: Rep[Address] = column[Address]("address")
-    def grouplessAddress: Rep[Option[AddressLike]] =
-      column[Option[AddressLike]]("groupless_address")
+    def grouplessAddress: Rep[Option[GrouplessAddress]] =
+      column[Option[GrouplessAddress]]("groupless_address")
     def tokens: Rep[Option[ArraySeq[Token]]] = column[Option[ArraySeq[Token]]]("tokens")
     def mainChain: Rep[Boolean]              = column[Boolean]("main_chain")
     def lockTime: Rep[Option[TimeStamp]]     = column[Option[TimeStamp]]("lock_time")

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenOutputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenOutputSchema.scala
@@ -23,10 +23,10 @@ import slick.jdbc.PostgresProfile.api._
 import slick.lifted.{Index, PrimaryKey, ProvenShape}
 
 import org.alephium.explorer.persistence.DBActionW
-import org.alephium.explorer.persistence.model.{OutputEntity, TokenOutputEntity}
+import org.alephium.explorer.persistence.model.{GrouplessAddress, OutputEntity, TokenOutputEntity}
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.protocol.Hash
-import org.alephium.protocol.model.{Address, AddressLike, BlockHash, TokenId, TransactionId}
+import org.alephium.protocol.model.{Address, BlockHash, TokenId, TransactionId}
 import org.alephium.util.{TimeStamp, U256}
 
 object TokenOutputSchema extends SchemaMainChain[TokenOutputEntity]("token_outputs") {
@@ -42,8 +42,8 @@ object TokenOutputSchema extends SchemaMainChain[TokenOutputEntity]("token_outpu
     def amount: Rep[U256] =
       column[U256]("amount", O.SqlType("DECIMAL(80,0)")) // U256.MaxValue has 78 digits
     def address: Rep[Address] = column[Address]("address")
-    def grouplessAddress: Rep[Option[AddressLike]] =
-      column[Option[AddressLike]]("groupless_address")
+    def grouplessAddress: Rep[Option[GrouplessAddress]] =
+      column[Option[GrouplessAddress]]("groupless_address")
     def mainChain: Rep[Boolean]          = column[Boolean]("main_chain")
     def lockTime: Rep[Option[TimeStamp]] = column[Option[TimeStamp]]("lock_time")
     def message: Rep[Option[ByteString]] = column[Option[ByteString]]("message")

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenTxPerAddressSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenTxPerAddressSchema.scala
@@ -22,9 +22,9 @@ import slick.jdbc.PostgresProfile.api._
 import slick.lifted.{Index, PrimaryKey, ProvenShape}
 
 import org.alephium.explorer.persistence.DBActionW
-import org.alephium.explorer.persistence.model.TokenTxPerAddressEntity
+import org.alephium.explorer.persistence.model.{GrouplessAddress, TokenTxPerAddressEntity}
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
-import org.alephium.protocol.model.{Address, AddressLike, BlockHash, TokenId, TransactionId}
+import org.alephium.protocol.model.{Address, BlockHash, TokenId, TransactionId}
 import org.alephium.util.TimeStamp
 
 object TokenPerAddressSchema
@@ -32,8 +32,8 @@ object TokenPerAddressSchema
 
   class TokenPerAddresses(tag: Tag) extends Table[TokenTxPerAddressEntity](tag, name) {
     def address: Rep[Address] = column[Address]("address")
-    def grouplessAddress: Rep[Option[AddressLike]] =
-      column[Option[AddressLike]]("groupless_address")
+    def grouplessAddress: Rep[Option[GrouplessAddress]] =
+      column[Option[GrouplessAddress]]("groupless_address")
     def txHash: Rep[TransactionId] = column[TransactionId]("tx_hash", O.SqlType("BYTEA"))
     def blockHash: Rep[BlockHash]  = column[BlockHash]("block_hash", O.SqlType("BYTEA"))
     def timestamp: Rep[TimeStamp]  = column[TimeStamp]("block_timestamp")

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionPerAddressSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionPerAddressSchema.scala
@@ -22,9 +22,9 @@ import slick.jdbc.PostgresProfile.api._
 import slick.lifted.{Index, PrimaryKey, ProvenShape}
 
 import org.alephium.explorer.persistence.DBActionW
-import org.alephium.explorer.persistence.model.TransactionPerAddressEntity
+import org.alephium.explorer.persistence.model.{GrouplessAddress, TransactionPerAddressEntity}
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
-import org.alephium.protocol.model.{Address, AddressLike, BlockHash, TransactionId}
+import org.alephium.protocol.model.{Address, BlockHash, TransactionId}
 import org.alephium.util.TimeStamp
 
 object TransactionPerAddressSchema
@@ -32,8 +32,8 @@ object TransactionPerAddressSchema
 
   class TransactionPerAddresses(tag: Tag) extends Table[TransactionPerAddressEntity](tag, name) {
     def address: Rep[Address] = column[Address]("address")
-    def grouplessAddress: Rep[Option[AddressLike]] =
-      column[Option[AddressLike]]("groupless_address")
+    def grouplessAddress: Rep[Option[GrouplessAddress]] =
+      column[Option[GrouplessAddress]]("groupless_address")
     def txHash: Rep[TransactionId] = column[TransactionId]("tx_hash", O.SqlType("BYTEA"))
     def blockHash: Rep[BlockHash]  = column[BlockHash]("block_hash", O.SqlType("BYTEA"))
     def timestamp: Rep[TimeStamp]  = column[TimeStamp]("block_timestamp")

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/UInputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/UInputSchema.scala
@@ -20,10 +20,10 @@ import akka.util.ByteString
 import slick.jdbc.PostgresProfile.api._
 import slick.lifted.{Index, PrimaryKey, ProvenShape}
 
-import org.alephium.explorer.persistence.model.UInputEntity
+import org.alephium.explorer.persistence.model.{GrouplessAddress, UInputEntity}
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.protocol.Hash
-import org.alephium.protocol.model.{Address, AddressLike, TransactionId}
+import org.alephium.protocol.model.{Address, TransactionId}
 
 object UInputSchema extends Schema[UInputEntity]("uinputs") {
 
@@ -33,8 +33,8 @@ object UInputSchema extends Schema[UInputEntity]("uinputs") {
     def outputRefKey: Rep[Hash]               = column[Hash]("output_ref_key", O.SqlType("BYTEA"))
     def unlockScript: Rep[Option[ByteString]] = column[Option[ByteString]]("unlock_script")
     def address: Rep[Option[Address]]         = column[Option[Address]]("address")
-    def grouplessAddress: Rep[Option[AddressLike]] =
-      column[Option[AddressLike]]("groupless_address")
+    def grouplessAddress: Rep[Option[GrouplessAddress]] =
+      column[Option[GrouplessAddress]]("groupless_address")
     def uinputOrder: Rep[Int] = column[Int]("uinput_order")
 
     def pk: PrimaryKey = primaryKey("uinputs_pk", (outputRefKey, txHash))

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/UOutputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/UOutputSchema.scala
@@ -23,10 +23,10 @@ import slick.jdbc.PostgresProfile.api._
 import slick.lifted.{Index, PrimaryKey, ProvenShape}
 
 import org.alephium.explorer.api.model.Token
-import org.alephium.explorer.persistence.model.UOutputEntity
+import org.alephium.explorer.persistence.model.{GrouplessAddress, UOutputEntity}
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.protocol.Hash
-import org.alephium.protocol.model.{Address, AddressLike, TransactionId}
+import org.alephium.protocol.model.{Address, TransactionId}
 import org.alephium.util.{TimeStamp, U256}
 
 object UOutputSchema extends Schema[UOutputEntity]("uoutputs") {
@@ -38,8 +38,8 @@ object UOutputSchema extends Schema[UOutputEntity]("uoutputs") {
     def amount: Rep[U256] =
       column[U256]("amount", O.SqlType("DECIMAL(80,0)")) // U256.MaxValue has 78 digits
     def address: Rep[Address] = column[Address]("address")
-    def grouplessAddress: Rep[Option[AddressLike]] =
-      column[Option[AddressLike]]("groupless_address")
+    def grouplessAddress: Rep[Option[GrouplessAddress]] =
+      column[Option[GrouplessAddress]]("groupless_address")
     def tokens: Rep[Option[ArraySeq[Token]]] = column[Option[ArraySeq[Token]]]("tokens")
     def lockTime: Rep[Option[TimeStamp]]     = column[Option[TimeStamp]]("lock_time")
     def message: Rep[Option[ByteString]]     = column[Option[ByteString]]("message")

--- a/app/src/main/scala/org/alephium/explorer/service/TokenService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/TokenService.scala
@@ -24,16 +24,17 @@ import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
 import slick.jdbc.PostgresProfile.api._
 
+import org.alephium.api.model.{Address => ApiAddress}
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.foldFutures
 import org.alephium.explorer.persistence.DBRunner._
 import org.alephium.explorer.persistence.queries.ContractQueries._
 import org.alephium.explorer.persistence.queries.TokenQueries._
-import org.alephium.protocol.model.{Address, AddressLike, TokenId}
+import org.alephium.protocol.model.{Address, TokenId}
 import org.alephium.util.U256
 
 trait TokenService {
-  def getTokenBalance(address: AddressLike, token: TokenId)(implicit
+  def getTokenBalance(address: ApiAddress, token: TokenId)(implicit
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]
   ): Future[(U256, U256)]
@@ -69,17 +70,20 @@ trait TokenService {
       dc: DatabaseConfig[PostgresProfile]
   ): Future[ArraySeq[NFTCollectionMetadata]]
 
-  def listAddressTokens(address: AddressLike, pagination: Pagination)(implicit
+  def listAddressTokens(address: ApiAddress, pagination: Pagination)(implicit
       dc: DatabaseConfig[PostgresProfile]
   ): Future[ArraySeq[TokenId]]
 
-  def listAddressTokenTransactions(address: AddressLike, token: TokenId, pagination: Pagination)(
-      implicit
+  def listAddressTokenTransactions(
+      address: ApiAddress,
+      token: TokenId,
+      pagination: Pagination
+  )(implicit
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]
   ): Future[ArraySeq[Transaction]]
 
-  def listAddressTokensWithBalance(address: AddressLike, pagination: Pagination)(implicit
+  def listAddressTokensWithBalance(address: ApiAddress, pagination: Pagination)(implicit
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]
   ): Future[ArraySeq[(TokenId, U256, U256)]]
@@ -112,7 +116,7 @@ trait TokenService {
 
 object TokenService extends TokenService with StrictLogging {
 
-  def getTokenBalance(address: AddressLike, token: TokenId)(implicit
+  def getTokenBalance(address: ApiAddress, token: TokenId)(implicit
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]
   ): Future[(U256, U256)] =
@@ -156,19 +160,22 @@ object TokenService extends TokenService with StrictLogging {
   ): Future[ArraySeq[NFTCollectionMetadata]] =
     run(listNFTCollectionMetadataQuery(addresses))
 
-  def listAddressTokens(address: AddressLike, pagination: Pagination)(implicit
+  def listAddressTokens(address: ApiAddress, pagination: Pagination)(implicit
       dc: DatabaseConfig[PostgresProfile]
   ): Future[ArraySeq[TokenId]] =
     run(listAddressTokensAction(address, pagination))
 
-  def listAddressTokenTransactions(address: AddressLike, token: TokenId, pagination: Pagination)(
-      implicit
+  def listAddressTokenTransactions(
+      address: ApiAddress,
+      token: TokenId,
+      pagination: Pagination
+  )(implicit
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]
   ): Future[ArraySeq[Transaction]] =
     run(getTokenTransactionsByAddress(address, token, pagination))
 
-  def listAddressTokensWithBalance(address: AddressLike, pagination: Pagination)(implicit
+  def listAddressTokensWithBalance(address: ApiAddress, pagination: Pagination)(implicit
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]
   ): Future[ArraySeq[(TokenId, U256, U256)]] =

--- a/app/src/main/scala/org/alephium/explorer/util/AddressUtil.scala
+++ b/app/src/main/scala/org/alephium/explorer/util/AddressUtil.scala
@@ -16,17 +16,21 @@
 
 package org.alephium.explorer.util
 
-import org.alephium.protocol.model.{Address, AddressLike}
+import org.alephium.api.model.{Address => ApiAddress}
+import org.alephium.explorer.persistence.model.GrouplessAddress
+import org.alephium.protocol.model.Address
 import org.alephium.protocol.vm.LockupScript
 
 object AddressUtil {
 
-  def convertToGrouplessAddress(address: Address): Option[AddressLike] =
+  def convertToGrouplessAddress(address: Address): Option[GrouplessAddress] =
     address match {
       case Address.Asset(lockup) =>
         lockup match {
           case LockupScript.P2PK(pk, _) =>
-            Some(AddressLike(LockupScript.HalfDecodedP2PK(pk)))
+            Some(GrouplessAddress(ApiAddress.HalfDecodedP2PK(pk)))
+          case LockupScript.P2HMPK(hash, _) =>
+            Some(GrouplessAddress(ApiAddress.HalfDecodedP2HMPK(hash)))
           case _ => None
         }
       case _ => None

--- a/app/src/main/scala/org/alephium/explorer/util/InputAddressUtil.scala
+++ b/app/src/main/scala/org/alephium/explorer/util/InputAddressUtil.scala
@@ -48,6 +48,8 @@ object InputAddressUtil extends StrictLogging {
             Some(protocol.model.Address.p2pkh(pk))
           case protocol.vm.UnlockScript.P2PK =>
             None
+          case protocol.vm.UnlockScript.P2HMPK(_, _) =>
+            None
           case protocol.vm.UnlockScript.SameAsPrevious =>
             None
           case protocol.vm.UnlockScript.P2MPKH(_) =>

--- a/app/src/main/scala/org/alephium/explorer/util/SlickUtil.scala
+++ b/app/src/main/scala/org/alephium/explorer/util/SlickUtil.scala
@@ -27,10 +27,9 @@ import slick.jdbc._
 import slick.jdbc.PostgresProfile.api._
 import slick.sql._
 
+import org.alephium.api.model.{Address => ApiAddress}
 import org.alephium.explorer.api.model.Pagination
 import org.alephium.explorer.persistence.{DBActionR, DBActionSR}
-import org.alephium.protocol.model.{Address, AddressLike}
-import org.alephium.protocol.vm.LockupScript
 
 /** Convenience functions for Slick */
 object SlickUtil {
@@ -154,12 +153,12 @@ object SlickUtil {
 
   @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
   def addressColumn(
-      address: AddressLike,
+      address: ApiAddress,
       full: String = "address",
       half: String = "groupless_address"
   ): String = {
-    address.lockupScriptResult match {
-      case LockupScript.HalfDecodedP2PK(_) =>
+    address.lockupScript match {
+      case _: ApiAddress.HalfDecodedLockupScript =>
         half
       case _ =>
         full
@@ -167,14 +166,14 @@ object SlickUtil {
   }
 
   def splitAddresses(
-      addresses: ArraySeq[AddressLike]
-  ): (ArraySeq[Address], ArraySeq[AddressLike]) = {
+      addresses: ArraySeq[ApiAddress]
+  ): (ArraySeq[ApiAddress], ArraySeq[ApiAddress]) = {
     addresses.partitionMap { address =>
-      address.lockupScriptResult match {
-        case LockupScript.HalfDecodedP2PK(_) =>
-          Right(address)
-        case LockupScript.CompleteLockupScript(lockupScript) =>
-          Left(Address.from(lockupScript))
+      address.lockupScript match {
+        case lockupScript: ApiAddress.HalfDecodedLockupScript =>
+          Right(ApiAddress(lockupScript))
+        case ApiAddress.CompleteLockupScript(lockupScript) =>
+          Left(ApiAddress.from(lockupScript))
       }
     }
   }

--- a/app/src/test/scala/org/alephium/explorer/GenApiModel.scala
+++ b/app/src/test/scala/org/alephium/explorer/GenApiModel.scala
@@ -25,26 +25,20 @@ import akka.util.ByteString
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
 
+import org.alephium.api.model.{Address => ApiAddress}
 import org.alephium.explorer.ConfigDefaults._
 import org.alephium.explorer.GenCoreApi._
 import org.alephium.explorer.GenCoreProtocol._
 import org.alephium.explorer.GenCoreUtil._
 import org.alephium.explorer.api.model._
-import org.alephium.protocol.model.{
-  Address,
-  AddressLike,
-  ChainIndex,
-  GroupIndex,
-  TokenId,
-  TxOutputRef
-}
+import org.alephium.protocol.model.{Address, ChainIndex, GroupIndex, TokenId, TxOutputRef}
 
 /** Generators for types supplied by `org.alephium.explorer.api.model` package */
 object GenApiModel extends ImplicitConversions {
 
   @SuppressWarnings(Array("org.wartremover.warts.ImplicitConversion"))
-  implicit def addressToLike(address: Address): AddressLike = {
-    AddressLike.fromBase58(address.toBase58).get
+  implicit def addressToLike(address: Address): ApiAddress = {
+    ApiAddress.fromProtocol(address)
   }
 
   def tokenIdGen(implicit gs: GroupSetting): Gen[TokenId] = for {
@@ -70,19 +64,14 @@ object GenApiModel extends ImplicitConversions {
   val intervalTypeGen: Gen[IntervalType] =
     Gen.oneOf(ArraySeq[IntervalType](IntervalType.Hourly, IntervalType.Daily))
 
-  val addressLikeGen: Gen[AddressLike] = for {
+  val apiAddressGen: Gen[ApiAddress] = for {
     groupIndex <- groupIndexGen
     lockup     <- GenCoreProtocol.lockupGen(groupIndex)
-  } yield AddressLike.from(lockup)
+  } yield ApiAddress.from(lockup)
 
   val addressGen: Gen[Address] = for {
     groupIndex <- groupIndexGen
     lockup     <- GenCoreProtocol.lockupGen(groupIndex)
-  } yield Address.from(lockup)
-
-  val grouplessAddressGen: Gen[Address] = for {
-    groupIndex <- groupIndexGen
-    lockup     <- GenCoreProtocol.p2pkLockupGen(groupIndex)
   } yield Address.from(lockup)
 
   val outputRefGen: Gen[OutputRef] = for {

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/InputQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/InputQueriesSpec.scala
@@ -108,7 +108,7 @@ class InputQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForEach wi
                 unlockScript = entity.unlockScript,
                 outputRefTxHash = entity.outputRefTxHash,
                 outputRefAddress = entity.outputRefAddress,
-                outputRefAddressLike = entity.outputRefAddressLike,
+                outputRefGrouplessAddress = entity.outputRefGrouplessAddress,
                 outputRefAmount = entity.outputRefAmount,
                 outputRefTokens = entity.outputRefTokens,
                 contractInput = entity.contractInput
@@ -156,7 +156,7 @@ class InputQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForEach wi
               unlockScript = input.unlockScript,
               outputRefTxHash = input.outputRefTxHash,
               outputRefAddress = input.outputRefAddress,
-              outputRefAddressLike = input.outputRefAddressLike,
+              outputRefGrouplessAddress = input.outputRefGrouplessAddress,
               outputRefAmount = input.outputRefAmount,
               outputRefTokens = input.outputRefTokens,
               contractInput = input.contractInput

--- a/app/src/test/scala/org/alephium/explorer/service/EmptyTokenService.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/EmptyTokenService.scala
@@ -22,12 +22,13 @@ import scala.concurrent.{ExecutionContext, Future}
 import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
 
+import org.alephium.api.model.{Address => ApiAddress}
 import org.alephium.explorer.api.model._
-import org.alephium.protocol.model.{Address, AddressLike, TokenId}
+import org.alephium.protocol.model.{Address, TokenId}
 import org.alephium.util.U256
 
 trait EmptyTokenService extends TokenService {
-  def getTokenBalance(address: AddressLike, token: TokenId)(implicit
+  def getTokenBalance(address: ApiAddress, token: TokenId)(implicit
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]
   ): Future[(U256, U256)] = ???
@@ -63,17 +64,20 @@ trait EmptyTokenService extends TokenService {
       dc: DatabaseConfig[PostgresProfile]
   ): Future[ArraySeq[NFTCollectionMetadata]] = ???
 
-  def listAddressTokens(address: AddressLike, pagination: Pagination)(implicit
+  def listAddressTokens(address: ApiAddress, pagination: Pagination)(implicit
       dc: DatabaseConfig[PostgresProfile]
   ): Future[ArraySeq[TokenId]] = ???
 
-  def listAddressTokenTransactions(address: AddressLike, token: TokenId, pagination: Pagination)(
-      implicit
+  def listAddressTokenTransactions(
+      address: ApiAddress,
+      token: TokenId,
+      pagination: Pagination
+  )(implicit
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]
   ): Future[ArraySeq[Transaction]] = ???
 
-  def listAddressTokensWithBalance(address: AddressLike, pagination: Pagination)(implicit
+  def listAddressTokensWithBalance(address: ApiAddress, pagination: Pagination)(implicit
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]
   ): Future[ArraySeq[(TokenId, U256, U256)]] = ???

--- a/app/src/test/scala/org/alephium/explorer/service/EmptyTransactionService.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/EmptyTransactionService.scala
@@ -27,10 +27,12 @@ import io.vertx.core.buffer.Buffer
 import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
 
+import org.alephium.api.model.{Address => ApiAddress}
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.cache.TransactionCache
 import org.alephium.explorer.service.TransactionService
-import org.alephium.protocol.model.{AddressLike, TransactionId}
+import org.alephium.protocol.config.GroupConfig
+import org.alephium.protocol.model.TransactionId
 import org.alephium.util.{TimeStamp, U256}
 
 trait EmptyTransactionService extends TransactionService {
@@ -41,12 +43,12 @@ trait EmptyTransactionService extends TransactionService {
     Future.successful(None)
 
   override def getTransactionsNumberByAddress(
-      address: AddressLike
+      address: ApiAddress
   )(implicit ec: ExecutionContext, dc: DatabaseConfig[PostgresProfile]): Future[Int] =
     Future.successful(0)
 
   override def getTransactionsByAddress(
-      address: AddressLike,
+      address: ApiAddress,
       pagination: Pagination
   )(implicit
       ec: ExecutionContext,
@@ -55,7 +57,7 @@ trait EmptyTransactionService extends TransactionService {
     Future.successful(ArraySeq.empty)
 
   override def getTransactionsByAddresses(
-      addresses: ArraySeq[AddressLike],
+      addresses: ArraySeq[ApiAddress],
       fromTs: Option[TimeStamp],
       toTs: Option[TimeStamp],
       pagination: Pagination
@@ -66,7 +68,7 @@ trait EmptyTransactionService extends TransactionService {
     Future.successful(ArraySeq.empty)
 
   override def getTransactionsByAddressTimeRanged(
-      address: AddressLike,
+      address: ApiAddress,
       fromTime: TimeStamp,
       toTime: TimeStamp,
       pagination: Pagination
@@ -76,13 +78,13 @@ trait EmptyTransactionService extends TransactionService {
   ): Future[ArraySeq[Transaction]] =
     Future.successful(ArraySeq.empty)
 
-  override def getLatestTransactionInfoByAddress(address: AddressLike)(implicit
+  override def getLatestTransactionInfoByAddress(address: ApiAddress)(implicit
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]
   ): Future[Option[TransactionInfo]] =
     Future.successful(None)
 
-  override def listMempoolTransactionsByAddress(address: AddressLike)(implicit
+  override def listMempoolTransactionsByAddress(address: ApiAddress)(implicit
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]
   ): Future[ArraySeq[MempoolTransaction]] = {
@@ -90,7 +92,7 @@ trait EmptyTransactionService extends TransactionService {
   }
 
   override def getBalance(
-      address: AddressLike,
+      address: ApiAddress,
       from: TimeStamp
   )(implicit ec: ExecutionContext, dc: DatabaseConfig[PostgresProfile]): Future[(U256, U256)] =
     Future.successful((U256.Zero, U256.Zero))
@@ -102,27 +104,32 @@ trait EmptyTransactionService extends TransactionService {
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]
   ): Future[ArraySeq[MempoolTransaction]] = ???
-  def areAddressesActive(addresses: ArraySeq[AddressLike])(implicit
+  def areAddressesActive(addresses: ArraySeq[ApiAddress])(implicit
       ec: ExecutionContext,
-      dc: DatabaseConfig[PostgresProfile]
+      dc: DatabaseConfig[PostgresProfile],
+      groupConfig: GroupConfig
   ): Future[ArraySeq[Boolean]] = {
     Future.successful(ArraySeq(true))
   }
-  def hasAddressMoreTxsThan(address: AddressLike, from: TimeStamp, to: TimeStamp, threshold: Int)(
-      implicit
+  def hasAddressMoreTxsThan(
+      address: ApiAddress,
+      from: TimeStamp,
+      to: TimeStamp,
+      threshold: Int
+  )(implicit
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]
   ): Future[Boolean] = ???
 
   def getUnlockScript(
-      address: AddressLike
+      address: ApiAddress
   )(implicit
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]
   ): Future[Option[ByteString]] = Future.successful(None)
 
   def exportTransactionsByAddress(
-      address: AddressLike,
+      address: ApiAddress,
       from: TimeStamp,
       to: TimeStamp,
       batchSize: Int,
@@ -130,7 +137,7 @@ trait EmptyTransactionService extends TransactionService {
   )(implicit ec: ExecutionContext, dc: DatabaseConfig[PostgresProfile]): Flowable[Buffer] = ???
 
   def getAmountHistory(
-      address: AddressLike,
+      address: ApiAddress,
       from: TimeStamp,
       to: TimeStamp,
       intervalType: IntervalType

--- a/app/src/test/scala/org/alephium/explorer/service/TokenSupplyServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TokenSupplyServiceSpec.scala
@@ -158,7 +158,8 @@ class TokenSupplyServiceSpec extends AlephiumFutureSpec with DatabaseFixtureForE
 
     implicit val blockCache: BlockCache = TestBlockCache()(gs, executionContext, databaseConfig)
 
-    val genesisAddress = Address.fromBase58("122uvHwwcaWoXR1ryub9VK1yh2CZvYCqXxzsYDHRb2jYB").get
+    val genesisAddress =
+      Address.fromBase58("122uvHwwcaWoXR1ryub9VK1yh2CZvYCqXxzsYDHRb2jYB").rightValue
 
     lazy val genesisBlock = {
       val lockTime =
@@ -228,7 +229,7 @@ class TokenSupplyServiceSpec extends AlephiumFutureSpec with DatabaseFixtureForE
           .fromBase58(
             "X4TqZeAizjDV8yt7XzxDVLywdzmJvLALtdAnjAERtCY3TPkyPXt4A5fxvXAX7UucXPpSYF7amNysNiniqb98vQ5rs9gh12MDXhsAf5kWmbmjXDygxV9AboSj8QR7QK8duaKAkZ"
           )
-          .get
+          .rightValue
       block.copy(
         timestamp = timestamp,
         transactions = block.transactions.map(_.copy(timestamp = timestamp)),

--- a/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
@@ -41,6 +41,7 @@ import org.alephium.explorer.persistence.model._
 import org.alephium.explorer.persistence.model.AppState._
 import org.alephium.explorer.persistence.queries._
 import org.alephium.explorer.persistence.schema.CustomGetResult._
+import org.alephium.explorer.util.AddressUtil
 import org.alephium.protocol.ALPH
 import org.alephium.protocol.model.{BlockHash, ChainIndex, GroupIndex}
 import org.alephium.util.{Duration, TimeStamp, U256}
@@ -143,7 +144,7 @@ class TransactionServiceSpec extends AlephiumActorSpecLike with DatabaseFixtureF
         hashGen.sample.get,
         U256.One,
         address0,
-        Some(address0),
+        AddressUtil.convertToGrouplessAddress(address0),
         None,
         true,
         None,
@@ -211,7 +212,7 @@ class TransactionServiceSpec extends AlephiumActorSpecLike with DatabaseFixtureF
       hashGen.sample.get,
       U256.One,
       address1,
-      Some(address1),
+      AddressUtil.convertToGrouplessAddress(address1),
       None,
       true,
       None,
@@ -343,7 +344,7 @@ class TransactionServiceSpec extends AlephiumActorSpecLike with DatabaseFixtureF
           hashGen.sample.get,
           U256.One,
           address0,
-          Some(address0),
+          AddressUtil.convertToGrouplessAddress(address0),
           None,
           true,
           None,

--- a/app/src/test/scala/org/alephium/explorer/util/UtxoUtilSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/util/UtxoUtilSpec.scala
@@ -25,6 +25,7 @@ import org.alephium.explorer.AlephiumSpec
 import org.alephium.explorer.ConfigDefaults.groupSetting
 import org.alephium.explorer.GenApiModel._
 import org.alephium.explorer.api.model.{AssetOutput, ContractOutput, Output, Token}
+import org.alephium.explorer.config.Default.groupConfig
 import org.alephium.util.U256
 
 class UtxoUtilSpec extends AlephiumSpec {

--- a/app/src/test/scala/org/alephium/explorer/web/ContractServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/ContractServerSpec.scala
@@ -125,7 +125,7 @@ class ContractServerSpec()
     forAll(addressAssetProtocolGen()) { address =>
       Get(s"/contracts/$address/parent") check { response =>
         response.as[BadRequest] is BadRequest(
-          s"Invalid value for: path parameter contract_address (Expect contract address, but was asset address: $address: $address)"
+          s"Invalid value for: path parameter contract_address (Expected a contract address, but got an asset address: $address: $address)"
         )
       }
     }
@@ -141,7 +141,7 @@ class ContractServerSpec()
     forAll(addressAssetProtocolGen()) { address =>
       Get(s"/contracts/$address/sub-contracts") check { response =>
         response.as[BadRequest] is BadRequest(
-          s"Invalid value for: path parameter contract_address (Expect contract address, but was asset address: $address: $address)"
+          s"Invalid value for: path parameter contract_address (Expected a contract address, but got an asset address: $address: $address)"
         )
       }
     }

--- a/app/src/test/scala/org/alephium/explorer/web/StatementTimeoutSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/StatementTimeoutSpec.scala
@@ -23,6 +23,7 @@ import slick.jdbc.PostgresProfile
 import slick.jdbc.PostgresProfile.api._
 import sttp.model.StatusCode
 
+import org.alephium.api.model.{Address => ApiAddress}
 import org.alephium.explorer._
 import org.alephium.explorer.ConfigDefaults._
 import org.alephium.explorer.GenApiModel._
@@ -30,7 +31,6 @@ import org.alephium.explorer.HttpFixture._
 import org.alephium.explorer.cache.{BlockCache, TestBlockCache}
 import org.alephium.explorer.persistence.{DatabaseFixtureForAll, DBRunner}
 import org.alephium.explorer.service.{EmptyTokenService, EmptyTransactionService}
-import org.alephium.protocol.model.AddressLike
 import org.alephium.util.{TimeStamp, U256}
 
 class StatementTimeoutSpec()
@@ -65,7 +65,7 @@ class StatementTimeoutSpec()
 object StatementTimeoutSpec {
   def transactionService() = new EmptyTransactionService {
     override def getBalance(
-        address: AddressLike,
+        address: ApiAddress,
         latestFinalizedBlock: TimeStamp
     )(implicit ec: ExecutionContext, dc: DatabaseConfig[PostgresProfile]): Future[(U256, U256)] =
       DBRunner

--- a/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/DBBenchmark.scala
+++ b/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/DBBenchmark.scala
@@ -25,19 +25,20 @@ import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
 import slick.jdbc.PostgresProfile.api._
 
+import org.alephium.api.model.{Address => ApiAddress}
 import org.alephium.explorer.GenApiModel._
 import org.alephium.explorer.GroupSetting
 import org.alephium.explorer.api.model.{IntervalType, Pagination}
 import org.alephium.explorer.benchmark.db.BenchmarkSettings._
 import org.alephium.explorer.benchmark.db.state._
 import org.alephium.explorer.cache.BlockCache
+import org.alephium.explorer.config.Default.groupConfig
 import org.alephium.explorer.persistence.dao.{BlockDao, TransactionDao}
 import org.alephium.explorer.persistence.queries.InputQueries._
 import org.alephium.explorer.persistence.queries.OutputQueries._
 import org.alephium.explorer.persistence.queries.TransactionQueries
 import org.alephium.explorer.persistence.schema.BlockHeaderSchema
 import org.alephium.explorer.service.TransactionService
-import org.alephium.protocol.model.{Address, AddressLike}
 import org.alephium.util.{Duration, TimeStamp}
 
 /** Implements all JMH functions executing benchmarks on Postgres.
@@ -257,7 +258,7 @@ class DBBenchmark {
     val _ =
       state.db.runNow(
         TransactionQueries.areAddressesActiveAction(
-          state.next.map(address => AddressLike.from(address.lockupScript))
+          state.next.map(address => ApiAddress.from(address.lockupScript))
         ),
         requestTimeout
       )
@@ -270,7 +271,7 @@ class DBBenchmark {
     val _ =
       state.db.runNow(
         TransactionQueries.areAddressesActiveAction(
-          state.next.map(address => AddressLike.from(address.lockupScript))
+          state.next.map(address => ApiAddress.from(address.lockupScript))
         ),
         requestTimeout
       )
@@ -280,7 +281,7 @@ class DBBenchmark {
   def transactions_per_address_read_state(state: TransactionsPerAddressReadState): Unit = {
     val query =
       TransactionQueries.getTxHashesByAddressQueryTimeRanged(
-        address = Address.fromBase58(state.next).get,
+        address = ApiAddress.fromBase58(state.next).toOption.get,
         fromTime = TimeStamp.zero,
         toTime = TimeStamp.unsafe(Long.MaxValue),
         pagination = Pagination.unsafe(1, Int.MaxValue)

--- a/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/DataGenerator.scala
+++ b/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/DataGenerator.scala
@@ -26,6 +26,7 @@ import akka.util.ByteString
 import org.alephium.explorer.GenApiModel._
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.persistence.model._
+import org.alephium.explorer.util.AddressUtil
 import org.alephium.protocol.Hash
 import org.alephium.protocol.model.{Address, BlockHash, GroupIndex, TransactionId}
 import org.alephium.util.{TimeStamp, U256}
@@ -82,7 +83,7 @@ object DataGenerator {
         key = Hash.generate,
         amount = U256.unsafe(Random.nextInt(100)),
         address = address,
-        grouplessAddress = Some(address),
+        grouplessAddress = AddressUtil.convertToGrouplessAddress(address),
         tokens = None,
         mainChain = transaction.mainChain,
         lockTime = Some(TimeStamp.now()),
@@ -165,7 +166,7 @@ object DataGenerator {
   def genTransactionPerAddressEntity(address: Address = genAddress()): TransactionPerAddressEntity =
     TransactionPerAddressEntity(
       address = address,
-      grouplessAddress = Some(address),
+      grouplessAddress = AddressUtil.convertToGrouplessAddress(address),
       hash = TransactionId.generate,
       blockHash = BlockHash.generate,
       timestamp = TimeStamp.now(),

--- a/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/AddressReadState.scala
+++ b/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/AddressReadState.scala
@@ -28,7 +28,6 @@ import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
 
 import org.alephium.crypto.Blake2b
-import org.alephium.explorer.GenApiModel._
 import org.alephium.explorer.GroupSetting
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.benchmark.db.{DataGenerator, DBConnectionPool, DBExecutor}
@@ -38,6 +37,7 @@ import org.alephium.explorer.persistence.model._
 import org.alephium.explorer.persistence.queries.InputUpdateQueries
 import org.alephium.explorer.persistence.schema._
 import org.alephium.explorer.service.FinalizerService
+import org.alephium.explorer.util.AddressUtil
 import org.alephium.protocol.{ALPH, Hash}
 import org.alephium.protocol.model.{Address, BlockHash, GroupIndex, TransactionId}
 import org.alephium.util.{Duration, TimeStamp, U256}
@@ -145,7 +145,7 @@ class AddressReadState(val db: DBExecutor)
       key = Hash.generate,
       amount = ALPH.alph(1),
       address = address0,
-      grouplessAddress = Some(address0),
+      grouplessAddress = AddressUtil.convertToGrouplessAddress(address0),
       tokens = None,
       mainChain = true,
       lockTime = None,

--- a/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/TransactionsPerAddressReadState.scala
+++ b/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/TransactionsPerAddressReadState.scala
@@ -63,7 +63,7 @@ class TransactionsPerAddressReadState(
     (0 to transactionsPerAddress) flatMap { timeStamp =>
       val transactionsPerDayGen =
         genTransactionPerAddressEntity(
-          addressGen = Gen.const(Address.fromBase58(address).get),
+          addressGen = Gen.const(Address.fromBase58(address).toOption.get),
           timestampGen = Gen.const(TimeStamp.unsafe(timeStamp.toLong))
         )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@
 import sbt._
 
 object Version {
-  lazy val common = "3.14.2"
+  lazy val common = "3.15.1"
 
   lazy val akka       = "2.6.20"
   lazy val rxJava     = "3.1.8"


### PR DESCRIPTION
This commit adapt the new way of handling half-decoded addresses.

In full node, all the half-decoded addresses are managed in `org.alephium.api.model.Address` and are used only at `api` level, while the complete addresess are still defined in `protocol` and are used in the rest of the code base.

We used the same strategy:
  * `ApiAddress` are used as api entry, to let user choose for anykind of address
  * `Address` from protocol is used as DB model, as it's the type received from the node when syncing
  * `GrouplessAddress` is an new wrapper around `HalfDecodedLockupScript`, used in DB for all `groupless_address` column, which help us to avoid inserting non-groupless address in those columns.