### PR TITLE
Support token price for multiple symbol with same token

### DIFF
--- a/app/src/main/resources/application.conf
+++ b/app/src/main/resources/application.conf
@@ -74,17 +74,24 @@ explorer {
 
     market {
         symbol-name {
-            "ALPH"  = "alephium",
-            "USDC"  = "usd-coin",
-            "USDT"  = "tether",
-            "WBTC"  = "wrapped-bitcoin",
-            "WETH"  = "weth",
-            "DAI"   = "dai",
-            "AYIN"  = "ayin",
-            "ABX"   = "alphbanx",
-            "APAD"  = "alphpad"
-            "EX"    = "elexium"
-            "ONION" = "myonion-fun"
+            "ALPH"    = "alephium",
+            # USDC values
+            "USDC"    = "usd-coin",
+            "USDCeth" = "usd-coin",
+            "USDCbsc" = "usd-coin",
+            # USDT values
+            "USDT"    = "tether",
+            "USDTeth" = "tether",
+            "USDTbsc" = "tether",
+            # Others
+            "WBTC"    = "wrapped-bitcoin",
+            "WETH"    = "weth",
+            "DAI"     = "dai",
+            "AYIN"    = "ayin",
+            "ABX"     = "alphbanx",
+            "APAD"    = "alphpad"
+            "EX"      = "elexium"
+            "ONION"   = "myonion-fun"
         }
         chart-symbol-name {
             "ALPH" = "alephium"

--- a/app/src/test/scala/org/alephium/explorer/service/market/MarketServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/market/MarketServiceSpec.scala
@@ -138,6 +138,16 @@ class MarketServiceSpec extends AlephiumFutureSpec {
     }
   }
 
+  "support multiple symbol with same token" in new Fixture {
+
+    marketService.start().futureValue
+
+    eventually {
+      marketService.getPrices(ArraySeq("USDC"), "usd").rightValue is ArraySeq(Some(usdcPrice))
+      marketService.getPrices(ArraySeq("USDCeth"), "usd").rightValue is ArraySeq(Some(usdcPrice))
+    }
+  }
+
   trait Fixture {
     val localhost: InetAddress = InetAddress.getByName("127.0.0.1")
     val coingeckoPort          = SocketUtil.temporaryLocalPort(SocketUtil.Both)
@@ -183,16 +193,18 @@ object MarketServiceSpec {
     Codec.string.map(value => ujson.read(value))(_.toString)
 
   val alphPrice = 1.223123123
+  val usdcPrice = 1.0012412
   var usdtPrice = 1.0012412
 
   val symbolNames = ListMap(
-    "ALPH" -> "alephium",
-    "USDC" -> "usd-coin",
-    "USDT" -> "tether",
-    "WBTC" -> "wrapped-bitcoin",
-    "WETH" -> "weth",
-    "DAI"  -> "dai",
-    "AYIN" -> "ayin"
+    "ALPH"    -> "alephium",
+    "USDC"    -> "usd-coin",
+    "USDCeth" -> "usd-coin",
+    "USDT"    -> "tether",
+    "WBTC"    -> "wrapped-bitcoin",
+    "WETH"    -> "weth",
+    "DAI"     -> "dai",
+    "AYIN"    -> "ayin"
   )
   val currencies =
     ArraySeq("btc", "usd", "eur", "chf", "gbp", "idr", "vnd", "rub", "try", "cad", "aud")
@@ -314,6 +326,9 @@ object MarketServiceSpec {
   val coingeckoPrices: String = s"""{
       "alephium": {
         "usd": $alphPrice
+      },
+      "usd-coin": {
+        "usd": $usdcPrice
       }
     }"""
 

--- a/e2e/docker/docker-compose.yml
+++ b/e2e/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   alephium:
-    image: alephium/alephium:v3.14.2
+    image: alephium/alephium:v4.0.0
     restart: unless-stopped
     ports:
       - 19973:19973/tcp


### PR DESCRIPTION
In our [token list](https://github.com/alephium/token-list/blob/684276e19d7ed7f05216b5ab4c509d25fe809720/tokens/mainnet.json#L126-L149) we have:

```
symbol = "USDCeth"
...
symbol = "USDCbsc" 
```

So when using the sdk, the FE is asking price for `USDCeth`, while we were currently only responding to `USDC` request.

This PR is handling such case.
Now we have:
![image](https://github.com/user-attachments/assets/552be285-42fb-4a2a-b745-4a0b235e98ba)
