### PR TITLE
Add a `IF EXISTS` safety in migration

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/persistence/Migrations.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/Migrations.scala
@@ -85,7 +85,7 @@ object Migrations extends StrictLogging {
       tableName: String,
       grouplessAddressColumn: String
   ): DBActionAll[Int] =
-    sqlu"""ALTER TABLE #$tableName ADD COLUMN #$grouplessAddressColumn CHARACTER VARYING"""
+    sqlu"""ALTER TABLE #$tableName ADD COLUMN IF NOT EXISTS #$grouplessAddressColumn CHARACTER VARYING"""
 
   def migration5(implicit ec: ExecutionContext): DBActionAll[Unit] =
     for {


### PR DESCRIPTION
In case we need to roll back the migration version, with this we can safely come back to a previous version