### PR TITLE
Unique txs groupless

### DIFF
--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -1534,7 +1534,8 @@
               }
             }
           }
-        }
+        },
+        "deprecated": true
       }
     },
     "/addresses/{address}/timeranged-transactions": {

--- a/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
@@ -67,6 +67,7 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
       .in(pagination)
       .out(jsonBody[ArraySeq[Transaction]])
       .summary("List transactions for given addresses")
+      .deprecated()
 
   val getTransactionsByAddressTimeRanged: BaseEndpoint[(ApiAddress, TimeInterval, Pagination), ArraySeq[Transaction]] =
     addressesLikeEndpoint.get

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/MempoolQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/MempoolQueries.scala
@@ -44,13 +44,15 @@ object MempoolQueries {
       .asASE[MempoolTransactionEntity](mempoolTransactionGetResult)
   }
 
-  def listUTXHashesByAddress(address: ApiAddress): DBActionSR[TransactionId] = {
+  def listUTXHashesByAddress(
+      address: ApiAddress
+  ): DBActionSR[TransactionId] = {
     sql"""
-      SELECT tx_hash
+      SELECT #${distinct(address)} tx_hash
       FROM uinputs
       WHERE #${addressColumn(address)} = $address
       UNION
-      SELECT tx_hash
+      SELECT #${distinct(address)} tx_hash
       FROM uoutputs
       WHERE #${addressColumn(address)} = $address
     """.asAS[TransactionId]

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/TokenQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/TokenQueries.scala
@@ -147,7 +147,7 @@ object TokenQueries extends StrictLogging {
       pagination: Pagination
   ): DBActionSR[TxByTokenQR] = {
     sql"""
-      SELECT #${TxByTokenQR.selectFields}
+      SELECT #${distinct(address)} #${TxByTokenQR.selectFields}
       FROM token_tx_per_addresses
       WHERE main_chain = true
       AND #${addressColumn(address)} = $address

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
@@ -143,7 +143,7 @@ object TransactionQueries extends StrictLogging {
       address: ApiAddress
   ): DBActionSR[Int] = {
     sql"""
-      SELECT COUNT(*)
+      SELECT COUNT(#${distinct(address)} tx_hash)
       FROM transaction_per_addresses
       WHERE main_chain = true
       AND #${addressColumn(address)} = $address
@@ -156,7 +156,7 @@ object TransactionQueries extends StrictLogging {
       pagination: Pagination
   ): DBActionSR[TxByAddressQR] = {
     sql"""
-      SELECT #${TxByAddressQR.selectFields}
+      SELECT #${distinct(address)} #${TxByAddressQR.selectFields}
       FROM transaction_per_addresses
       WHERE main_chain = true
       AND #${addressColumn(address)} = $address
@@ -263,7 +263,7 @@ object TransactionQueries extends StrictLogging {
       pagination: Pagination
   ): DBActionSR[TxByAddressQR] = {
     sql"""
-      SELECT #${TxByAddressQR.selectFields}
+      SELECT #${distinct(address)} #${TxByAddressQR.selectFields}
       FROM transaction_per_addresses
       WHERE main_chain = true
         AND #${addressColumn(address)} = $address
@@ -369,7 +369,7 @@ object TransactionQueries extends StrictLogging {
       to: TimeStamp
   ): StreamAction[TxByAddressQR] = {
     sql"""
-      SELECT #${TxByAddressQR.selectFields}
+      SELECT #${distinct(address)} #${TxByAddressQR.selectFields}
       FROM transaction_per_addresses
       WHERE #${addressColumn(address)} = $address
       AND main_chain = true

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenTxPerAddressSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenTxPerAddressSchema.scala
@@ -50,6 +50,7 @@ object TokenPerAddressSchema
   def createConcurrentIndexes()(implicit ec: ExecutionContext): DBActionW[Unit] =
     for {
       _ <- createTokenGrouplessAddressIndex()
+      _ <- createUniqueGrouplessIndex()
     } yield ()
 
   def createTokenGrouplessAddressIndex(): DBActionW[Int] =
@@ -58,6 +59,15 @@ object TokenPerAddressSchema
       ON token_tx_per_addresses (token, groupless_address)
       WHERE groupless_address IS NOT NULL;
     """
+
+  def createUniqueGrouplessIndex(): DBActionW[Int] =
+    sqlu"""
+        CREATE UNIQUE INDEX IF NOT EXISTS token_tx_per_address_groupless_unique_idx
+        ON token_tx_per_addresses (
+          token, address, groupless_address, block_timestamp, tx_order, tx_hash, block_hash
+        )
+        WHERE groupless_address is not null AND main_chain = true;
+      """
 
   val table: TableQuery[TokenPerAddresses] = TableQuery[TokenPerAddresses]
 }

--- a/app/src/main/scala/org/alephium/explorer/util/SlickUtil.scala
+++ b/app/src/main/scala/org/alephium/explorer/util/SlickUtil.scala
@@ -152,6 +152,16 @@ object SlickUtil {
     }
   }
 
+  def distinct(
+      address: ApiAddress
+  ): String = {
+    address.lockupScript match {
+      case _: ApiAddress.HalfDecodedLockupScript =>
+        s"DISTINCT"
+      case _ =>
+        ""
+    }
+  }
   def splitAddresses(
       addresses: ArraySeq[ApiAddress]
   ): (ArraySeq[ApiAddress], ArraySeq[ApiAddress]) = {

--- a/app/src/test/scala/org/alephium/explorer/GenCoreProtocol.scala
+++ b/app/src/test/scala/org/alephium/explorer/GenCoreProtocol.scala
@@ -151,6 +151,15 @@ object GenCoreProtocol {
       }
   }
 
+  def halfDecodedLockupGen(
+      groupIndex: GroupIndex
+  )(implicit groupSetting: GroupSetting): Gen[LockupScript] = {
+    Gen.oneOf(
+      p2pkhLockupGen(groupIndex),
+      p2pkLockupGen(groupIndex)
+    )
+  }
+
   def lockupGen(groupIndex: GroupIndex)(implicit groupSetting: GroupSetting): Gen[LockupScript] = {
     Gen.oneOf(
       p2pkhLockupGen(groupIndex),
@@ -164,12 +173,9 @@ object GenCoreProtocol {
 
   def addressAssetProtocolGen()(implicit groupSetting: GroupSetting): Gen[Address.Asset] =
     for {
-      group <- Gen.choose(0, groupSetting.groupNum - 1)
-    } yield {
-      val groupIndex     = GroupIndex.unsafe(group)(groupSetting.groupConfig)
-      val (_, publicKey) = groupIndex.generateKey(groupSetting.groupConfig)
-      Address.p2pkh(publicKey)
-    }
+      group   <- Gen.choose(0, groupSetting.groupNum - 1)
+      address <- assetLockupGen(new GroupIndex(group)).map(Address.Asset(_))
+    } yield address
 
   def addressContractProtocolGen(implicit groupSetting: GroupSetting): Gen[Address.Contract] =
     for {

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/TokenQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/TokenQueriesSpec.scala
@@ -18,6 +18,7 @@ import org.alephium.explorer.persistence.{DatabaseFixtureForEach, DBRunner}
 import org.alephium.explorer.persistence.queries.TokenQueries
 import org.alephium.explorer.persistence.queries.result.TxByTokenQR
 import org.alephium.explorer.persistence.schema._
+import org.alephium.explorer.util.AddressUtil
 import org.alephium.util.{TimeStamp, U256}
 
 class TokenQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with DBRunner {
@@ -53,7 +54,11 @@ class TokenQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForEach wi
           run(TokenPerAddressSchema.table.delete).futureValue
           run(
             TokenPerAddressSchema.table ++= txPerAddressTokens.map(
-              _.copy(address = address, token = token)
+              _.copy(
+                address = address,
+                grouplessAddress = AddressUtil.convertToGrouplessAddress(address),
+                token = token
+              )
             )
           ).futureValue
 

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/TransactionQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/TransactionQueriesSpec.scala
@@ -61,7 +61,10 @@ class TransactionQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForE
 
     val output1 = output(address, ALPH.alph(1), None)
     val output2 = output(address, ALPH.alph(2), None)
-    val input1  = input(output2.hint, output2.key).copy(outputRefAddress = Some(address))
+    val input1 = input(output2.hint, output2.key).copy(
+      outputRefAddress = Some(address),
+      outputRefGrouplessAddress = AddressUtil.convertToGrouplessAddress(address)
+    )
 
     run(OutputSchema.table ++= ArraySeq(output1, output2)).futureValue
     run(InputSchema.table += input1).futureValue

--- a/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
@@ -460,7 +460,14 @@ class TransactionServiceSpec extends AlephiumActorSpecLike with DatabaseFixtureF
     val blocks = Gen
       .listOfN(20, blockEntityGen(chainIndex))
       .map(_.map { block =>
-        block.copy(outputs = block.outputs.map(_.copy(address = address)))
+        block.copy(outputs =
+          block.outputs.map(
+            _.copy(
+              address = address,
+              grouplessAddress = AddressUtil.convertToGrouplessAddress(address)
+            )
+          )
+        )
       })
       .sample
       .get
@@ -509,7 +516,14 @@ class TransactionServiceSpec extends AlephiumActorSpecLike with DatabaseFixtureF
     val block =
       blockEntityGen(chainIndex)
         .map { block =>
-          block.copy(outputs = block.outputs.map(_.copy(address = address)))
+          block.copy(outputs =
+            block.outputs.map(
+              _.copy(
+                address = address,
+                grouplessAddress = AddressUtil.convertToGrouplessAddress(address)
+              )
+            )
+          )
         }
         .sample
         .get

--- a/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
@@ -49,7 +49,14 @@ class TransactionServiceSpec extends AlephiumActorSpecLike with DatabaseFixtureF
     val blocks = Gen
       .listOfN(20, blockEntityGen(chainIndex))
       .map(_.map { block =>
-        block.copy(outputs = block.outputs.map(_.copy(address = address)))
+        block.copy(outputs =
+          block.outputs.map(
+            _.copy(
+              address = address,
+              grouplessAddress = AddressUtil.convertToGrouplessAddress(address)
+            )
+          )
+        )
       })
       .sample
       .get
@@ -689,9 +696,20 @@ class TransactionServiceSpec extends AlephiumActorSpecLike with DatabaseFixtureF
         val timestamp = now + (halfDay.timesUnsafe(index.toLong))
         block.copy(
           timestamp = timestamp,
-          outputs = block.outputs.map(_.copy(address = address, timestamp = timestamp)),
-          inputs =
-            block.inputs.map(_.copy(outputRefAddress = Some(address), timestamp = timestamp)),
+          outputs = block.outputs.map(
+            _.copy(
+              address = address,
+              grouplessAddress = AddressUtil.convertToGrouplessAddress(address),
+              timestamp = timestamp
+            )
+          ),
+          inputs = block.inputs.map(
+            _.copy(
+              outputRefAddress = Some(address),
+              outputRefGrouplessAddress = AddressUtil.convertToGrouplessAddress(address),
+              timestamp = timestamp
+            )
+          ),
           transactions = block.transactions.map { tx =>
             tx.copy(timestamp = timestamp)
           }

--- a/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/DBBenchmark.scala
+++ b/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/DBBenchmark.scala
@@ -13,7 +13,6 @@ import slick.jdbc.PostgresProfile
 import slick.jdbc.PostgresProfile.api._
 
 import org.alephium.api.model.{Address => ApiAddress}
-import org.alephium.explorer.GenApiModel._
 import org.alephium.explorer.GroupSetting
 import org.alephium.explorer.api.model.{IntervalType, Pagination}
 import org.alephium.explorer.benchmark.db.BenchmarkSettings._
@@ -245,7 +244,7 @@ class DBBenchmark {
     val _ =
       state.db.runNow(
         TransactionQueries.areAddressesActiveAction(
-          state.next.map(address => ApiAddress.from(address.lockupScript))
+          state.next
         ),
         requestTimeout
       )
@@ -258,7 +257,7 @@ class DBBenchmark {
     val _ =
       state.db.runNow(
         TransactionQueries.areAddressesActiveAction(
-          state.next.map(address => ApiAddress.from(address.lockupScript))
+          state.next
         ),
         requestTimeout
       )

--- a/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/DataGenerator.scala
+++ b/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/DataGenerator.scala
@@ -10,12 +10,14 @@ import scala.util.Random
 
 import akka.util.ByteString
 
+import org.alephium.api.model.{Address => ApiAddress}
+import org.alephium.explorer.ConfigDefaults._
 import org.alephium.explorer.GenApiModel._
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.persistence.model._
 import org.alephium.explorer.util.AddressUtil
 import org.alephium.protocol.Hash
-import org.alephium.protocol.model.{Address, BlockHash, GroupIndex, TransactionId}
+import org.alephium.protocol.model.{BlockHash, GroupIndex, TransactionId}
 import org.alephium.util.{TimeStamp, U256}
 
 /** Data generators for JMH benchmarks.
@@ -147,13 +149,15 @@ object DataGenerator {
     )
   }
 
-  def genAddress(): Address =
+  def genAddress(): ApiAddress =
     addressGen.sample.get
 
-  def genTransactionPerAddressEntity(address: Address = genAddress()): TransactionPerAddressEntity =
+  def genTransactionPerAddressEntity(
+      address: ApiAddress = genAddress()
+  ): TransactionPerAddressEntity =
     TransactionPerAddressEntity(
-      address = address,
-      grouplessAddress = AddressUtil.convertToGrouplessAddress(address),
+      address = address.toProtocol(),
+      grouplessAddress = AddressUtil.convertToGrouplessAddress(address.toProtocol()),
       hash = TransactionId.generate,
       blockHash = BlockHash.generate,
       timestamp = TimeStamp.now(),

--- a/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/AreAddressesActiveReadState.scala
+++ b/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/AreAddressesActiveReadState.scala
@@ -7,25 +7,25 @@ import scala.collection.immutable.ArraySeq
 
 import org.openjdk.jmh.annotations.{Scope, State}
 
+import org.alephium.api.model.{Address => ApiAddress}
 import org.alephium.explorer.benchmark.db.{DataGenerator, DBConnectionPool, DBExecutor}
 import org.alephium.explorer.benchmark.db.BenchmarkSettings._
 import org.alephium.explorer.benchmark.db.state.ListBlocksReadStateSettings._
 import org.alephium.explorer.persistence.schema.TransactionPerAddressSchema
-import org.alephium.protocol.model.Address
 
 /** JMH state for benchmarking via
   * [[org.alephium.explorer.persistence.queries.TransactionQueries.areAddressesActiveAction]]
   */
 class AreAddressesActiveReadState(val db: DBExecutor)
-    extends ReadBenchmarkState[ArraySeq[Address]](testDataCount = maxPages, db = db) {
+    extends ReadBenchmarkState[ArraySeq[ApiAddress]](testDataCount = maxPages, db = db) {
 
   import config.profile.api._
 
   // scalastyle:off magic.number
-  override def generateData(currentCacheSize: Int): ArraySeq[Address] =
+  override def generateData(currentCacheSize: Int): ArraySeq[ApiAddress] =
     ArraySeq.fill(40)(DataGenerator.genAddress()) // Generate 40 address per query
 
-  override def persist(data: Array[ArraySeq[Address]]): Unit = {
+  override def persist(data: Array[ArraySeq[ApiAddress]]): Unit = {
     val transactions = // for every address generate a TransactionPerAddressEntity
       data flatMap { addresses =>
         addresses map DataGenerator.genTransactionPerAddressEntity


### PR DESCRIPTION
Related to https://github.com/alephium/alephium-frontend/issues/1402

Few month ago we removed `DISTINCT` because they were less performant and not necessary, now following the above issue we need to bring them back for groupless addresses.

With this PR, the `DISTINCT` is added only if it's a groupless address, for regular one we keep the same query.

New indexes have been added  for those cases, I ran multiple benchmark, comparing the previous version and the new one.
I forced the requested data to be a half-decoded address, to be sure the `DISTINCT` were used.

The result are of course a bit slower, but negligible IMO, this is due to the indexes, before them the results were catastrophic.

```
[info] Benchmark                                  Mode  Cnt      Score   Error  Units
[info] DBBenchmark.getOLDTxHashesByAddressQuery  thrpt       13419.515          ops/s
[info] DBBenchmark.getTxHashesByAddressQuery     thrpt       11160.033          ops/s
```

```
[info] Benchmark                                 Mode  Cnt     Score   Error  Units
[info] DBBenchmark.OLDcountAddressTransactions  thrpt       1608.738          ops/s
[info] DBBenchmark.countAddressTransactions     thrpt       1227.655          ops/s
```

I also reworked a bit the test framework to be sure that our address generator is producing some half-decoded value. Previously it was generating some `P2PK`, but only the complete version. Now every tests is running some half-decoded address.