### PR TITLE
Ensure transaction inputs return complete output data

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/InputQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/InputQueries.scala
@@ -14,7 +14,7 @@ import slick.jdbc.PostgresProfile.api._
 import org.alephium.api.model.{Address => ApiAddress}
 import org.alephium.explorer.persistence._
 import org.alephium.explorer.persistence.model._
-import org.alephium.explorer.persistence.queries.result.{InputsFromTxQR, InputsQR}
+import org.alephium.explorer.persistence.queries.result.{InputFromTxQR, InputQR}
 import org.alephium.explorer.persistence.schema.CustomGetResult._
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.explorer.util.SlickExplainUtil._
@@ -76,9 +76,9 @@ object InputQueries {
 
   def inputsFromTxs(
       hashes: ArraySeq[(TransactionId, BlockHash)]
-  ): DBActionR[ArraySeq[InputsFromTxQR]] =
+  ): DBActionR[ArraySeq[InputFromTxQR]] =
     if (hashes.nonEmpty) {
-      inputsFromTxsBuilder(hashes).asAS[InputsFromTxQR]
+      inputsFromTxsBuilder(hashes).asAS[InputFromTxQR]
     } else {
       DBIOAction.successful(ArraySeq.empty)
     }
@@ -90,7 +90,7 @@ object InputQueries {
 
     val query =
       s"""
-         SELECT ${InputsFromTxQR.selectFields}
+         SELECT ${InputFromTxQR.selectFields}
          FROM inputs
          WHERE (tx_hash, block_hash) IN $params
 
@@ -109,14 +109,14 @@ object InputQueries {
     )
   }
 
-  def getInputsQuery(txHash: TransactionId, blockHash: BlockHash): DBActionSR[InputsQR] =
+  def getInputsQuery(txHash: TransactionId, blockHash: BlockHash): DBActionSR[InputQR] =
     sql"""
-        SELECT #${InputsQR.selectFields}
+        SELECT #${InputQR.selectFields}
         FROM inputs
         WHERE tx_hash = $txHash
           AND block_hash = $blockHash
         ORDER BY input_order
-    """.asAS[InputsQR]
+    """.asAS[InputQR]
 
   def getMainChainInputs(ascendingOrder: Boolean): DBActionSR[InputEntity] =
     sql"""

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/OutputQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/OutputQueries.scala
@@ -309,6 +309,18 @@ object OutputQueries {
     }
   }
 
+  def getOutputFromKey(
+      key: Hash
+  ): DBActionR[Option[OutputsFromTxQR]] = {
+    sql"""
+     SELECT #${OutputsFromTxQR.selectFields}
+     FROM outputs
+     WHERE main_chain = true
+     AND #${notConflicted()}
+     AND key = $key
+     """.as[OutputsFromTxQR].headOption
+  }
+
   def outputsFromTxs(
       hashes: ArraySeq[(TransactionId, BlockHash)]
   ): DBActionR[ArraySeq[OutputsFromTxQR]] =

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/OutputQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/OutputQueries.scala
@@ -14,7 +14,7 @@ import org.alephium.api.model.{Address => ApiAddress}
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.persistence._
 import org.alephium.explorer.persistence.model._
-import org.alephium.explorer.persistence.queries.result.{OutputsFromTxQR, OutputsQR}
+import org.alephium.explorer.persistence.queries.result.{OutputFromTxQR, OutputQR}
 import org.alephium.explorer.persistence.schema.CustomGetResult._
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.explorer.util.SlickExplainUtil._
@@ -311,25 +311,25 @@ object OutputQueries {
 
   def getOutputFromKey(
       key: Hash
-  ): DBActionR[Option[OutputsFromTxQR]] = {
+  ): DBActionR[Option[OutputFromTxQR]] = {
     sql"""
-     SELECT #${OutputsFromTxQR.selectFields}
+     SELECT #${OutputFromTxQR.selectFields}
      FROM outputs
      WHERE main_chain = true
      AND #${notConflicted()}
      AND key = $key
-     """.as[OutputsFromTxQR].headOption
+     """.as[OutputFromTxQR].headOption
   }
 
   def outputsFromTxs(
       hashes: ArraySeq[(TransactionId, BlockHash)]
-  ): DBActionR[ArraySeq[OutputsFromTxQR]] =
+  ): DBActionR[ArraySeq[OutputFromTxQR]] =
     if (hashes.nonEmpty) {
       val params = paramPlaceholderTuple2(1, hashes.size)
 
       val query =
         s"""
-           SELECT ${OutputsFromTxQR.selectFields}
+           SELECT ${OutputFromTxQR.selectFields}
            FROM outputs
            WHERE (outputs.tx_hash, outputs.block_hash) IN $params
            """
@@ -344,19 +344,19 @@ object OutputQueries {
       SQLActionBuilder(
         sql = query,
         setParameter = parameters
-      ).asAS[OutputsFromTxQR]
+      ).asAS[OutputFromTxQR]
     } else {
       DBIOAction.successful(ArraySeq.empty)
     }
 
