### PR TITLE
Fix Address Transaction Count Cache for `ReadOnly` Mode

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/AppServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/AppServer.scala
@@ -10,7 +10,7 @@ import io.vertx.ext.web._
 import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
 
-import org.alephium.explorer.cache.{BlockCache, MetricCache, TransactionCache}
+import org.alephium.explorer.cache._
 import org.alephium.explorer.config.ExplorerConfig
 import org.alephium.explorer.service._
 import org.alephium.explorer.web._
@@ -31,6 +31,7 @@ object AppServer {
       blockCache: BlockCache,
       metricCache: MetricCache,
       transactionCache: TransactionCache,
+      addressTxCountCache: AddressTxCountCache,
       groupSetting: GroupSetting
   ): ArraySeq[Router => Route] = {
 

--- a/app/src/main/scala/org/alephium/explorer/cache/AddressTxCountCache.scala
+++ b/app/src/main/scala/org/alephium/explorer/cache/AddressTxCountCache.scala
@@ -1,0 +1,89 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.explorer.cache
+
+import java.util.concurrent.TimeUnit
+
+import scala.collection.immutable.ArraySeq
+import scala.concurrent.{ExecutionContext, Future}
+
+import com.github.benmanes.caffeine.cache.{Cache, Caffeine}
+import slick.jdbc.PostgresProfile.api._
+
+import org.alephium.api.model.{Address => ApiAddress}
+import org.alephium.explorer.persistence.Database
+import org.alephium.explorer.persistence.DBRunner._
+import org.alephium.explorer.persistence.model._
+import org.alephium.explorer.persistence.queries.TransactionQueries
+import org.alephium.explorer.persistence.schema.AddressTotalTransactionSchema
+import org.alephium.util.Service
+
+trait AddressTxCountCache extends Service {
+  def getAddressTotalTransaction(
+      address: ApiAddress
+  ): Future[Option[AddressTotalTransactionsEntity]]
+
+  def updateAddressTotalTransaction(
+      value: AddressTotalTransactionsEntity
+  ): Future[Unit]
+
+  override def startSelfOnce(): Future[Unit] = Future.successful(())
+
+  override def stopSelfOnce(): Future[Unit] = Future.successful(())
+
+}
+
+final case class InMemoryAddressTxCountCache(database: Database)(implicit
+    val executionContext: ExecutionContext
+) extends AddressTxCountCache {
+
+  // scalasty:off magic.number
+  private val invalidationPeriodInDays = 14L // TODO make it configurable
+  // scalasty:on magic.number
+
+  val cache: Cache[ApiAddress, AddressTotalTransactionsEntity] =
+    Caffeine
+      .newBuilder()
+      .expireAfterWrite(invalidationPeriodInDays, TimeUnit.DAYS)
+      .build[ApiAddress, AddressTotalTransactionsEntity]()
+
+  override def getAddressTotalTransaction(
+      address: ApiAddress
+  ): Future[Option[AddressTotalTransactionsEntity]] = {
+    val valueOrNull = cache.getIfPresent(address)
+
+    if (valueOrNull == null) {
+      run(TransactionQueries.getAddressTotalTransaction(address))(database.databaseConfig)
+    } else {
+      Future.successful(Some(valueOrNull))
+    }
+  }
+
+  override def updateAddressTotalTransaction(
+      value: AddressTotalTransactionsEntity
+  ): Future[Unit] = Future.successful {
+    cache.put(value.address, value)
+  }
+
+  override def subServices: ArraySeq[Service] = ArraySeq(database)
+}
+
+final case class DBAddressTxCountCache(database: Database)(implicit
+    val executionContext: ExecutionContext
+) extends AddressTxCountCache {
+  override def getAddressTotalTransaction(
+      address: ApiAddress
+  ): Future[Option[AddressTotalTransactionsEntity]] =
+    run(TransactionQueries.getAddressTotalTransaction(address))(database.databaseConfig)
+
+  override def updateAddressTotalTransaction(
+      value: AddressTotalTransactionsEntity
+  ): Future[Unit] =
+    run(
+      AddressTotalTransactionSchema.table
+        .insertOrUpdate(value)
+    )(database.databaseConfig).map(_ => ())
+
+  override def subServices: ArraySeq[Service] = ArraySeq(database)
+}

--- a/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
@@ -18,7 +18,7 @@ import slick.jdbc.PostgresProfile
 
 import org.alephium.api.model.{Address => ApiAddress}
 import org.alephium.explorer.api.model._
-import org.alephium.explorer.cache.TransactionCache
+import org.alephium.explorer.cache._
 import org.alephium.explorer.persistence.DBRunner._
 import org.alephium.explorer.persistence.dao.{MempoolDao, TransactionDao}
 import org.alephium.explorer.persistence.queries.{InputQueries, TokenQueries}
@@ -75,6 +75,7 @@ trait TransactionService {
   def getTransactionsNumberByAddress(
       address: ApiAddress
   )(implicit
+      cache: AddressTxCountCache,
       groupConfig: GroupConfig,
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]
@@ -191,11 +192,12 @@ object TransactionService extends TransactionService {
   def getTransactionsNumberByAddress(
       address: ApiAddress
   )(implicit
+      cache: AddressTxCountCache,
       groupConfig: GroupConfig,
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]
   ): Future[Int] =
-    TransactionDao.getNumberByAddress(address)
+    TransactionDao.getNumberByAddress(address, cache)
 
   def getBalance(
       address: ApiAddress,

--- a/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
@@ -20,7 +20,7 @@ import org.alephium.api.model.{Address => ApiAddress, TimeInterval}
 import org.alephium.explorer.GroupSetting
 import org.alephium.explorer.api.AddressesEndpoints
 import org.alephium.explorer.api.model._
-import org.alephium.explorer.cache.BlockCache
+import org.alephium.explorer.cache._
 import org.alephium.explorer.config.Default.groupConfig
 import org.alephium.explorer.config.ExplorerConfig
 import org.alephium.explorer.service.{TokenService, TransactionService}
@@ -40,6 +40,7 @@ class AddressServer(
 )(implicit
     val executionContext: ExecutionContext,
     groupSetting: GroupSetting,
+    addressTxCountCache: AddressTxCountCache,
     blockCache: BlockCache,
     dc: DatabaseConfig[PostgresProfile]
 ) extends Server

--- a/app/src/test/scala/org/alephium/explorer/cache/TestAddressTxCountCache.scala
+++ b/app/src/test/scala/org/alephium/explorer/cache/TestAddressTxCountCache.scala
@@ -1,0 +1,28 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.explorer.cache
+
+import scala.concurrent.ExecutionContext
+
+import slick.basic.DatabaseConfig
+import slick.jdbc.PostgresProfile
+
+import org.alephium.explorer.config._
+import org.alephium.explorer.persistence.Database
+
+object TestAddressTxCountCache {
+
+  /** @return
+    *   Test instance of [[TransactionPerAddressCountCache]] for faster cache reloads than
+    *   configured periods in `application.conf`
+    */
+  def apply()(implicit
+      ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile]
+  ): AddressTxCountCache =
+    DBAddressTxCountCache(
+      new Database(BootMode.ReadWrite)(ec, dc, TestExplorerConfig())
+    )
+
+}

--- a/app/src/test/scala/org/alephium/explorer/service/EmptyTransactionService.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/EmptyTransactionService.scala
@@ -16,7 +16,7 @@ import slick.jdbc.PostgresProfile
 
 import org.alephium.api.model.{Address => ApiAddress}
 import org.alephium.explorer.api.model._
-import org.alephium.explorer.cache.TransactionCache
+import org.alephium.explorer.cache._
 import org.alephium.explorer.service.TransactionService
 import org.alephium.protocol.config.GroupConfig
 import org.alephium.protocol.model.TransactionId
@@ -32,6 +32,7 @@ trait EmptyTransactionService extends TransactionService {
   override def getTransactionsNumberByAddress(
       address: ApiAddress
   )(implicit
+      cache: AddressTxCountCache,
       groupConfig: GroupConfig,
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]

--- a/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
@@ -431,6 +431,8 @@ class TransactionServiceSpec
   trait Fixture {
     implicit val blockCache: BlockCache             = TestBlockCache()
     implicit val transactionCache: TransactionCache = TestTransactionCache()
+    implicit val addressTxCountCache: AddressTxCountCache =
+      TestAddressTxCountCache()
 
     val groupIndex = GroupIndex.Zero
     val chainIndex = ChainIndex(groupIndex, groupIndex)

--- a/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
@@ -27,7 +27,7 @@ import org.alephium.explorer.GenCoreProtocol._
 import org.alephium.explorer.HttpFixture._
 import org.alephium.explorer.api.Json._
 import org.alephium.explorer.api.model._
-import org.alephium.explorer.cache.{BlockCache, TestBlockCache}
+import org.alephium.explorer.cache._
 import org.alephium.explorer.config.Default.groupConfig
 import org.alephium.explorer.persistence.DatabaseFixtureForAll
 import org.alephium.explorer.service.{
@@ -176,6 +176,8 @@ class AddressServerSpec()
   }
 
   implicit val blockCache: BlockCache = TestBlockCache()
+  implicit val addressTxCountCache: AddressTxCountCache =
+    TestAddressTxCountCache()
 
   val server =
     new AddressServer(

--- a/app/src/test/scala/org/alephium/explorer/web/StatementTimeoutSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/StatementTimeoutSpec.scala
@@ -15,7 +15,7 @@ import org.alephium.explorer._
 import org.alephium.explorer.ConfigDefaults._
 import org.alephium.explorer.GenApiModel._
 import org.alephium.explorer.HttpFixture._
-import org.alephium.explorer.cache.{BlockCache, TestBlockCache}
+import org.alephium.explorer.cache._
 import org.alephium.explorer.persistence.{DatabaseFixtureForAll, DBRunner}
 import org.alephium.explorer.service.{EmptyTokenService, EmptyTransactionService}
 import org.alephium.util.{TimeStamp, U256}
@@ -26,6 +26,8 @@ class StatementTimeoutSpec()
     with HttpServerFixture {
 
   implicit val blockCache: BlockCache = TestBlockCache()
+  implicit val addressTxCountCache: AddressTxCountCache =
+    TestAddressTxCountCache()
 
   val server =
     new AddressServer(

--- a/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/DBBenchmark.scala
+++ b/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/DBBenchmark.scala
@@ -180,7 +180,7 @@ class DBBenchmark {
     val _ = Await.result(
       for {
         _ <- TransactionDao.getBalance(state.address, TimeStamp.zero)
-        _ <- TransactionDao.getNumberByAddress(state.address)
+        _ <- TransactionDao.getNumberByAddress(state.address, state.addressTxCountCache)
       } yield (),
       requestTimeout
     )

--- a/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/AddressReadState.scala
+++ b/benchmark/src/test/scala/org/alephium/explorer/benchmark/db/state/AddressReadState.scala
@@ -21,6 +21,7 @@ import org.alephium.explorer.GroupSetting
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.benchmark.db.{DataGenerator, DBConnectionPool, DBExecutor}
 import org.alephium.explorer.benchmark.db.BenchmarkSettings._
+import org.alephium.explorer.cache._
 import org.alephium.explorer.persistence.dao.BlockDao
 import org.alephium.explorer.persistence.model._
 import org.alephium.explorer.persistence.queries.InputUpdateQueries
@@ -51,6 +52,9 @@ class AddressReadState(val db: DBExecutor)
   implicit val databaseConfig: DatabaseConfig[PostgresProfile] = db.config
 
   import config.profile.api._
+
+  val addressTxCountCache: AddressTxCountCache =
+    TestAddressTxCountCache()
 
   val address: ApiAddress = DataGenerator.genAddress()
 


### PR DESCRIPTION
Previously, the address transaction count cache was optimized by updating the cached value "on-demand"—whenever a count was requested, the new value was written back to the database. However, this approach caused failures when running in `ReadOnly` mode, since database writes are not permitted.

This commit introduces separate cache implementations for read-only and write modes:
- **ReadOnly mode:** Uses an in-memory cache. Initial values are loaded from the database if available, but subsequent updates remain only in memory to avoid write operations.
- **Write mode:** Continues to use the database-backed cache, supporting persistent updates as before.

This change ensures correct and efficient behavior for both read-only and write-enabled instances.