### PR TITLE
Conflicted txs

### DIFF
--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -8586,6 +8586,13 @@
             "items": {
               "$ref": "#/components/schemas/GhostUncle"
             }
+          },
+          "conflictedTxs": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "32-byte-hash"
+            }
           }
         }
       },

--- a/app/src/main/scala/org/alephium/explorer/api/EndpointExamples.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/EndpointExamples.scala
@@ -137,7 +137,8 @@ object EndpointExamples extends EndpointsExamples {
       hashRate = HashRate.a128EhPerSecond.value,
       parent = Some(blockHash),
       mainChain = true,
-      ghostUncles = ArraySeq(GhostUncle(blockHash, addressAsset))
+      ghostUncles = ArraySeq(GhostUncle(blockHash, addressAsset)),
+      conflictedTxs = None
     )
 
   private val transaction: Transaction =

--- a/app/src/main/scala/org/alephium/explorer/api/model/BlockEntry.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/BlockEntry.scala
@@ -15,9 +15,10 @@ import org.alephium.explorer.api.Json.groupIndexReadWriter
 import org.alephium.explorer.service.FlowEntity
 import org.alephium.json.Json._
 import org.alephium.protocol.Hash
-import org.alephium.protocol.model.{BlockHash, GroupIndex}
+import org.alephium.protocol.model.{BlockHash, GroupIndex, TransactionId}
 import org.alephium.util.{AVector, TimeStamp}
 