-  def getOutputsQuery(txHash: TransactionId, blockHash: BlockHash): DBActionSR[OutputsQR] =
+  def getOutputsQuery(txHash: TransactionId, blockHash: BlockHash): DBActionSR[OutputQR] =
     sql"""
-        SELECT #${OutputsQR.selectFields}
+        SELECT #${OutputQR.selectFields}
         FROM outputs
         WHERE tx_hash = $txHash
           AND block_hash = $blockHash
         ORDER BY output_order
-      """.asAS[OutputsQR]
+      """.asAS[OutputQR]
 
   /** Get main chain [[org.alephium.explorer.persistence.model.OutputEntity]]s ordered by timestamp
     */

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/result/InfoFromTxQR.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/result/InfoFromTxQR.scala
@@ -12,14 +12,14 @@ import org.alephium.explorer.persistence.schema.CustomGetResult._
 import org.alephium.protocol.model.TransactionId
 import org.alephium.util.U256
 
-object InfoFromTxsQR {
+object InfoFromTxQR {
 
   val selectFields: String =
     "hash, version, network_id, script_opt, gas_amount, gas_price, script_execution_ok, input_signatures, script_signatures"
 
-  implicit val infoFromTxsQRGetResult: GetResult[InfoFromTxsQR] =
+  implicit val infoFromTxsQRGetResult: GetResult[InfoFromTxQR] =
     (result: PositionedResult) =>
-      InfoFromTxsQR(
+      InfoFromTxQR(
         txHash = result.<<,
         version = result.<<,
         networkId = result.<<,
@@ -31,8 +31,8 @@ object InfoFromTxsQR {
         scriptSignatures = result.<<?
       )
 
-  def empty(): InfoFromTxsQR =
-    InfoFromTxsQR(
+  def empty(): InfoFromTxQR =
+    InfoFromTxQR(
       TransactionId.zero,
       0,
       0,
@@ -46,7 +46,7 @@ object InfoFromTxsQR {
 }
 
 /** Query result for [[org.alephium.explorer.persistence.queries.TransactionQueries]] */
-final case class InfoFromTxsQR(
+final case class InfoFromTxQR(
     txHash: TransactionId,
     version: Byte,
     networkId: Byte,

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/result/InputFromTxQR.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/result/InputFromTxQR.scala
@@ -15,10 +15,12 @@ import org.alephium.protocol.Hash
 import org.alephium.protocol.model.{Address, TransactionId}
 import org.alephium.util.U256
 
-object InputsQR {
+object InputFromTxQR {
 
   val selectFields: String =
     """
+      tx_hash,
+      input_order,
       hint,
       output_ref_key,
       unlock_script,
