### PR TITLE
Optimize `BlockFlowSyncService.getRemoteMaxTimestamp`

### DIFF
--- a/app/src/main/resources/application.conf
+++ b/app/src/main/resources/application.conf
@@ -143,6 +143,8 @@ blockflow {
     network-id = 0
     network-id = ${?BLOCKFLOW_NETWORK_ID}
     group-num = 4
+    fetch-max-age = 30 minutes
+    fetch-max-age = ${?BLOCKFLOW_FETCH_MAX_AGE}
     api-key = null
     api-key = ${?ALEPHIUM_API_KEY}
 

--- a/app/src/main/scala/org/alephium/explorer/SyncServices.scala
+++ b/app/src/main/scala/org/alephium/explorer/SyncServices.scala
@@ -23,6 +23,7 @@ import org.alephium.explorer.error.ExplorerError._
 import org.alephium.explorer.service._
 import org.alephium.explorer.util.Scheduler
 import org.alephium.protocol.model.NetworkId
+import org.alephium.util
 
 /** Implements function for Sync Services boot-up sequence */
 @SuppressWarnings(Array("org.wartremover.warts.Overloading"))
@@ -54,7 +55,8 @@ object SyncServices extends StrictLogging {
             tokenSupplyServiceScheduleTime = config.tokenSupplyServiceScheduleTime,
             hashRateServiceSyncPeriod = config.hashRateServiceSyncPeriod,
             finalizerServiceSyncPeriod = config.finalizerServiceSyncPeriod,
-            transactionHistoryServiceSyncPeriod = config.transactionHistoryServiceSyncPeriod
+            transactionHistoryServiceSyncPeriod = config.transactionHistoryServiceSyncPeriod,
+            blockFlowFetchMaxAge = config.blockFlowFetchMaxAge
           )
         }
     }
@@ -68,7 +70,8 @@ object SyncServices extends StrictLogging {
       tokenSupplyServiceScheduleTime: LocalTime,
       hashRateServiceSyncPeriod: FiniteDuration,
       finalizerServiceSyncPeriod: FiniteDuration,
-      transactionHistoryServiceSyncPeriod: FiniteDuration
+      transactionHistoryServiceSyncPeriod: FiniteDuration,
+      blockFlowFetchMaxAge: FiniteDuration
   )(implicit
       scheduler: Scheduler,
       ec: ExecutionContext,
@@ -82,7 +85,8 @@ object SyncServices extends StrictLogging {
         Future
           .sequence(
             ArraySeq(
-              BlockFlowSyncService.start(peers, syncPeriod),
+              BlockFlowSyncService
+                .start(peers, syncPeriod, util.Duration.unsafe(blockFlowFetchMaxAge.toMillis)),
               MempoolSyncService.start(peers, syncPeriod),
               TokenSupplyService.start(tokenSupplyServiceScheduleTime),
               HashrateService.start(hashRateServiceSyncPeriod),

--- a/app/src/main/scala/org/alephium/explorer/config/ExplorerConfig.scala
+++ b/app/src/main/scala/org/alephium/explorer/config/ExplorerConfig.scala
@@ -204,6 +204,7 @@ object ExplorerConfig {
           blockflow.networkId,
           blockflow.consensus,
           blockflow.apiKey,
+          blockflow.fetchMaxAge,
           host,
           port,
           explorer.bootMode,
@@ -236,7 +237,8 @@ object ExplorerConfig {
       port: Int,
       networkId: NetworkId,
       consensus: Consensus,
-      apiKey: Option[ApiKey]
+      apiKey: Option[ApiKey],
+      fetchMaxAge: FiniteDuration
   )
 
   final case class Consensus(
@@ -311,6 +313,7 @@ final case class ExplorerConfig private (
     networkId: NetworkId,
     consensus: ExplorerConfig.Consensus,
     maybeBlockFlowApiKey: Option[ApiKey],
+    blockFlowFetchMaxAge: FiniteDuration,
     host: String,
     port: Int,
     bootMode: BootMode,

--- a/app/src/main/scala/org/alephium/explorer/service/BlockFlowSyncService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/BlockFlowSyncService.scala
@@ -234,9 +234,9 @@ case object BlockFlowSyncService extends StrictLogging {
       groupSetting: GroupSetting
   ): Future[Option[TimeStamp]] = {
     localTsOpt match {
-      case Some(locatTs) =>
+      case Some(localTs) =>
         val now = TimeStamp.now()
-        if (locatTs.plusUnsafe(step) >= now) {
+        if (localTs.plusUnsafe(step) >= now) {
           // We know that we can fetch blocks from the remote node in one time range
           Future.successful(Some(now))
         } else {


### PR DESCRIPTION
We were previously considering that EB was synced if latest synced block was 10s ago ([defaultBackStep](https://github.com/alephium/explorer-backend/blob/f1ccc62169dee965e31e9d898239f2efc16d1726/app/src/main/scala/org/alephium/explorer/service/BlockFlowSyncService.scala#L53)), otherwise we were contacting the node to know the latest block's timestamp.

We are now using the `blockFlowFetchMaxAge` value, which is now part of the config and use the same value of 30min as set in the node.

If our latest block is younger than (now - blockFlowFetchMaxAge), we don't need to call the node as we anyway can sync all remaining blocks in one call.

The previous value of 10s was sometime not enough in case of heavy load, it could happen that EB was just 12 seconds late and we were thus calling the node for nothing.