+@SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
 final case class BlockEntry(
     hash: BlockHash,
     timestamp: TimeStamp,
@@ -34,7 +35,8 @@ final case class BlockEntry(
     hashRate: BigInteger,
     parent: Option[BlockHash],
     mainChain: Boolean,
-    ghostUncles: ArraySeq[GhostUncle]
+    ghostUncles: ArraySeq[GhostUncle],
+    conflictedTxs: Option[ArraySeq[TransactionId]] = None
 ) extends FlowEntity {
 
   def toProtocol(
@@ -53,7 +55,8 @@ final case class BlockEntry(
       depStateHash,
       txsHash,
       target,
-      AVector.from(ghostUncles.map(_.toProtocol()))
+      AVector.from(ghostUncles.map(_.toProtocol())),
+      conflictedTxs = conflictedTxs.map(AVector.from(_))
     )
   }
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/Migrations.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/Migrations.scala
@@ -373,7 +373,7 @@ object Migrations extends StrictLogging {
             consensus = explorerConfig.consensus
           )
         ConflictedTxsService
-          .updateConflictedTxs(explorerConfig.consensus.danube.forkTimestamp)
+          .updateConflictedTxsFrom(explorerConfig.consensus.danube.forkTimestamp)
           .flatMap { _ =>
             logger.info("Conflicted transactions migration done")
             Future.unit

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/BlockEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/BlockEntity.scala
@@ -12,7 +12,7 @@ import akka.util.ByteString
 import org.alephium.explorer.api.model.{GhostUncle, Height}
 import org.alephium.explorer.service.FlowEntity
 import org.alephium.protocol.Hash
-import org.alephium.protocol.model.{BlockHash, GroupIndex}
+import org.alephium.protocol.model.{BlockHash, GroupIndex, TransactionId}
 import org.alephium.util.TimeStamp
 
 final case class BlockEntity(
@@ -32,10 +32,12 @@ final case class BlockEntity(
     txsHash: Hash,
     target: ByteString,
     hashrate: BigInteger,
-    ghostUncles: ArraySeq[GhostUncle]
+    ghostUncles: ArraySeq[GhostUncle],
+    conflictedTxs: Option[ArraySeq[TransactionId]]
 ) extends FlowEntity {
 
   @inline def toBlockHeader(groupNum: Int): BlockHeader =
     BlockHeader.fromEntity(this, groupNum)
 
+  def isIntraGroup(): Boolean = chainFrom == chainTo
 }

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/BlockHeader.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/BlockHeader.scala
@@ -11,7 +11,7 @@ import akka.util.ByteString
 
 import org.alephium.explorer.api.model.{BlockEntry, BlockEntryLite, GhostUncle, Height}
 import org.alephium.protocol.Hash
-import org.alephium.protocol.model.{BlockHash, GroupIndex}
+import org.alephium.protocol.model.{BlockHash, GroupIndex, TransactionId}
 import org.alephium.util.TimeStamp
 
 final case class BlockHeader(
@@ -30,7 +30,8 @@ final case class BlockHeader(
     hashrate: BigInteger,
     parent: Option[BlockHash],
     deps: ArraySeq[BlockHash],
-    ghostUncles: Option[ArraySeq[GhostUncle]]
+    ghostUncles: Option[ArraySeq[GhostUncle]],
+    conflictedTxs: Option[ArraySeq[TransactionId]]
 ) {
 
   def toApi(): BlockEntry =
@@ -50,7 +51,8 @@ final case class BlockHeader(
       hashrate,
       parent,
       mainChain,
-      ghostUncles.getOrElse(ArraySeq.empty)
+      ghostUncles.getOrElse(ArraySeq.empty),
+      conflictedTxs
     )
 
   val toLiteApi: BlockEntryLite =
@@ -85,7 +87,8 @@ object BlockHeader {
       blockEntity.hashrate,
       blockEntity.parent(groupNum),
       blockEntity.deps,
-      ghostUncles
+      ghostUncles,
+      blockEntity.conflictedTxs
     )
   }
 }

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/InputEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/InputEntity.scala
@@ -43,6 +43,7 @@ final case class InputEntity(
     outputRefKey: Hash,
     unlockScript: Option[ByteString],
     mainChain: Boolean,
+    conflicted: Option[Boolean],
     inputOrder: Int,
     txOrder: Int,
     outputRefTxHash: Option[TransactionId],

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/OutputEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/OutputEntity.scala
@@ -65,6 +65,7 @@ final case class OutputEntity(
     grouplessAddress: Option[GrouplessAddress],
     tokens: Option[ArraySeq[Token]], // None if empty list
     mainChain: Boolean,
+    conflicted: Option[Boolean],
     lockTime: Option[TimeStamp],
     message: Option[ByteString],
     outputOrder: Int,

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/TokenOutputEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/TokenOutputEntity.scala
@@ -21,6 +21,7 @@ final case class TokenOutputEntity(
     address: Address,
     grouplessAddress: Option[GrouplessAddress],
     mainChain: Boolean,
+    conflicted: Option[Boolean],
     lockTime: Option[TimeStamp],
     message: Option[ByteString],
     outputOrder: Int,

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/TokenTxPerAddressEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/TokenTxPerAddressEntity.scala
@@ -14,5 +14,6 @@ final case class TokenTxPerAddressEntity(
     timestamp: TimeStamp,
     txOrder: Int,
     mainChain: Boolean,
+    conflicted: Option[Boolean],
     token: TokenId
 )

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/TransactionEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/TransactionEntity.scala
@@ -24,6 +24,7 @@ final case class TransactionEntity(
     gasPrice: U256,
     order: Int,
     mainChain: Boolean,
+    conflicted: Option[Boolean],
     scriptExecutionOk: Boolean,
     inputSignatures: Option[ArraySeq[ByteString]],
     scriptSignatures: Option[ArraySeq[ByteString]],

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/TransactionPerAddressEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/TransactionPerAddressEntity.scala
@@ -14,5 +14,6 @@ final case class TransactionPerAddressEntity(
     timestamp: TimeStamp,
     txOrder: Int,
     mainChain: Boolean,
+    conflicted: Option[Boolean],
     coinbase: Boolean
 )

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/TransactionPerTokenEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/TransactionPerTokenEntity.scala
@@ -12,5 +12,6 @@ final case class TransactionPerTokenEntity(
     token: TokenId,
     timestamp: TimeStamp,
     txOrder: Int,
-    mainChain: Boolean
+    mainChain: Boolean,
+    conflicted: Option[Boolean]
 )

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
@@ -23,7 +23,7 @@ import org.alephium.explorer.persistence.schema.CustomGetResult._
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.explorer.util.SlickExplainUtil._
 import org.alephium.explorer.util.SlickUtil._
-import org.alephium.protocol.model.{BlockHash, GroupIndex}
+import org.alephium.protocol.model.{BlockHash, GroupIndex, TransactionId}
 import org.alephium.util.TimeStamp
 
 object BlockQueries extends StrictLogging {
@@ -251,6 +251,17 @@ object BlockQueries extends StrictLogging {
         setParameter = parameters
       ).asUpdate
     }
+
+  def updateConflictedTxs(
+      blockHash: BlockHash,
+      conflictedTxs: Option[ArraySeq[TransactionId]]
+  ): DBActionRWT[Int] = {
+    sqlu"""
+         UPDATE block_headers
+         SET conflicted_txs = $conflictedTxs
+         WHERE hash = $blockHash
+         """
+  }
 
   def getLatestBlock(chainFrom: GroupIndex, chainTo: GroupIndex): DBActionSR[LatestBlock] = {
     sql"""

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
@@ -263,9 +263,9 @@ object BlockQueries extends StrictLogging {
   }
 
   /** Inserts block_headers or ignore them if there is a primary key conflict */
-  // scalastyle:off magic.number
+  // scalastyle:off magic.number method.length
   def insertBlockHeaders(blocks: Iterable[BlockHeader]): DBActionW[Int] =
-    QuerySplitter.splitUpdates(rows = blocks, columnsPerRow = 16) { (blocks, placeholder) =>
+    QuerySplitter.splitUpdates(rows = blocks, columnsPerRow = 17) { (blocks, placeholder) =>
       val query =
         s"""
            INSERT INTO $block_headers ("hash",
@@ -283,7 +283,8 @@ object BlockQueries extends StrictLogging {
                                        "hashrate",
                                        "parent",
                                        "deps",
-                                       "ghost_uncles")
+                                       "ghost_uncles",
+                                       "conflicted_txs")
            VALUES $placeholder
            ON CONFLICT ON CONSTRAINT block_headers_pkey
                DO NOTHING
@@ -308,6 +309,7 @@ object BlockQueries extends StrictLogging {
             params >> block.parent
             params >> block.deps
             params >> block.ghostUncles
+            params >> block.conflictedTxs
           }
 
       SQLActionBuilder(

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/ConflictedTxsQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/ConflictedTxsQueries.scala
@@ -1,0 +1,106 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.explorer.persistence.queries
+
+import scala.collection.immutable.ArraySeq
+
+import com.typesafe.scalalogging.StrictLogging
+import slick.jdbc.{PositionedParameters, SetParameter, SQLActionBuilder}
+import slick.jdbc.PostgresProfile.api._
+
+import org.alephium.explorer.persistence._
+import org.alephium.explorer.persistence.schema.CustomGetResult._
+import org.alephium.explorer.persistence.schema.CustomSetParameter._
+import org.alephium.explorer.util.SlickUtil._
+import org.alephium.protocol.model.{BlockHash, TransactionId}
+import org.alephium.util.TimeStamp
+
+@SuppressWarnings(Array("org.wartremover.warts.IterableOps"))
+case object ConflictedTxsQueries extends StrictLogging {
+
+  def updateConflictStatus(
+      txHash: TransactionId,
+      blockHash: BlockHash,
+      conflicted: Boolean
+  ): DBActionRWT[Int] = {
+
+    val query =
+      s"""
+         BEGIN;
+         UPDATE transactions              SET conflicted = ? WHERE hash    = ? AND block_hash = ?;
+         UPDATE outputs                   SET conflicted = ? WHERE tx_hash = ? AND block_hash = ?;
+         UPDATE inputs                    SET conflicted = ? WHERE tx_hash = ? AND block_hash = ?;
+         UPDATE transaction_per_addresses SET conflicted = ? WHERE tx_hash = ? AND block_hash = ?;
+         UPDATE transaction_per_token     SET conflicted = ? WHERE tx_hash = ? AND block_hash = ?;
+         UPDATE token_tx_per_addresses    SET conflicted = ? WHERE tx_hash = ? AND block_hash = ?;
+         UPDATE token_outputs             SET conflicted = ? WHERE tx_hash = ? AND block_hash = ?;
+         COMMIT;
+      """
+
+    val parameters: SetParameter[Unit] =
+      (_: Unit, params: PositionedParameters) =>
+        (1 to 7) foreach { _ =>
+          params >> Some(conflicted)
+          params >> txHash
+          params >> blockHash
+        }
+
+    SQLActionBuilder(
+      sql = query,
+      setParameter = parameters
+    ).asUpdate
+
+  }
+
+  def updateBlockConflictTxs(
+      blockHash: BlockHash,
+      conflictedTxs: Option[ArraySeq[TransactionId]]
+  ): DBActionRWT[Int] = {
+    sql"""
+      UPDATE block_headers
+      SET conflicted_txs = $conflictedTxs
+      WHERE hash = $blockHash;
+    """.asUpdate
+  }
+
+  def findConflictedTxs(
+      timestamp: TimeStamp
+  ): DBActionSR[(TransactionId, BlockHash, Option[Boolean])] =
+    sql"""
+     SELECT DISTINCT ON (i.tx_hash) i.tx_hash, i.block_hash, i.conflicted
+      FROM inputs i
+      WHERE i.block_timestamp > $timestamp
+        AND i.main_chain = true
+        AND i.output_ref_key IN (
+          SELECT output_ref_key
+          FROM inputs
+          WHERE block_timestamp > $timestamp
+            AND main_chain = true
+          GROUP BY output_ref_key
+          HAVING COUNT(DISTINCT block_hash) > 1
+        )
+      """.asAS[(TransactionId, BlockHash, Option[Boolean])]
+
+  // Find inputs that were conflicted, but due to a reorg aren't anymore.
+  def findReorgedConflictedTxs(
+      timestamp: TimeStamp
+  ): DBActionSR[(TransactionId, BlockHash)] = {
+    sql"""
+        SELECT DISTINCT ON (i.tx_hash) i.tx_hash,i.block_hash
+        FROM inputs i
+        WHERE i.block_timestamp > $timestamp
+          AND i.conflicted IS NOT NULL
+          AND i.output_ref_key IN (
+            SELECT output_ref_key
+            FROM inputs
+            WHERE block_timestamp > $timestamp
+              AND conflicted IS NOT NULL
+            GROUP BY output_ref_key
+            HAVING
+              BOOL_OR(main_chain)         -- at least one TRUE
+              AND BOOL_OR(NOT main_chain) -- at least one FALSE
+          )
+      """.asAS[(TransactionId, BlockHash)]
+  }
+}

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/InputQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/InputQueries.scala
@@ -128,6 +128,7 @@ object InputQueries {
           output_ref_key,
           unlock_script,
           main_chain,
+          conflicted,
           input_order,
           tx_order,
           output_ref_tx_hash,
@@ -138,6 +139,7 @@ object InputQueries {
           contract_input
         FROM inputs
         WHERE main_chain = true
+        AND #${notConflicted()}
         ORDER BY block_timestamp #${if (ascendingOrder) "" else "DESC"}
     """.asASE[InputEntity](inputGetResult)
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/OutputQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/OutputQueries.scala
@@ -362,6 +362,7 @@ object OutputQueries {
         groupless_address,
         tokens,
         main_chain,
+        conflicted,
         lock_time,
         message,
         output_order,
@@ -372,6 +373,7 @@ object OutputQueries {
         fixed_output
       FROM outputs
       WHERE main_chain = true
+      AND #${notConflicted()}
       ORDER BY block_timestamp #${if (ascendingOrder) "" else "DESC"}
       """.asASE[OutputEntity](outputGetResult)
   }
@@ -418,6 +420,7 @@ object OutputQueries {
       SELECT tx_hash
       FROM outputs
       WHERE main_chain = true
+        AND #${notConflicted()}
         AND key = $key
     """
 
@@ -445,11 +448,13 @@ object OutputQueries {
                LEFT JOIN inputs
                          ON outputs.key = inputs.output_ref_key
                              AND inputs.main_chain = true
+                             AND #${notConflicted("inputs")}
                              AND inputs.#$inputAddressColumn = $address
                              AND inputs.block_timestamp > ${latestFinalizedTimestamp.millis}
       WHERE outputs.spent_finalized IS NULL
         AND outputs.#$ouptupAddressColumn = $address
         AND outputs.main_chain = true
+        AND #${notConflicted("outputs")}
         AND inputs.block_hash IS NULL
       """
       .asAS[(Option[U256], Option[U256])]

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/TokenQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/TokenQueries.scala
@@ -48,10 +48,12 @@ object TokenQueries extends StrictLogging {
                LEFT JOIN inputs
                          ON token_outputs.key = inputs.output_ref_key
                              AND inputs.main_chain = true
+                             AND #${notConflicted("inputs")}
       WHERE token_outputs.spent_finalized IS NULL
         AND token_outputs.#${addressColumn(address)} = $address
         AND token_outputs.token = $token
         AND token_outputs.main_chain = true
+        AND #${notConflicted("token_outputs")}
         AND inputs.block_hash IS NULL;
     """.asAS[(Option[U256], Option[U256])].exactlyOne
 
@@ -108,6 +110,7 @@ object TokenQueries extends StrictLogging {
       SELECT #${TxByTokenQR.selectFields}
       FROM transaction_per_token
       WHERE main_chain = true
+      AND #${notConflicted()}
       AND token = $token
       ORDER BY block_timestamp DESC, tx_order
     """
@@ -124,6 +127,7 @@ object TokenQueries extends StrictLogging {
       FROM token_tx_per_addresses
       WHERE #${addressColumn(address)} = $address
       AND main_chain = true
+      AND #${notConflicted()}
     """
       .paginate(pagination)
       .asAS[TokenId]
@@ -150,6 +154,7 @@ object TokenQueries extends StrictLogging {
       SELECT #${distinct(address)} #${TxByTokenQR.selectFields}
       FROM token_tx_per_addresses
       WHERE main_chain = true
+      AND #${notConflicted()}
       AND #${addressColumn(address)} = $address
       AND token = $token
       ORDER BY block_timestamp DESC, tx_order
@@ -183,9 +188,11 @@ object TokenQueries extends StrictLogging {
                LEFT JOIN inputs
                          ON token_outputs.key = inputs.output_ref_key
                              AND inputs.main_chain = true
+                             AND #${notConflicted("inputs")}
       WHERE token_outputs.spent_finalized IS NULL
         AND token_outputs.#${addressColumn(address)} = $address
         AND token_outputs.main_chain = true
+        AND #${notConflicted("token_outputs")}
         AND inputs.block_hash IS NULL
       GROUP BY token_outputs.token
     """

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
@@ -146,6 +146,7 @@ object TransactionQueries extends StrictLogging {
       SELECT COUNT(#${distinct(address)} tx_hash)
       FROM transaction_per_addresses
       WHERE main_chain = true
+      AND #${notConflicted()}
       AND #${addressColumn(address)} = $address
     """
       .asAS[Int]
@@ -160,6 +161,7 @@ object TransactionQueries extends StrictLogging {
       SELECT COUNT(#${distinct(address)} tx_hash)
       FROM transaction_per_addresses
       WHERE main_chain = true
+      AND #${notConflicted()}
       AND #${addressColumn(address)} = $address
       AND block_timestamp > $from
       #${to.map(ts => s"AND block_timestamp <= ${ts.millis}").getOrElse("")}
@@ -189,6 +191,7 @@ object TransactionQueries extends StrictLogging {
       SELECT #${distinct(address)} #${TxByAddressQR.selectFields}
       FROM transaction_per_addresses
       WHERE main_chain = true
+      AND #${notConflicted()}
       AND #${addressColumn(address)} = $address
       ORDER BY block_timestamp DESC, tx_order
     """
@@ -202,6 +205,7 @@ object TransactionQueries extends StrictLogging {
         FROM transactions
         WHERE block_timestamp > $time
         AND main_chain = true
+        AND #${notConflicted()}
         """.as[Int].head
 
   /** Get transactions for a list of addresses
@@ -251,6 +255,7 @@ object TransactionQueries extends StrictLogging {
            SELECT ${TxByAddressQR.selectFields}
            FROM transaction_per_addresses
            WHERE main_chain = true
+           AND ${notConflicted()}
              AND $addressesCondition
              ${fromTs.map(ts => s"AND block_timestamp >= ${ts.millis}").getOrElse("")}
              ${toTs.map(ts => s"AND block_timestamp < ${ts.millis}").getOrElse("")}
@@ -296,6 +301,7 @@ object TransactionQueries extends StrictLogging {
       SELECT #${distinct(address)} #${TxByAddressQR.selectFields}
       FROM transaction_per_addresses
       WHERE main_chain = true
+        AND #${notConflicted()}
         AND #${addressColumn(address)} = $address
         AND block_timestamp BETWEEN $fromTime AND $toTime
       ORDER BY block_timestamp DESC, tx_order
@@ -355,6 +361,7 @@ object TransactionQueries extends StrictLogging {
       SELECT #${TxByAddressQR.selectFields}
       FROM transaction_per_addresses
       WHERE main_chain = true AND #${addressColumn(address)} = $address
+      AND #${notConflicted()}
       ORDER BY block_timestamp DESC, tx_order
       LIMIT 1
     """
@@ -387,6 +394,7 @@ object TransactionQueries extends StrictLogging {
       FROM transaction_per_addresses
       WHERE #${addressColumn(address)} = $address
       AND main_chain = true
+      AND #${notConflicted()}
       AND block_timestamp >= $from
       AND block_timestamp < $to
       ORDER BY 1 OFFSET ($threshold) ROWS FETCH NEXT (1) ROWS ONLY;
@@ -403,6 +411,7 @@ object TransactionQueries extends StrictLogging {
       FROM transaction_per_addresses
       WHERE #${addressColumn(address)} = $address
       AND main_chain = true
+      AND #${notConflicted()}
       AND block_timestamp >= $from
       AND block_timestamp < $to
       ORDER BY block_timestamp DESC
@@ -444,6 +453,7 @@ object TransactionQueries extends StrictLogging {
       FROM outputs
       WHERE #${addressColumn(address)} = $address
       AND main_chain = true
+      AND #${notConflicted()}
       AND block_timestamp >= ${ALPH.GenesisTimestamp}
       AND block_timestamp <= $to
       GROUP BY ts
@@ -473,6 +483,7 @@ object TransactionQueries extends StrictLogging {
         "output_ref_groupless_address"
       )}= $address
       AND main_chain = true
+      AND #${notConflicted()}
       AND block_timestamp >= ${ALPH.GenesisTimestamp}
       AND block_timestamp <= $to
       GROUP BY ts

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/BlockHeaderSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/BlockHeaderSchema.scala
@@ -16,7 +16,7 @@ import org.alephium.explorer.api.model.{GhostUncle, Height}
 import org.alephium.explorer.persistence.model.BlockHeader
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
 import org.alephium.protocol.Hash
-import org.alephium.protocol.model.{BlockHash, GroupIndex}
+import org.alephium.protocol.model.{BlockHash, GroupIndex, TransactionId}
 import org.alephium.util.TimeStamp
 
 object BlockHeaderSchema extends SchemaMainChain[BlockHeader]("block_headers") {
@@ -44,6 +44,8 @@ object BlockHeaderSchema extends SchemaMainChain[BlockHeader]("block_headers") {
     def deps: Rep[ArraySeq[BlockHash]] = column[ArraySeq[BlockHash]]("deps")
     def ghostUncles: Rep[Option[ArraySeq[GhostUncle]]] =
       column[Option[ArraySeq[GhostUncle]]]("ghost_uncles")
+    def conflictedTxs: Rep[Option[ArraySeq[TransactionId]]] =
+      column[Option[ArraySeq[TransactionId]]]("conflicted_txs")
 
     def timestampIdx: Index = index("blocks_timestamp_idx", timestamp)
     def heightIdx: Index    = index("blocks_height_idx", height)
@@ -65,7 +67,8 @@ object BlockHeaderSchema extends SchemaMainChain[BlockHeader]("block_headers") {
         hashrate,
         parent,
         deps,
-        ghostUncles
+        ghostUncles,
+        conflictedTxs
       )
         .<>((BlockHeader.apply _).tupled, BlockHeader.unapply)
   }

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomGetResult.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomGetResult.scala
@@ -203,6 +203,7 @@ object CustomGetResult {
         grouplessAddress = result.<<?,
         tokens = result.<<?,
         mainChain = result.<<,
+        conflicted = result.<<?,
         lockTime = result.<<?,
         message = result.<<?,
         outputOrder = result.<<,
@@ -223,6 +224,7 @@ object CustomGetResult {
         outputRefKey = result.<<,
         unlockScript = result.<<?,
         mainChain = result.<<,
+        conflicted = result.<<?,
         inputOrder = result.<<,
         txOrder = result.<<,
         outputRefTxHash = result.<<?,
@@ -253,6 +255,15 @@ object CustomGetResult {
   implicit val optionGhostUnclesGetResult: GetResult[Option[ArraySeq[GhostUncle]]] =
     (result: PositionedResult) =>
       result.nextBytesOption().map(bytes => readBinary[ArraySeq[GhostUncle]](bytes))
+
+  implicit val optionTransactionIdsGetResult: GetResult[Option[ArraySeq[TransactionId]]] =
+    (result: PositionedResult) =>
+      result.nextBytesOption().map { bytes =>
+        deserialize[ArraySeq[TransactionId]](ByteString.fromArrayUnsafe(bytes)) match {
+          case Left(error)  => throw error
+          case Right(value) => value
+        }
+      }
 
   /** GetResult type for BlockEntryLite
     *
@@ -292,7 +303,8 @@ object CustomGetResult {
         hashrate = result.<<,
         parent = result.<<?,
         deps = result.<<,
-        ghostUncles = result.<<?
+        ghostUncles = result.<<?,
+        conflictedTxs = result.<<?
       )
 
   val transactionEntityGetResult: GetResult[TransactionEntity] =
@@ -310,6 +322,7 @@ object CustomGetResult {
         gasPrice = result.<<,
         order = result.<<,
         mainChain = result.<<,
+        conflicted = result.<<?,
         scriptExecutionOk = result.<<,
         inputSignatures = result.<<?,
         scriptSignatures = result.<<?,

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomJdbcTypes.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomJdbcTypes.scala
@@ -206,4 +206,10 @@ object CustomJdbcTypes {
       uncles => writeBinary(uncles),
       bytes => readBinary[ArraySeq[GhostUncle]](bytes)
     )
+
+  implicit val optionTransactionIdsTpye: JdbcType[ArraySeq[TransactionId]] =
+    MappedJdbcType.base[ArraySeq[TransactionId], Array[Byte]](
+      txs => writeBinary(txs),
+      bytes => readBinary[ArraySeq[TransactionId]](bytes)
+    )
 }

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomSetParameter.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/CustomSetParameter.scala
@@ -312,4 +312,21 @@ object CustomSetParameter {
         // scalastyle:on null
       }
   }
+
+  implicit object OptionTransactionIdsSetParameter
+      extends SetParameter[Option[ArraySeq[TransactionId]]] {
+    override def apply(
+        option: Option[ArraySeq[TransactionId]],
+        params: PositionedParameters
+    ): Unit =
+      option match {
+        case Some(transactionIds) =>
+          params setBytes serialize(transactionIds).toArray
+
+        case None =>
+          // scalastyle:off null
+          params setBytes null
+        // scalastyle:on null
+      }
+  }
 }

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/InputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/InputSchema.scala
@@ -28,6 +28,7 @@ object InputSchema extends SchemaMainChain[InputEntity]("inputs") {
     def outputRefKey: Rep[Hash]               = column[Hash]("output_ref_key", O.SqlType("BYTEA"))
     def unlockScript: Rep[Option[ByteString]] = column[Option[ByteString]]("unlock_script")
     def mainChain: Rep[Boolean]               = column[Boolean]("main_chain")
+    def conflicted: Rep[Option[Boolean]]      = column[Option[Boolean]]("conflicted")
     def inputOrder: Rep[Int]                  = column[Int]("input_order")
     def txOrder: Rep[Int]                     = column[Int]("tx_order")
     def outputRefTxHash: Rep[Option[TransactionId]] =
@@ -61,6 +62,7 @@ object InputSchema extends SchemaMainChain[InputEntity]("inputs") {
         outputRefKey,
         unlockScript,
         mainChain,
+        conflicted,
         inputOrder,
         txOrder,
         outputRefTxHash,

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/OutputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/OutputSchema.scala
@@ -34,6 +34,7 @@ object OutputSchema extends SchemaMainChain[OutputEntity]("outputs") {
       column[Option[GrouplessAddress]]("groupless_address")
     def tokens: Rep[Option[ArraySeq[Token]]] = column[Option[ArraySeq[Token]]]("tokens")
     def mainChain: Rep[Boolean]              = column[Boolean]("main_chain")
+    def conflicted: Rep[Option[Boolean]]     = column[Option[Boolean]]("conflicted")
     def lockTime: Rep[Option[TimeStamp]]     = column[Option[TimeStamp]]("lock_time")
     def message: Rep[Option[ByteString]]     = column[Option[ByteString]]("message")
     def outputOrder: Rep[Int]                = column[Int]("output_order")
@@ -66,6 +67,7 @@ object OutputSchema extends SchemaMainChain[OutputEntity]("outputs") {
         grouplessAddress,
         tokens,
         mainChain,
+        conflicted,
         lockTime,
         message,
         outputOrder,

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenOutputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenOutputSchema.scala
@@ -32,6 +32,7 @@ object TokenOutputSchema extends SchemaMainChain[TokenOutputEntity]("token_outpu
     def grouplessAddress: Rep[Option[GrouplessAddress]] =
       column[Option[GrouplessAddress]]("groupless_address")
     def mainChain: Rep[Boolean]          = column[Boolean]("main_chain")
+    def conflicted: Rep[Option[Boolean]] = column[Option[Boolean]]("conflicted")
     def lockTime: Rep[Option[TimeStamp]] = column[Option[TimeStamp]]("lock_time")
     def message: Rep[Option[ByteString]] = column[Option[ByteString]]("message")
     def outputOrder: Rep[Int]            = column[Int]("output_order")
@@ -63,6 +64,7 @@ object TokenOutputSchema extends SchemaMainChain[TokenOutputEntity]("token_outpu
         address,
         grouplessAddress,
         mainChain,
+        conflicted,
         lockTime,
         message,
         outputOrder,

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenTxPerAddressSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenTxPerAddressSchema.scala
@@ -21,12 +21,13 @@ object TokenPerAddressSchema
     def address: Rep[Address] = column[Address]("address")
     def grouplessAddress: Rep[Option[GrouplessAddress]] =
       column[Option[GrouplessAddress]]("groupless_address")
-    def txHash: Rep[TransactionId] = column[TransactionId]("tx_hash", O.SqlType("BYTEA"))
-    def blockHash: Rep[BlockHash]  = column[BlockHash]("block_hash", O.SqlType("BYTEA"))
-    def timestamp: Rep[TimeStamp]  = column[TimeStamp]("block_timestamp")
-    def txOrder: Rep[Int]          = column[Int]("tx_order")
-    def mainChain: Rep[Boolean]    = column[Boolean]("main_chain")
-    def token: Rep[TokenId]        = column[TokenId]("token")
+    def txHash: Rep[TransactionId]       = column[TransactionId]("tx_hash", O.SqlType("BYTEA"))
+    def blockHash: Rep[BlockHash]        = column[BlockHash]("block_hash", O.SqlType("BYTEA"))
+    def timestamp: Rep[TimeStamp]        = column[TimeStamp]("block_timestamp")
+    def txOrder: Rep[Int]                = column[Int]("tx_order")
+    def mainChain: Rep[Boolean]          = column[Boolean]("main_chain")
+    def conflicted: Rep[Option[Boolean]] = column[Option[Boolean]]("conflicted")
+    def token: Rep[TokenId]              = column[TokenId]("token")
 
     def pk: PrimaryKey = primaryKey("token_tx_per_address_pk", (txHash, blockHash, address, token))
 
@@ -37,7 +38,17 @@ object TokenPerAddressSchema
     def tokenAddressIdx: Index = index("token_tx_per_address_token_address_idx", (token, address))
 
     def * : ProvenShape[TokenTxPerAddressEntity] =
-      (address, grouplessAddress, txHash, blockHash, timestamp, txOrder, mainChain, token)
+      (
+        address,
+        grouplessAddress,
+        txHash,
+        blockHash,
+        timestamp,
+        txOrder,
+        mainChain,
+        conflicted,
+        token
+      )
         .<>((TokenTxPerAddressEntity.apply _).tupled, TokenTxPerAddressEntity.unapply)
   }
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionPerAddressSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionPerAddressSchema.scala
@@ -21,12 +21,13 @@ object TransactionPerAddressSchema
     def address: Rep[Address] = column[Address]("address")
     def grouplessAddress: Rep[Option[GrouplessAddress]] =
       column[Option[GrouplessAddress]]("groupless_address")
-    def txHash: Rep[TransactionId] = column[TransactionId]("tx_hash", O.SqlType("BYTEA"))
-    def blockHash: Rep[BlockHash]  = column[BlockHash]("block_hash", O.SqlType("BYTEA"))
-    def timestamp: Rep[TimeStamp]  = column[TimeStamp]("block_timestamp")
-    def txOrder: Rep[Int]          = column[Int]("tx_order")
-    def mainChain: Rep[Boolean]    = column[Boolean]("main_chain")
-    def coinbase: Rep[Boolean]     = column[Boolean]("coinbase")
+    def txHash: Rep[TransactionId]       = column[TransactionId]("tx_hash", O.SqlType("BYTEA"))
+    def blockHash: Rep[BlockHash]        = column[BlockHash]("block_hash", O.SqlType("BYTEA"))
+    def timestamp: Rep[TimeStamp]        = column[TimeStamp]("block_timestamp")
+    def txOrder: Rep[Int]                = column[Int]("tx_order")
+    def mainChain: Rep[Boolean]          = column[Boolean]("main_chain")
+    def conflicted: Rep[Option[Boolean]] = column[Option[Boolean]]("conflicted")
+    def coinbase: Rep[Boolean]           = column[Boolean]("coinbase")
 
     def pk: PrimaryKey = primaryKey("txs_per_address_pk", (txHash, blockHash, address))
 
@@ -37,7 +38,17 @@ object TransactionPerAddressSchema
       index("txs_per_address_address_timestamp_idx", (address, timestamp))
 
     def * : ProvenShape[TransactionPerAddressEntity] =
-      (address, grouplessAddress, txHash, blockHash, timestamp, txOrder, mainChain, coinbase)
+      (
+        address,
+        grouplessAddress,
+        txHash,
+        blockHash,
+        timestamp,
+        txOrder,
+        mainChain,
+        conflicted,
+        coinbase
+      )
         .<>((TransactionPerAddressEntity.apply _).tupled, TransactionPerAddressEntity.unapply)
   }
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionPerTokenSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionPerTokenSchema.scala
@@ -15,12 +15,13 @@ object TransactionPerTokenSchema
     extends SchemaMainChain[TransactionPerTokenEntity]("transaction_per_token") {
 
   class TransactionPerTokens(tag: Tag) extends Table[TransactionPerTokenEntity](tag, name) {
-    def hash: Rep[TransactionId]  = column[TransactionId]("tx_hash", O.SqlType("BYTEA"))
-    def blockHash: Rep[BlockHash] = column[BlockHash]("block_hash", O.SqlType("BYTEA"))
-    def token: Rep[TokenId]       = column[TokenId]("token")
-    def timestamp: Rep[TimeStamp] = column[TimeStamp]("block_timestamp")
-    def txOrder: Rep[Int]         = column[Int]("tx_order")
-    def mainChain: Rep[Boolean]   = column[Boolean]("main_chain")
+    def hash: Rep[TransactionId]         = column[TransactionId]("tx_hash", O.SqlType("BYTEA"))
+    def blockHash: Rep[BlockHash]        = column[BlockHash]("block_hash", O.SqlType("BYTEA"))
+    def token: Rep[TokenId]              = column[TokenId]("token")
+    def timestamp: Rep[TimeStamp]        = column[TimeStamp]("block_timestamp")
+    def txOrder: Rep[Int]                = column[Int]("tx_order")
+    def mainChain: Rep[Boolean]          = column[Boolean]("main_chain")
+    def conflicted: Rep[Option[Boolean]] = column[Option[Boolean]]("conflicted")
 
     def pk: PrimaryKey = primaryKey("transaction_per_token_pk", (hash, blockHash, token))
 
@@ -29,7 +30,7 @@ object TransactionPerTokenSchema
     def tokenIdx: Index     = index("transaction_per_token_token_idx", token)
 
     def * : ProvenShape[TransactionPerTokenEntity] =
-      (hash, blockHash, token, timestamp, txOrder, mainChain)
+      (hash, blockHash, token, timestamp, txOrder, mainChain, conflicted)
         .<>((TransactionPerTokenEntity.apply _).tupled, TransactionPerTokenEntity.unapply)
   }
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionSchema.scala
@@ -28,9 +28,10 @@ object TransactionSchema extends SchemaMainChain[TransactionEntity]("transaction
     def gasAmount: Rep[Int]            = column[Int]("gas_amount")
     def gasPrice: Rep[U256] =
       column[U256]("gas_price", O.SqlType("DECIMAL(80,0)")) // U256.MaxValue has 78 digits
-    def txOrder: Rep[Int]               = column[Int]("tx_order")
-    def mainChain: Rep[Boolean]         = column[Boolean]("main_chain")
-    def scriptExecutionOk: Rep[Boolean] = column[Boolean]("script_execution_ok")
+    def txOrder: Rep[Int]                = column[Int]("tx_order")
+    def mainChain: Rep[Boolean]          = column[Boolean]("main_chain")
+    def conflicted: Rep[Option[Boolean]] = column[Option[Boolean]]("conflicted")
+    def scriptExecutionOk: Rep[Boolean]  = column[Boolean]("script_execution_ok")
     def inputSignatures: Rep[Option[ArraySeq[ByteString]]] =
       column[Option[ArraySeq[ByteString]]]("input_signatures")
     def scriptSignatures: Rep[Option[ArraySeq[ByteString]]] =
@@ -58,6 +59,7 @@ object TransactionSchema extends SchemaMainChain[TransactionEntity]("transaction
         gasPrice,
         txOrder,
         mainChain,
+        conflicted,
         scriptExecutionOk,
         inputSignatures,
         scriptSignatures,

--- a/app/src/main/scala/org/alephium/explorer/service/BlockFlowClient.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/BlockFlowClient.scala
@@ -568,7 +568,8 @@ object BlockFlowClient extends StrictLogging {
       block.txsHash,
       block.target,
       computeHashRate(block.target, block.timestamp),
-      ghostUncles
+      ghostUncles,
+      block.conflictedTxs.map(_.toArraySeq)
     )
   }
   // scalastyle:on null
@@ -643,6 +644,7 @@ object BlockFlowClient extends StrictLogging {
       tx.unsigned.gasPrice,
       index,
       mainChain,
+      conflicted = None,
       tx.scriptExecutionOk,
       if (tx.inputSignatures.isEmpty) None else Some(tx.inputSignatures.toArraySeq),
       if (tx.scriptSignatures.isEmpty) None else Some(tx.scriptSignatures.toArraySeq),
@@ -679,6 +681,7 @@ object BlockFlowClient extends StrictLogging {
       input.outputRef.key,
       Some(input.unlockScript),
       mainChain,
+      conflicted = None,
       index,
       txOrder,
       None,
@@ -708,6 +711,7 @@ object BlockFlowClient extends StrictLogging {
       outputRef.key,
       None,
       mainChain,
+      conflicted = None,
       index,
       txOrder,
       None,
@@ -798,6 +802,7 @@ object BlockFlowClient extends StrictLogging {
       grouplessAddress,
       tokens,
       mainChain,
+      conflicted = None,
       lockTime,
       message,
       index,

--- a/app/src/main/scala/org/alephium/explorer/service/BlockFlowSyncService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/BlockFlowSyncService.scala
@@ -141,6 +141,7 @@ case object BlockFlowSyncService extends StrictLogging {
           .map(_.sum)
         _ <- dc.db.run(InputUpdateQueries.updateInputs())
         _ <- updateMetadatas(blockFlowClient)
+        _ <- ConflictedTxsService.handleConflictedTxs(multiChain.flatMap(_.map(_.block)))
       } yield res
     }
   }

--- a/app/src/main/scala/org/alephium/explorer/service/ConflictedTxsService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/ConflictedTxsService.scala
@@ -1,0 +1,132 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.explorer.service
+
+import scala.collection.immutable.ArraySeq
+import scala.concurrent.{ExecutionContext, Future}
+
+import com.typesafe.scalalogging.StrictLogging
+import slick.basic.DatabaseConfig
+import slick.jdbc.PostgresProfile
+import slick.jdbc.PostgresProfile.api._
+
+import org.alephium.explorer.cache.BlockCache
+import org.alephium.explorer.foldFutures
+import org.alephium.explorer.persistence.model._
+import org.alephium.explorer.persistence.queries.BlockQueries
+import org.alephium.explorer.persistence.queries.ConflictedTxsQueries._
+import org.alephium.protocol.model.{BlockHash, TransactionId}
+import org.alephium.util.TimeStamp
+
+@SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.IterableOps"))
+case object ConflictedTxsService extends StrictLogging {
+
+  // TODO we could optimize by checking only the chain indexes that had intra groups
+  def handleConflictedTxs(blocksWithEvents: ArraySeq[BlockEntity])(implicit
+      ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile],
+      blockFlowClient: BlockFlowClient,
+      cache: BlockCache
+  ): Future[Unit] = {
+    if (blocksWithEvents.exists(_.isIntraGroup())) {
+      for {
+        _ <- updateConflictedTxs(cache.getLastFinalizedTimestamp())
+        // TODO do we want to check reorged conflicted txs at every new intra group?
+        _ <- checkAndUpdateReorgedConflictedTxs(cache.getLastFinalizedTimestamp())
+      } yield ()
+    } else {
+      Future.unit
+    }
+  }
+
+  def updateConflictedTxs(from: TimeStamp)(implicit
+      ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile],
+      blockFlowClient: BlockFlowClient
+  ): Future[Unit] = {
+    logger.debug("Checking conflicted txs")
+    dc.db.run(findConflictedTxs(from)).flatMap { conflictedTxs =>
+      if (conflictedTxs.isEmpty) {
+        logger.debug("No conflicted txs found")
+        Future.unit
+      } else {
+        logger.debug("Conflicted txs found")
+        foldFutures(conflictedTxs) { case (txHash, blockHash, conflicted) =>
+          conflicted match {
+            case Some(true) =>
+              // Already flagged as conflicted, no need to update
+              logger.debug(s"Tx $txHash already flagged as conflicted in block $blockHash")
+              Future.unit
+            case _ =>
+              logger.debug(s"Checking tx $txHash in block $blockHash for conflicts")
+              fetchBlockAndUpdateConflict(blockHash, txHash)
+          }
+        }.map(_ => ())
+      }
+
+    }
+  }
+
+  // TODO optimization could be done if inputs had `chainFrom` value
+  def fetchBlockAndUpdateConflict(
+      blockHash: BlockHash,
+      txHash: TransactionId
+  )(implicit
+      ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile],
+      blockFlowClient: BlockFlowClient
+  ): Future[Unit] = {
+    dc.db.run(BlockQueries.getBlockEntryLiteAction(blockHash)).flatMap {
+      case None =>
+        logger.error(s"Block $blockHash not found for conflicted tx $txHash")
+        Future.unit
+      case Some(block) =>
+        blockFlowClient.fetchBlock(block.chainFrom, blockHash).flatMap { newBlock =>
+          val conflicted = newBlock.conflictedTxs.map(_.contains(txHash)).getOrElse(false)
+          updateConflict(txHash, conflicted, blockHash, newBlock.conflictedTxs)
+        }
+    }
+  }
+
+  def updateConflict(
+      txHash: TransactionId,
+      conflicted: Boolean,
+      blockHash: BlockHash,
+      conflictedTxs: Option[ArraySeq[TransactionId]]
+  )(implicit
+      ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile]
+  ): Future[Unit] = {
+    logger.debug(
+      s"Updating conflict status for tx $txHash in block $blockHash to $conflicted"
+    )
+    dc.db.run(
+      (for {
+        _ <- updateConflictStatus(txHash, blockHash, conflicted)
+        _ <- updateBlockConflictTxs(blockHash, conflictedTxs)
+      } yield ()).transactionally
+    )
+  }
+
+  def checkAndUpdateReorgedConflictedTxs(
+      timestamp: TimeStamp
+  )(implicit
+      ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile],
+      blockFlowClient: BlockFlowClient
+  ): Future[Unit] = {
+    logger.debug("Checking and updating reorged conflicted txs")
+    dc.db.run(findReorgedConflictedTxs(timestamp)).flatMap { txs =>
+      if (txs.isEmpty) {
+        logger.debug("No reorged conflicted txs found")
+        Future.unit
+      } else {
+        logger.debug("Updated reorged conflicted txs found")
+        foldFutures(txs) { case (txHash, blockHash) =>
+          fetchBlockAndUpdateConflict(blockHash, txHash)
+        }.map(_ => ())
+      }
+    }
+  }
+}

--- a/app/src/main/scala/org/alephium/explorer/service/FinalizerService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/FinalizerService.scala
@@ -136,6 +136,7 @@ case object FinalizerService extends StrictLogging {
       SELECT hash, block_hash, block_timestamp
       FROM transactions
       WHERE main_chain = true
+      AND #${notConflicted()}
       AND block_timestamp >= $from
       AND block_timestamp <= $to;
       """.asAS[(TransactionId, BlockHash, TimeStamp)]
@@ -198,6 +199,7 @@ case object FinalizerService extends StrictLogging {
     SET spent_finalized = $txHash, spent_timestamp = $blockTimestamp
     WHERE key = $outputRefKey
     AND main_chain = true
+    AND #${notConflicted()}
   """
 
   /*
@@ -214,6 +216,7 @@ case object FinalizerService extends StrictLogging {
       SET spent_finalized = $txHash, spent_timestamp = $blockTimestamp
       WHERE key = $outputRefKey
       AND main_chain = true
+      AND #${notConflicted()}
     """
 
   def getFinalizedTxCountOrCount(upTo: TimeStamp)(implicit
@@ -252,9 +255,42 @@ case object FinalizerService extends StrictLogging {
     })
   }
 
+  /*
+   * We want to make sure our conflicted transactions are correct after finalization.
+   * For this we re-fetch the blocks of flagged conflicted transactions
+   * and update the conflict status in the database.
+   */
+  private def finalizeConflictedTxs(
+      from: TimeStamp,
+      to: TimeStamp
+  )(implicit
+      ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile],
+      blockFlowClient: BlockFlowClient
+  ): Future[Unit] = {
+    dc.db
+      .run(sql"""
+      SELECT block_hash, hash FROM transactions
+      WHERE block_timestamp >= $from
+      AND block_timestamp <= $to
+      AND conflicted IS NOT NULL
+      AND main_chain = true
+      """.as[(BlockHash, TransactionId)])
+      .flatMap { txs =>
+        foldFutures(ArraySeq.from(txs)) { case (blockHash, txHash) =>
+          ConflictedTxsService
+            .fetchBlockAndUpdateConflict(blockHash, txHash)
+        }.map(_ => ())
+
+      }
+  }
+
   private def getMinInputsTs(implicit ec: ExecutionContext): DBActionR[Option[TimeStamp]] =
     sql"""
-      SELECT MIN(block_timestamp) FROM inputs WHERE main_chain = true
+      SELECT MIN(block_timestamp)
+      FROM inputs
+      WHERE main_chain = true
+      AND #${notConflicted()}
     """.asAS[TimeStamp].headOrNone
 
   private def getMaxInputsTs(implicit ec: ExecutionContext): DBActionR[Option[TimeStamp]] =
@@ -269,6 +305,7 @@ case object FinalizerService extends StrictLogging {
         FROM transactions
         WHERE block_timestamp < $time
         AND main_chain = true
+        AND #${notConflicted()}
         """.as[Int].head
   }
 

--- a/app/src/main/scala/org/alephium/explorer/service/HolderService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/HolderService.scala
@@ -22,6 +22,7 @@ import org.alephium.explorer.persistence.queries.InfoQueries
 import org.alephium.explorer.persistence.schema.CustomGetResult._
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.explorer.util.Scheduler
+import org.alephium.explorer.util.SlickUtil._
 import org.alephium.protocol.model.TokenId
 import org.alephium.util.TimeStamp
 
@@ -139,6 +140,7 @@ case object HolderService extends HolderService with StrictLogging {
         outputs.block_timestamp <= $time
         AND (outputs.spent_finalized IS NULL OR outputs.spent_timestamp > $time)
         AND outputs.main_chain = true
+        AND #${notConflicted("outputs")}
     GROUP BY outputs.address
   """
 
@@ -152,6 +154,7 @@ case object HolderService extends HolderService with StrictLogging {
         WHERE outputs.block_timestamp > $from
           AND outputs.block_timestamp <= $to
           AND outputs.main_chain = true
+          AND #${notConflicted("outputs")}
         GROUP BY outputs.address
     ),
     outflow AS (
@@ -161,9 +164,11 @@ case object HolderService extends HolderService with StrictLogging {
         INNER JOIN inputs
                 ON outputs.key = inputs.output_ref_key
                 AND inputs.main_chain = true
+                AND #${notConflicted("inputs")}
         WHERE inputs.block_timestamp > $from
           AND inputs.block_timestamp <= $to
           AND outputs.main_chain = true
+          AND #${notConflicted("outputs")}
         GROUP BY outputs.address
     ),
     balance_diff AS (
@@ -193,6 +198,7 @@ case object HolderService extends HolderService with StrictLogging {
         token_outputs.block_timestamp <= $time
         AND (token_outputs.spent_finalized IS NULL OR token_outputs.spent_timestamp > $time)
         AND token_outputs.main_chain = true
+        AND #${notConflicted("token_outputs")}
     GROUP BY token_outputs.address, token_outputs.token
   """
 
@@ -207,6 +213,7 @@ case object HolderService extends HolderService with StrictLogging {
         WHERE token_outputs.block_timestamp > $from
           AND token_outputs.block_timestamp <= $to
           AND token_outputs.main_chain = true
+          AND #${notConflicted("token_outputs")}
         GROUP BY token_outputs.address, token_outputs.token
     ),
     outflow AS (
@@ -217,9 +224,11 @@ case object HolderService extends HolderService with StrictLogging {
         INNER JOIN inputs
                 ON token_outputs.key = inputs.output_ref_key
                 AND inputs.main_chain = true
+                AND #${notConflicted("inputs")}
         WHERE inputs.block_timestamp > $from
           AND inputs.block_timestamp <= $to
           AND token_outputs.main_chain = true
+          AND #${notConflicted("token_outputs")}
         GROUP BY token_outputs.address, token_outputs.token
     ),
     balance_diff AS (

--- a/app/src/main/scala/org/alephium/explorer/service/TokenSupplyService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/TokenSupplyService.scala
@@ -152,6 +152,7 @@ case object TokenSupplyService extends TokenSupplyService with StrictLogging {
       AND (spent_timestamp > $at OR spent_timestamp IS NULL)
       AND (lock_time is NULL OR lock_time <= $at) /* Only count unlock tokens */
       AND main_chain = true
+      AND #${notConflicted()}
       AND address NOT IN (#$reservedAddresses) /* We exclude the reserved wallets */
         """.asAS[Option[U256]].exactlyOne
 
@@ -165,6 +166,7 @@ case object TokenSupplyService extends TokenSupplyService with StrictLogging {
         SELECT sum(outputs.amount)
         FROM outputs
         WHERE outputs.main_chain = true
+        AND #${notConflicted("outputs")}
         AND outputs.block_timestamp <=$at
         AND (spent_timestamp > $at OR spent_timestamp IS NULL)
       """.asAS[Option[U256]].exactlyOne
@@ -181,6 +183,7 @@ case object TokenSupplyService extends TokenSupplyService with StrictLogging {
        WHERE outputs.block_timestamp <= $at
        AND (spent_timestamp > $at OR spent_timestamp IS NULL)
        AND outputs.main_chain = true
+       AND #${notConflicted("outputs")}
        AND outputs.address IN (#$reservedAddresses) /* We only take the reserved wallets */
         """.asAS[Option[U256]].exactlyOne
 
@@ -196,6 +199,7 @@ case object TokenSupplyService extends TokenSupplyService with StrictLogging {
        WHERE outputs.block_timestamp <= $at
        AND outputs.lock_time > $at /* count only locked tokens */
        AND outputs.main_chain = true
+       AND #${notConflicted("outputs")}
        AND outputs.address NOT IN (#$reservedAddresses) /* We exclude the reserved wallets */
         """.asAS[Option[U256]].exactlyOne
 

--- a/app/src/main/scala/org/alephium/explorer/util/SlickUtil.scala
+++ b/app/src/main/scala/org/alephium/explorer/util/SlickUtil.scala
@@ -162,6 +162,16 @@ object SlickUtil {
         ""
     }
   }
+
+  @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
+  def notConflicted(table: String = ""): String = {
+    if (table.isEmpty) {
+      "(conflicted IS NULL OR conflicted = false)"
+    } else {
+      s"($table.conflicted IS NULL OR $table.conflicted = false)"
+    }
+  }
+
   def splitAddresses(
       addresses: ArraySeq[ApiAddress]
   ): (ArraySeq[ApiAddress], ArraySeq[ApiAddress]) = {

--- a/app/src/test/scala/org/alephium/explorer/GenApiModel.scala
+++ b/app/src/test/scala/org/alephium/explorer/GenApiModel.scala
@@ -281,7 +281,8 @@ object GenApiModel extends ImplicitConversions {
         hashrate,
         parent,
         mainChain,
-        ghostUncles
+        ghostUncles,
+        conflictedTxs = None
       )
     }
 

--- a/app/src/test/scala/org/alephium/explorer/GenDBModel.scala
+++ b/app/src/test/scala/org/alephium/explorer/GenDBModel.scala
@@ -76,6 +76,7 @@ object GenDBModel {
         grouplessAddress = AddressUtil.convertToGrouplessAddress(address),
         tokens = tokens,
         mainChain = mainChain,
+        conflicted = None,
         lockTime = if (outputType == OutputEntity.Asset) lockTime else None,
         message = if (outputType == OutputEntity.Asset) message else None,
         outputOrder = outputOrder,
@@ -139,6 +140,7 @@ object GenDBModel {
         outputRefKey = outputEntity.key,
         unlockScript = unlockScript,
         mainChain = outputEntity.mainChain,
+        conflicted = None,
         inputOrder = outputEntity.outputOrder,
         txOrder = txOrder,
         None,
@@ -204,6 +206,7 @@ object GenDBModel {
       timestamp = timestamp,
       txOrder = txOrder,
       mainChain = mainChain,
+      conflicted = None,
       coinbase = coinbase
     )
 
@@ -223,7 +226,8 @@ object GenDBModel {
       token = token,
       timestamp = timestamp,
       txOrder = txOrder,
-      mainChain = mainChain
+      mainChain = mainChain,
+      conflicted = None
     )
 
   def tokenTxPerAddressEntityGen(
@@ -245,6 +249,7 @@ object GenDBModel {
       timestamp = timestamp,
       txOrder = txOrder,
       mainChain = mainChain,
+      conflicted = None,
       token = token
     )
 
@@ -305,6 +310,7 @@ object GenDBModel {
       address,
       AddressUtil.convertToGrouplessAddress(address),
       mainChain,
+      conflicted = None,
       lockTime,
       message,
       outputOrder,
@@ -412,6 +418,7 @@ object GenDBModel {
       gasPrice = gasPrice,
       order = order,
       mainChain = mainChain,
+      conflicted = None,
       scriptExecutionOk = scriptExecutionOk,
       inputSignatures = None,
       scriptSignatures = None,
@@ -476,7 +483,8 @@ object GenDBModel {
       hashrate = hashrate,
       parent = parent,
       deps = deps,
-      ghostUncles = None
+      ghostUncles = None,
+      conflictedTxs = None
     )
 
   val blockHeaderTransactionEntityGen: Gen[(BlockHeader, List[TransactionEntity])] =
@@ -520,7 +528,8 @@ object GenDBModel {
         BigDecimal(hashrate).toBigInt.bigInteger,
         parent,
         deps,
-        ghostUncles
+        ghostUncles,
+        conflictedTxs = None
       )
     }
   }

--- a/app/src/test/scala/org/alephium/explorer/persistence/dao/BlockDaoSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/dao/BlockDaoSpec.scala
@@ -276,6 +276,7 @@ class BlockDaoSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with T
         timestamp = output.timestamp,
         txOrder = input.txOrder,
         mainChain = output.mainChain,
+        conflicted = None,
         coinbase = false
       )
 

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/BlockQueriesSpec.scala
@@ -319,4 +319,20 @@ class BlockQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForEach wi
       }
     }
   }
+
+  "block header with conflicted txs" should {
+    "be insertable and readable" in {
+      forAll(blockHeaderGen) { block =>
+        val blockWithConflictedTxs = block.copy(
+          conflictedTxs = Some(ArraySeq.from(Gen.listOfN(5, transactionHashGen).sample.get))
+        )
+
+        exec(BlockQueries.insertBlockHeaders(ArraySeq(blockWithConflictedTxs)))
+
+        exec(BlockQueries.getBlockHeaderAction(blockWithConflictedTxs.hash)) is Some(
+          blockWithConflictedTxs
+        )
+      }
+    }
+  }
 }

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/ConflictedTxsQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/ConflictedTxsQueriesSpec.scala
@@ -1,0 +1,223 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+//scalastyle:off file.size.limit
+package org.alephium.explorer.persistence.queries
+
+import scala.collection.immutable.ArraySeq
+
+import slick.jdbc.PostgresProfile.api._
+
+import org.alephium.explorer.AlephiumFutureSpec
+import org.alephium.explorer.ConfigDefaults._
+import org.alephium.explorer.GenDBModel._
+import org.alephium.explorer.cache._
+import org.alephium.explorer.persistence.{DatabaseFixtureForEach, TestDBRunner}
+import org.alephium.explorer.persistence.model._
+import org.alephium.explorer.persistence.queries._
+import org.alephium.explorer.persistence.schema._
+import org.alephium.protocol.Hash
+import org.alephium.protocol.model.{BlockHash, ChainIndex, GroupIndex, TransactionId}
+import org.alephium.util.TimeStamp
+
+@SuppressWarnings(
+  Array(
+    "org.wartremover.warts.Var",
+    "org.wartremover.warts.DefaultArguments",
+    "org.wartremover.warts.AsInstanceOf"
+  )
+)
+class ConflictedTxsQueriesSpec
+    extends AlephiumFutureSpec
+    with DatabaseFixtureForEach
+    with TestDBRunner {
+
+  "Find conflicted transactions" when {
+    "2 main chain input share same output ref key " in new Fixture {
+      val input1 = mainChainInput()
+      val input2 = mainChainInput(input1.outputRefKey)
+
+      insertInputs(input1, input2)
+
+      val conflicts = exec(
+        ConflictedTxsQueries
+          .findConflictedTxs(TimeStamp.zero)
+      )
+
+      val expected = findConflictedTxsExpected(input1, input2)
+
+      conflicts should contain theSameElementsAs expected
+    }
+
+    "3 main chain input share same output ref key " in new Fixture {
+      val input1 = mainChainInput()
+      val input2 = mainChainInput(input1.outputRefKey)
+      val input3 = mainChainInput(input1.outputRefKey)
+
+      insertInputs(input1, input2, input3)
+
+      val conflicts = exec(
+        ConflictedTxsQueries
+          .findConflictedTxs(TimeStamp.zero)
+      )
+
+      val expected = findConflictedTxsExpected(input1, input2, input3)
+
+      conflicts should contain theSameElementsAs expected
+    }
+
+    // Could occur when we first sync the two blocks of the two firt inputs,
+    // the  algorithm will flag them as conflicted
+    // but on next sync, we might receive a third block with the same output ref key
+    "3 main chain input share same output ref key, 2 already checked" in new Fixture {
+      val input1 = mainChainInput().copy(conflicted = Some(true))
+      val input2 = mainChainInput(input1.outputRefKey).copy(conflicted = Some(false))
+      val input3 = mainChainInput(input1.outputRefKey)
+
+      insertInputs(input1, input2, input3)
+
+      val conflicts = exec(
+        ConflictedTxsQueries
+          .findConflictedTxs(TimeStamp.zero)
+      )
+
+      val expected = findConflictedTxsExpected(input1, input2, input3)
+
+      conflicts should contain theSameElementsAs expected
+    }
+  }
+
+  "Not find conflicted transactions" when {
+    "1 main chain input and 1 not " in new Fixture {
+      val input1 = mainChainInput()
+      val input2 = mainChainInput(input1.outputRefKey).copy(mainChain = false)
+
+      insertInputs(input1, input2)
+
+      val conflicts = exec(
+        ConflictedTxsQueries
+          .findConflictedTxs(TimeStamp.zero)
+      )
+
+      conflicts is ArraySeq.empty
+    }
+  }
+
+  "Find already conflicted transactions, but one isn't in main chain anymore" when {
+    "2 inputs " in new Fixture {
+      val input1 = mainChainInput().copy(conflicted = Some(true))
+      val input2 =
+        mainChainInput(input1.outputRefKey).copy(mainChain = false, conflicted = Some(false))
+
+      insertInputs(input1, input2)
+
+      val updates = exec(
+        ConflictedTxsQueries
+          .findReorgedConflictedTxs(TimeStamp.zero)
+      )
+
+      val expected = findUpdatedConflictedTxsExpected(input1, input2)
+
+      updates should contain theSameElementsAs expected
+    }
+
+    "3 inputs, 2 in main chain, 1 not " in new Fixture {
+      val input1 = mainChainInput().copy(conflicted = Some(true))
+      val input2 = mainChainInput(input1.outputRefKey).copy(conflicted = Some(false))
+      val input3 =
+        mainChainInput(input1.outputRefKey).copy(mainChain = false, conflicted = Some(false))
+
+      insertInputs(input1, input2, input3)
+
+      val updates = exec(
+        ConflictedTxsQueries
+          .findReorgedConflictedTxs(TimeStamp.zero)
+      )
+
+      val expected = findUpdatedConflictedTxsExpected(input1, input2, input3)
+
+      updates should contain theSameElementsAs expected
+    }
+
+    "3 inputs, 1 in main chain, 2 not " in new Fixture {
+      val input1 = mainChainInput().copy(conflicted = Some(true))
+      val input2 =
+        mainChainInput(input1.outputRefKey).copy(mainChain = false, conflicted = Some(false))
+      val input3 =
+        mainChainInput(input1.outputRefKey).copy(mainChain = false, conflicted = Some(false))
+
+      insertInputs(input1, input2, input3)
+
+      val updates = exec(
+        ConflictedTxsQueries
+          .findReorgedConflictedTxs(TimeStamp.zero)
+      )
+
+      val expected = findUpdatedConflictedTxsExpected(input1, input2, input3)
+
+      updates should contain theSameElementsAs expected
+    }
+  }
+
+  "Not find conflicted inputs" when {
+    "2 inputs are in main_chain" in new Fixture {
+      val input1 = mainChainInput().copy(conflicted = Some(true))
+      val input2 =
+        mainChainInput(input1.outputRefKey).copy(conflicted = Some(false))
+
+      insertInputs(input1, input2)
+
+      val updates = exec(
+        ConflictedTxsQueries
+          .findReorgedConflictedTxs(TimeStamp.zero)
+      )
+
+      updates is ArraySeq.empty
+    }
+
+    "1 input isn't confirmed yet" in new Fixture {
+      val input1 = mainChainInput().copy(conflicted = Some(true))
+      val input2 =
+        mainChainInput(input1.outputRefKey).copy(mainChain = false, conflicted = None)
+
+      insertInputs (input1, input2)
+
+      val updates = exec(
+        ConflictedTxsQueries
+          .findReorgedConflictedTxs(TimeStamp.zero)
+      )
+
+      updates is ArraySeq.empty
+    }
+  }
+
+  trait Fixture {
+    implicit val blockCache: BlockCache             = TestBlockCache()
+    implicit val transactionCache: TransactionCache = TestTransactionCache()
+
+    val groupIndex = GroupIndex.Zero
+    val chainIndex = ChainIndex(groupIndex, groupIndex)
+
+    def insertInputs(inputs: InputEntity*) =
+      exec(InputSchema.table ++= ArraySeq(inputs: _*))
+
+    def mainChainInput(): InputEntity = inputEntityGen().sample.get.copy(mainChain = true)
+    def mainChainInput(outputRefKey: Hash): InputEntity =
+      mainChainInput().copy(outputRefKey = outputRefKey)
+
+    def findConflictedTxsExpected(
+        inputs: InputEntity*
+    ): ArraySeq[(TransactionId, BlockHash, Option[Boolean])] =
+      inputs.map { input =>
+        (input.txHash, input.blockHash, input.conflicted)
+      }
+
+    def findUpdatedConflictedTxsExpected(
+        inputs: InputEntity*
+    ): ArraySeq[(TransactionId, BlockHash)] =
+      inputs.map { input =>
+        (input.txHash, input.blockHash)
+      }
+
+  }
+}

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/ConflictedTxsQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/ConflictedTxsQueriesSpec.scala
@@ -157,6 +157,39 @@ class ConflictedTxsQueriesSpec
 
       updates should contain theSameElementsAs expected
     }
+
+    "1 input comes from a conflicted transaction" in new Fixture {
+      val input1 = mainChainInput().copy(conflicted = Some(true))
+      val input2 = mainChainInput().copy(outputRefTxHash = Some(input1.txHash))
+
+      insertInputs(input1, input2)
+
+      val updates = exec(
+        ConflictedTxsQueries
+          .findTxsUsingConflictedTxs(TimeStamp.zero)
+      )
+
+      val expected = findConflictedTxsExpected(input2)
+
+      updates should contain theSameElementsAs expected
+    }
+
+    "2 inputs comes from a conflicted transaction" in new Fixture {
+      val input1 = mainChainInput().copy(conflicted = Some(true))
+      val input2 = mainChainInput().copy(outputRefTxHash = Some(input1.txHash))
+      val input3 = mainChainInput().copy(outputRefTxHash = Some(input1.txHash))
+
+      insertInputs(input1, input2, input3)
+
+      val updates = exec(
+        ConflictedTxsQueries
+          .findTxsUsingConflictedTxs(TimeStamp.zero)
+      )
+
+      val expected = findConflictedTxsExpected(input2, input3)
+
+      updates should contain theSameElementsAs expected
+    }
   }
 
   "Not find conflicted inputs" when {
@@ -180,7 +213,7 @@ class ConflictedTxsQueriesSpec
       val input2 =
         mainChainInput(input1.outputRefKey).copy(mainChain = false, conflicted = None)
 
-      insertInputs (input1, input2)
+      insertInputs(input1, input2)
 
       val updates = exec(
         ConflictedTxsQueries

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/TransactionQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/TransactionQueriesSpec.scala
@@ -60,7 +60,7 @@ class TransactionQueriesSpec
 
   }
 
-  "get balance should only return unpent outputs" in new Fixture {
+  "get balance should only return unspent outputs" in new Fixture {
 
     val output1 = output(address, ALPH.alph(1), None)
     val output2 = output(address, ALPH.alph(2), None)

--- a/app/src/test/scala/org/alephium/explorer/service/ConflictedTxsServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/ConflictedTxsServiceSpec.scala
@@ -1,0 +1,280 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+//scalastyle:off file.size.limit
+package org.alephium.explorer.service
+
+import scala.collection.immutable.ArraySeq
+import scala.concurrent.Future
+
+import org.scalacheck.Gen
+import slick.jdbc.PostgresProfile.api._
+
+import org.alephium.explorer.AlephiumFutureSpec
+import org.alephium.explorer.ConfigDefaults._
+import org.alephium.explorer.GenApiModel._
+import org.alephium.explorer.GenCoreProtocol._
+import org.alephium.explorer.GenDBModel._
+import org.alephium.explorer.cache._
+import org.alephium.explorer.foldFutures
+import org.alephium.explorer.persistence.{DatabaseFixtureForEach, TestDBRunner}
+import org.alephium.explorer.persistence.dao.BlockDao
+import org.alephium.explorer.persistence.model._
+import org.alephium.explorer.persistence.queries._
+import org.alephium.explorer.persistence.schema.CustomGetResult._
+import org.alephium.explorer.persistence.schema.CustomSetParameter._
+import org.alephium.protocol.Hash
+import org.alephium.protocol.model.{BlockHash, ChainIndex, GroupIndex, TransactionId}
+import org.alephium.util.TimeStamp
+
+@SuppressWarnings(
+  Array(
+    "org.wartremover.warts.Var",
+    "org.wartremover.warts.DefaultArguments",
+    "org.wartremover.warts.AsInstanceOf"
+  )
+)
+class ConflictedTxsServiceSpec
+    extends AlephiumFutureSpec
+    with DatabaseFixtureForEach
+    with TestDBRunner {
+
+  "ConflictedTxsService " should {
+    "not trigger anything " when {
+      "no blocks were inserted" in new Fixture {
+        val input1 = mainChainInput()
+        val input2 = mainChainInput(input1.outputRefKey)
+
+        insertInputs(input1, input2)
+
+        implicit val blockFlowClient: BlockFlowClient = new EmptyBlockFlowClient {}
+
+        ConflictedTxsService
+          .handleConflictedTxs(ArraySeq.empty)
+          .futureValue
+
+        assertNullConflictedInputs()
+
+      }
+
+      "no intra-blocks only" in new Fixture {
+        val input1 = mainChainInput()
+        val input2 = mainChainInput(input1.outputRefKey)
+
+        insertInputs(input1, input2)
+
+        val nonIntraBlocks =
+          ArraySeq.from(Gen.nonEmptyListOf(blockGen).sample.get.filterNot(_.isIntraGroup()))
+
+        implicit val blockFlowClient: BlockFlowClient = new EmptyBlockFlowClient {}
+
+        ConflictedTxsService
+          .handleConflictedTxs(nonIntraBlocks)
+          .futureValue
+
+        assertNullConflictedInputs()
+      }
+    }
+
+    "find and update the conflicts" when {
+      "2 main chain input share same output ref key " in new Fixture {
+        val (blocks, inputs) = setupMainChainBlocks(2)
+
+        implicit val blockFlowClient: BlockFlowClient =
+          makeBlockFlowClient(
+            blocks,
+            conflictedBlockHash = Some(blocks(0).hash),
+            conflictedTxs = Some(ArraySeq(inputs(0).txHash))
+          )
+
+        ConflictedTxsService
+          .handleConflictedTxs(ArraySeq(intraBlock))
+          .futureValue
+
+        assertConflictStates(
+          Seq(
+            (blocks(0).hash, true, Some(ArraySeq(inputs(0).txHash))),
+            (blocks(1).hash, false, None)
+          )
+        )
+      }
+
+      "3 main chain input share same output ref key " in new Fixture {
+        val (blocks, inputs) = setupMainChainBlocks(3)
+
+        implicit val blockFlowClient: BlockFlowClient =
+          makeBlockFlowClient(
+            blocks,
+            conflictedBlockHash = Some(blocks(0).hash),
+            conflictedTxs = Some(ArraySeq(inputs(0).txHash))
+          )
+
+        ConflictedTxsService
+          .handleConflictedTxs(ArraySeq(intraBlock))
+          .futureValue
+
+        assertConflictStates(
+          Seq(
+            (blocks(0).hash, true, Some(ArraySeq(inputs(0).txHash))),
+            (blocks(1).hash, false, None),
+            (blocks(2).hash, false, None)
+          )
+        )
+      }
+
+      "a reorg happen, with one block getting out of main_chain" in new Fixture {
+        val (blocks, inputs) = setupMainChainBlocks(2)
+
+        var nodeBlocks = blocks
+
+        implicit val blockFlowClient: BlockFlowClient = new EmptyBlockFlowClient {
+          override def fetchBlock(fromGroup: GroupIndex, hash: BlockHash): Future[BlockEntity] = {
+            nodeBlocks.find(_.hash == hash) match {
+              case Some(block) =>
+                Future.successful(block)
+              case None => Future.failed(new Exception(s"Block not found: $hash"))
+            }
+          }
+        }
+
+        // block1 has conflicted txs, block2 not
+        nodeBlocks = blocks.map { block =>
+          if (block.hash == blocks(0).hash) {
+            block.copy(conflictedTxs = Some(ArraySeq(inputs(0).txHash)))
+          } else {
+            block
+          }
+        }
+
+        ConflictedTxsService
+          .handleConflictedTxs(ArraySeq(intraBlock))
+          .futureValue
+
+        assertConflictStates(
+          Seq(
+            (blocks(0).hash, true, Some(ArraySeq(inputs(0).txHash))),
+            (blocks(1).hash, false, None)
+          )
+        )
+
+        // block2 will not be in main chain anymore, no conflicted txs now
+        nodeBlocks = blocks.map { block =>
+          block.copy(conflictedTxs = None)
+        }
+
+        // Kicking off block2 from main chain
+        BlockDao.updateMainChainStatus(blocks(1).hash, false).futureValue
+
+        ConflictedTxsService
+          .handleConflictedTxs(ArraySeq(intraBlock))
+          .futureValue
+
+        // Both inputs are not conflicted anymore
+        assertConflictStates(
+          Seq(
+            (blocks(0).hash, false, None),
+            (blocks(1).hash, false, None)
+          )
+        )
+      }
+    }
+  }
+
+  trait Fixture {
+
+    val intraChainIndex = ChainIndex(new GroupIndex(0), new GroupIndex(0))
+    val intraBlock      = blockEntityGen(intraChainIndex).sample.get
+
+    val blockGen = for {
+      chain <- chainIndexGen
+      block <- blockEntityGen(chain)
+    } yield block
+
+    implicit val blockCache: BlockCache             = TestBlockCache()
+    implicit val transactionCache: TransactionCache = TestTransactionCache()
+
+    def makeBlockFlowClient(
+        blocks: Seq[BlockEntity],
+        conflictedBlockHash: Option[BlockHash] = None,
+        conflictedTxs: Option[ArraySeq[TransactionId]] = None
+    ): BlockFlowClient = new EmptyBlockFlowClient {
+      override def fetchBlock(fromGroup: GroupIndex, hash: BlockHash): Future[BlockEntity] = {
+        blocks.find(_.hash == hash) match {
+          case Some(block) if conflictedBlockHash.contains(hash) =>
+            Future.successful(block.copy(conflictedTxs = conflictedTxs))
+          case Some(block) =>
+            Future.successful(block)
+          case None => Future.failed(new Exception(s"Block not found: $hash"))
+        }
+      }
+    }
+
+    def assertNullConflictedInputs() = {
+      exec(sql"SELECT COUNT(*) FROM inputs WHERE conflicted IS NOT NULL".as[Int]).head is 0
+    }
+
+    def insertInputs(inputs: InputEntity*) = {
+      exec(InputQueries.insertInputs(ArraySeq.from(inputs)))
+    }
+
+    def assertConflictStates(
+        expected: Seq[(BlockHash, Boolean, Option[ArraySeq[TransactionId]])]
+    ) = {
+      expected.foreach { case (blockHash, conflicted, conflictedTxs) =>
+        exec(
+          sql"SELECT conflicted FROM inputs WHERE block_hash = $blockHash".as[Boolean]
+        ).head is conflicted
+        exec(
+          sql"SELECT conflicted_txs FROM block_headers WHERE hash = $blockHash"
+            .as[Option[ArraySeq[TransactionId]]]
+        ).head is conflictedTxs
+      }
+    }
+
+    val groupIndex = GroupIndex.Zero
+    val chainIndex = ChainIndex(groupIndex, groupIndex)
+
+    def mainChainInput(): InputEntity = inputEntityGen().sample.get.copy(mainChain = true)
+
+    def mainChainInput(outputRefKey: Hash): InputEntity =
+      mainChainInput().copy(outputRefKey = outputRefKey)
+
+    def setupMainChainBlocks(n: Int): (ArraySeq[BlockEntity], ArraySeq[InputEntity]) = {
+      val blockHashes = List.fill(n)(blockHashGen.sample.get)
+      val firstInput  = mainChainInput().copy(blockHash = blockHashes.head)
+      val otherInputs = blockHashes.tail.map { hash =>
+        mainChainInput(firstInput.outputRefKey).copy(blockHash = hash)
+      }
+      val blocks = blockHashes.zip(firstInput +: otherInputs).map { case (hash, input) =>
+        blockEntityGen(chainIndex).sample.get.copy(hash = hash, inputs = ArraySeq(input))
+      }
+
+      insertMainChainBlocks(blocks)
+
+      (blocks, firstInput +: otherInputs)
+    }
+
+    def insertMainChainBlocks(blocks: ArraySeq[BlockEntity]) = {
+
+      val latestBlocks = blocks.groupBy(b => (b.chainFrom, b.chainTo)).map { case (_, blocks) =>
+        blocks.maxBy(_.timestamp)
+      }
+
+      BlockDao.insertAll(blocks).futureValue
+
+      foldFutures(latestBlocks)(BlockDao.updateLatestBlock).futureValue
+
+      eventually {
+        // Check that the block cache is updated
+        blockCache.getAllLatestBlocks().futureValue.head._2.timestamp > TimeStamp.zero is true
+      }
+
+      foldFutures(blocks) { block =>
+        for {
+          _ <- databaseConfig.db.run(InputUpdateQueries.updateInputs())
+          _ <- BlockDao.updateMainChainStatus(block.hash, true)
+        } yield (())
+      }.futureValue
+    }
+  }
+}

--- a/app/src/test/scala/org/alephium/explorer/service/HolderServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/HolderServiceSpec.scala
@@ -107,7 +107,8 @@ class HolderServiceSpec extends AlephiumFutureSpec with DatabaseFixtureForEach {
         txsHash = hashGen.sample.get,
         target = bytesGen.sample.get,
         hashrate = BigInteger.ZERO,
-        ghostUncles = ArraySeq.empty
+        ghostUncles = ArraySeq.empty,
+        conflictedTxs = None
       )
 
     def getAll: DBActionSR[(Address, U256)] =

--- a/app/src/test/scala/org/alephium/explorer/service/TokenSupplyServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TokenSupplyServiceSpec.scala
@@ -194,6 +194,7 @@ class TokenSupplyServiceSpec
             out.key,
             None,
             false,
+            conflicted = None,
             index,
             0,
             None,

--- a/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
@@ -431,6 +431,7 @@ class TransactionServiceSpec
   trait Fixture {
     implicit val blockCache: BlockCache             = TestBlockCache()
     implicit val transactionCache: TransactionCache = TestTransactionCache()
+    implicit val blockflowClient: BlockFlowClient   = new EmptyBlockFlowClient {}
 
     val groupIndex = GroupIndex.Zero
     val chainIndex = ChainIndex(groupIndex, groupIndex)

--- a/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/DataGenerator.scala
+++ b/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/DataGenerator.scala
@@ -50,6 +50,7 @@ object DataGenerator {
         gasPrice = U256.unsafe(0),
         order = Random.nextInt(1000),
         mainChain = mainChain,
+        conflicted = None,
         scriptExecutionOk = Random.nextBoolean(),
         inputSignatures = None,
         scriptSignatures = None,
@@ -75,6 +76,7 @@ object DataGenerator {
         grouplessAddress = AddressUtil.convertToGrouplessAddress(address),
         tokens = None,
         mainChain = transaction.mainChain,
+        conflicted = None,
         lockTime = Some(TimeStamp.now()),
         message = None,
         outputOrder = order,
@@ -97,6 +99,7 @@ object DataGenerator {
         outputRefKey = output.key,
         unlockScript = Some(unlockScriptGen.sample.get),
         mainChain = output.mainChain,
+        conflicted = None,
         inputOrder = order,
         txOrder = order,
         None,
@@ -145,7 +148,8 @@ object DataGenerator {
       txsHash = Hash.generate,
       target = ByteString.fromString(Random.alphanumeric.take(10).mkString),
       hashrate = BigInteger.valueOf(Random.nextLong(Long.MaxValue)),
-      ghostUncles = ArraySeq.empty
+      ghostUncles = ArraySeq.empty,
+      conflictedTxs = None
     )
   }
 
@@ -163,6 +167,7 @@ object DataGenerator {
       timestamp = TimeStamp.now(),
       txOrder = Random.nextInt(100),
       mainChain = Random.nextBoolean(),
+      conflicted = None,
       coinbase = false
     )
 }

--- a/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/AddressReadState.scala
+++ b/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/AddressReadState.scala
@@ -84,6 +84,7 @@ class AddressReadState(val db: DBExecutor)
       outputRefKey = key,
       unlockScript = None,
       mainChain = true,
+      conflicted = None,
       inputOrder = 0,
       txOrder = 0,
       None,
@@ -112,6 +113,7 @@ class AddressReadState(val db: DBExecutor)
       gasPrice = U256.unsafe(0),
       order = 0,
       mainChain = true,
+      conflicted = None,
       scriptExecutionOk = Random.nextBoolean(),
       inputSignatures = None,
       scriptSignatures = None,
@@ -137,6 +139,7 @@ class AddressReadState(val db: DBExecutor)
       grouplessAddress = AddressUtil.convertToGrouplessAddress(address0.toProtocol()),
       tokens = None,
       mainChain = true,
+      conflicted = None,
       lockTime = None,
       message = None,
       outputOrder = 0,
@@ -187,7 +190,8 @@ class AddressReadState(val db: DBExecutor)
         txsHash = Blake2b.generate,
         target = ByteString.emptyByteString,
         hashrate = BigInteger.ONE,
-        ghostUncles = ArraySeq.empty
+        ghostUncles = ArraySeq.empty,
+        conflictedTxs = None
       )
     })
 

--- a/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/BlockHeaderMainChainReadState.scala
+++ b/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/BlockHeaderMainChainReadState.scala
@@ -49,7 +49,8 @@ class BlockHeaderMainChainReadState(
       hashrate = BigInteger.ONE,
       parent = Some(BlockHash.generate),
       deps = ArraySeq.from(0 to 4).map(_ => BlockHash.generate),
-      ghostUncles = None
+      ghostUncles = None,
+      conflictedTxs = None
     )
 
   def persist(data: Array[BlockHeader]): Unit = {

--- a/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/ListBlocksReadState.scala
+++ b/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/ListBlocksReadState.scala
@@ -70,7 +70,8 @@ class ListBlocksReadState(
       hashrate = BigInteger.ONE,
       parent = Some(BlockHash.generate),
       deps = ArraySeq.from(0 to 4).map(_ => BlockHash.generate),
-      ghostUncles = None
+      ghostUncles = None,
+      conflictedTxs = None
     )
 
   private def generateTransactions(header: BlockHeader): Seq[TransactionEntity] =
@@ -88,6 +89,7 @@ class ListBlocksReadState(
         gasPrice = U256.unsafe(0),
         order = 0,
         mainChain = header.mainChain,
+        conflicted = None,
         scriptExecutionOk = Random.nextBoolean(),
         inputSignatures = None,
         scriptSignatures = None,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@
 import sbt._
 
 object Version {
-  lazy val common = "4.0.0"
+  lazy val common = "4.2.2"
 
   lazy val akka       = "2.6.20"
   lazy val rxJava     = "3.1.8"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@
 import sbt._
 
 object Version {
-  lazy val common = "4.2.2"
+  lazy val common = "4.2.4"
 
   lazy val akka       = "2.6.20"
   lazy val rxJava     = "3.1.8"


### PR DESCRIPTION
## Overview

This pull request implements robust handling of the new `conflictedTxs` information from the node, enabling the explorer to correctly reflect transaction conflicts arising from parallel block mining. To improve block times, our protocol allows two blocks to be mined in parallel, potentially spending the same `output_ref`. Once the intra-block is mined, it decides which transaction is accepted and flags the conflicting one as `conflicted`.

## Conflict Detection Logic

When syncing, upon receiving an intra-block, we need to revisit recent blocks to detect and resolve any transaction conflicts. There are two main scenarios:

1. **Duplicate Usage of an Output Reference**
   - Find all `(block_hash, tx_hash)` pairs where the same `output_ref` is spent by two transactions on the `main_chain`.

2. **Output Reference Originates from a Conflicted Transaction**
   - Find all `(block_hash, tx_hash)` pairs where the `output_ref_tx_hash` is on the `main_chain` and marked as `conflicted`.

For each detected conflict, we query the node for the updated `conflicted_txs` value and update our records accordingly.

## Handling Re-orgs

If two blocks compete for a transaction but, after a re-org, only one remains on the `main_chain`, we must:
- Identify duplicate `output_ref` entries marked as `conflicted`, where one is on the `main_chain` and the other is not.
- Update the conflicted status by querying the node as usual.

## Finalization

During data finalization, we perform a comprehensive check of all blocks flagged as `conflicted` to ensure accuracy, since these records are no longer modified once finalized.

## Querying Data

With the introduction of `conflictedTxs`, we now need to handle these cases carefully when querying data:

- **Block Transactions:**  
  When retrieving all transactions for a block, we must include both regular and conflicted transactions to accurately reflect the node’s data.

- **Address Transactions and Balances:**  
  When requesting the transaction history or balance for an address, conflicted transactions should be excluded. This ensures users see only valid (non-conflicted) transactions in their wallet or history, matching the canonical chain state.

This distinction is important to maintain consistency between explorer results and node responses, and to provide users with correct transaction and balance information.