@@ -30,9 +32,11 @@ object InputsQR {
       contract_input
     """
 
-  implicit val inputsQRGetResult: GetResult[InputsQR] =
+  implicit val inputsFromTxQRGetResult: GetResult[InputFromTxQR] =
     (result: PositionedResult) =>
-      InputsQR(
+      InputFromTxQR(
+        txHash = result.<<,
+        inputOrder = result.<<,
         hint = result.<<,
         outputRefKey = result.<<,
         unlockScript = result.<<?,
@@ -45,8 +49,10 @@ object InputsQR {
       )
 }
 
-/** Query result for [[org.alephium.explorer.persistence.queries.InputQueries.getInputsQuery]] */
-final case class InputsQR(
+/** Query result for [[org.alephium.explorer.persistence.queries.InputQueries.inputsFromTxs]] */
+final case class InputFromTxQR(
+    txHash: TransactionId,
+    inputOrder: Int,
     hint: Int,
     outputRefKey: Hash,
     unlockScript: Option[ByteString],

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/result/InputQR.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/result/InputQR.scala
@@ -15,12 +15,10 @@ import org.alephium.protocol.Hash
 import org.alephium.protocol.model.{Address, TransactionId}
 import org.alephium.util.U256
 
-object InputsFromTxQR {
+object InputQR {
 
   val selectFields: String =
     """
-      tx_hash,
-      input_order,
       hint,
       output_ref_key,
       unlock_script,
@@ -32,11 +30,9 @@ object InputsFromTxQR {
       contract_input
     """
 
-  implicit val inputsFromTxQRGetResult: GetResult[InputsFromTxQR] =
+  implicit val inputsQRGetResult: GetResult[InputQR] =
     (result: PositionedResult) =>
-      InputsFromTxQR(
-        txHash = result.<<,
-        inputOrder = result.<<,
+      InputQR(
         hint = result.<<,
         outputRefKey = result.<<,
         unlockScript = result.<<?,
@@ -49,10 +45,8 @@ object InputsFromTxQR {
       )
 }
 
-/** Query result for [[org.alephium.explorer.persistence.queries.InputQueries.inputsFromTxs]] */
-final case class InputsFromTxQR(
-    txHash: TransactionId,
-    inputOrder: Int,
+/** Query result for [[org.alephium.explorer.persistence.queries.InputQueries.getInputsQuery]] */
+final case class InputQR(
     hint: Int,
     outputRefKey: Hash,
     unlockScript: Option[ByteString],

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/result/OutputFromTxQR.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/result/OutputFromTxQR.scala
@@ -14,14 +14,15 @@ import org.alephium.explorer.persistence.schema.CustomGetResult._
 import org.alephium.protocol.Hash
 import org.alephium.protocol.model.{Address, TransactionId}
 import org.alephium.util.{TimeStamp, U256}
-object OutputsFromTxQR {
+
+object OutputFromTxQR {
 
   val selectFields: String =
     "tx_hash, output_order, output_type, hint, key, amount, address, groupless_address, tokens, lock_time, message, spent_finalized, fixed_output"
 
-  implicit val outputsFromTxQRGetResult: GetResult[OutputsFromTxQR] =
+  implicit val outputsFromTxQRGetResult: GetResult[OutputFromTxQR] =
     (result: PositionedResult) =>
-      OutputsFromTxQR(
+      OutputFromTxQR(
         txHash = result.<<,
         outputOrder = result.<<,
         outputType = result.<<,
@@ -39,7 +40,7 @@ object OutputsFromTxQR {
 }
 
 /** Query result for [[org.alephium.explorer.persistence.queries.OutputQueries.outputsFromTxs]] */
-final case class OutputsFromTxQR(
+final case class OutputFromTxQR(
     txHash: TransactionId,
     outputOrder: Int,
     outputType: OutputEntity.OutputType,

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/result/OutputQR.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/result/OutputQR.scala
@@ -15,14 +15,14 @@ import org.alephium.protocol.Hash
 import org.alephium.protocol.model.{Address, TransactionId}
 import org.alephium.util.{TimeStamp, U256}
 
-object OutputsQR {
+object OutputQR {
 
   val selectFields: String =
     "output_type, hint, key, amount, address, groupless_address, tokens, lock_time, message, spent_finalized, fixed_output"
 
-  implicit val outputsQRGetResult: GetResult[OutputsQR] =
+  implicit val outputsQRGetResult: GetResult[OutputQR] =
     (result: PositionedResult) =>
-      OutputsQR(
+      OutputQR(
         outputType = result.<<,
         hint = result.<<,
         key = result.<<,
@@ -38,7 +38,7 @@ object OutputsQR {
 }
 
 /** Query result for [[org.alephium.explorer.persistence.queries.OutputQueries.getOutputsQuery]] */
-final case class OutputsQR(
+final case class OutputQR(
     outputType: OutputEntity.OutputType,
     hint: Int,
     key: Hash,

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/InputQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/InputQueriesSpec.scala
@@ -11,7 +11,7 @@ import org.alephium.explorer.GenDBModel._
 import org.alephium.explorer.persistence.{DatabaseFixtureForEach, TestDBRunner}
 import org.alephium.explorer.persistence.model.InputEntity
 import org.alephium.explorer.persistence.queries.InputQueries._
-import org.alephium.explorer.persistence.queries.result.{InputsFromTxQR, InputsQR}
+import org.alephium.explorer.persistence.queries.result.{InputFromTxQR, InputQR}
 import org.alephium.explorer.persistence.schema.InputSchema
 
 class InputQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForEach with TestDBRunner {
@@ -87,7 +87,7 @@ class InputQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForEach wi
           // expected query result
           val expected =
             inputs.map { entity =>
-              InputsFromTxQR(
+              InputFromTxQR(
                 txHash = entity.txHash,
                 inputOrder = entity.inputOrder,
                 hint = entity.hint,
@@ -136,8 +136,8 @@ class InputQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForEach wi
             exec(InputQueries.getInputsQuery(input.txHash, input.blockHash))
 
           // expected query result
-          val expected: InputsQR =
-            InputsQR(
+          val expected: InputQR =
+            InputQR(
               hint = input.hint,
               outputRefKey = input.outputRefKey,
               unlockScript = input.unlockScript,

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/OutputQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/OutputQueriesSpec.scala
@@ -11,7 +11,7 @@ import org.alephium.explorer.GenApiModel._
 import org.alephium.explorer.GenDBModel._
 import org.alephium.explorer.persistence.{DatabaseFixtureForEach, TestDBRunner}
 import org.alephium.explorer.persistence.queries.OutputQueries._
-import org.alephium.explorer.persistence.queries.result.{OutputsFromTxQR, OutputsQR}
+import org.alephium.explorer.persistence.queries.result.{OutputFromTxQR, OutputQR}
 import org.alephium.explorer.persistence.schema.CustomSetParameter._
 import org.alephium.explorer.persistence.schema.OutputSchema
 import org.alephium.explorer.util.SlickExplainUtil._
@@ -78,7 +78,7 @@ class OutputQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForEach w
           // expected query result
           val expected =
             outputs.map { entity =>
-              OutputsFromTxQR(
+              OutputFromTxQR(
                 txHash = entity.txHash,
                 outputOrder = entity.outputOrder,
                 outputType = entity.outputType,
@@ -129,8 +129,8 @@ class OutputQueriesSpec extends AlephiumFutureSpec with DatabaseFixtureForEach w
             exec(OutputQueries.getOutputsQuery(output.txHash, output.blockHash))
 
           // expected query result
-          val expected: OutputsQR =
-            OutputsQR(
+          val expected: OutputQR =
+            OutputQR(
               outputType = output.outputType,
               hint = output.hint,
               key = output.key,


### PR DESCRIPTION
There is a rare edge case when querying transactions that have just been inserted, but whose inputs have not yet been updated by `InputUpdateQueries`. In this scenario, the API returns the transactions, but the inputs are missing output data such as address and amount. This makes it difficult for applications to process these transactions.

To address this, the API should only return transactions with complete data. For this edge case (which typically lasts around 300ms between insert and update), when querying transactions, we check if input data is complete—which is almost always the case. If not, we retrieve the corresponding output so users always receive complete transaction data.

If for some reason we can't find the output, we'll return then incomplete input.