### PR TITLE
Run `MarketService` even without mobula api-key

### DIFF
--- a/app/src/test/scala/org/alephium/explorer/service/MarketServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/MarketServiceSpec.scala
@@ -151,8 +151,8 @@ class MarketServiceSpec extends AlephiumFutureSpec {
       new MarketServiceSpec.MobulaMock(localhost, mobulaPort)
     val tokenList: MarketServiceSpec.TokenListMock =
       new MarketServiceSpec.TokenListMock(localhost, tokenListPort)
-    val marketService: MarketService.MarketServiceWithApiKey =
-      new MarketService.MarketServiceWithApiKey(marketConfig, apiKey)
+    val marketService: MarketService.MarketServiceImpl =
+      new MarketService.MarketServiceImpl(marketConfig, Some(apiKey))
   }
 }
 


### PR DESCRIPTION
Now that coingecko act as fall back, without an api-key we can still get coingecko results.