### PR TITLE
Fix incorrect field order in SQL queries due to use of SELECT *

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/persistence/dao/BlockDao.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/dao/BlockDao.scala
@@ -22,9 +22,6 @@ import org.alephium.explorer.persistence.queries.ContractQueries._
 import org.alephium.explorer.persistence.queries.EventQueries._
 import org.alephium.explorer.persistence.queries.TransactionQueries._
 import org.alephium.explorer.persistence.schema._
-import org.alephium.explorer.persistence.schema.CustomGetResult._
-import org.alephium.explorer.persistence.schema.CustomSetParameter._
-import org.alephium.explorer.util.SlickUtil._
 import org.alephium.protocol.model.{BlockHash, ChainIndex, GroupIndex}
 import org.alephium.util.{Duration, TimeStamp}
 
@@ -94,14 +91,7 @@ object BlockDao {
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]
   ): Future[ArraySeq[BlockEntryLite]] = {
-    run(sql"""
-      SELECT *
-      FROM block_headers
-      WHERE block_timestamp >= $from
-      AND block_timestamp <= $to
-      ORDER BY block_timestamp DESC, hash
-
-      """.asASE[BlockHeader](blockHeaderGetResult)).map(_.map(_.toLiteApi))
+    run(listIncludingForksAction(from, to)).map(_.map(_.toLiteApi))
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.Recursion"))

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/ContractQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/ContractQueries.scala
@@ -18,6 +18,24 @@ import org.alephium.explorer.util.SlickUtil._
 import org.alephium.protocol.model.{Address, GroupIndex}
 
 object ContractQueries {
+
+  private def contractFields: String =
+    """
+      contract,
+      parent,
+      std_interface_id_guessed,
+      creation_block_hash,
+      creation_tx_hash,
+      creation_timestamp,
+      creation_event_order,
+      destruction_block_hash,
+      destruction_tx_hash,
+      destruction_timestamp,
+      destruction_event_order,
+      category,
+      interface_id
+    """
+
   def insertOrUpdateContracts(
       events: Iterable[EventEntity],
       from: GroupIndex
@@ -108,7 +126,7 @@ object ContractQueries {
       contract: Address
   ): DBActionSR[ContractEntity] = {
     sql"""
-      SELECT *
+      SELECT #$contractFields
       FROM contracts
       WHERE contract = $contract
       """.asASE[ContractEntity](contractEntityGetResult)
@@ -146,8 +164,7 @@ object ContractQueries {
   ): DBActionW[Int] = {
     sqlu"""
       INSERT INTO nft_collection_metadata (
-        "contract",
-        "collection_uri"
+        #${TokenQueries.nftCollectionMetadataFields}
         )
       VALUES (${contract},${metadata.collectionUri})
       ON CONFLICT

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/TokenQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/TokenQueries.scala
@@ -24,6 +24,27 @@ import org.alephium.util.{TimeStamp, U256}
 
 object TokenQueries extends StrictLogging {
 
+  val nftCollectionMetadataFields: String =
+    """
+      contract,
+      collection_uri
+    """
+  private val nftMetadataFields: String =
+    """
+      token,
+      token_uri,
+      collection_id,
+      nft_index
+    """
+
+  private val fungibleTokenMetadataFields: String =
+    """
+      token,
+      symbol,
+      name,
+      decimals
+    """
+
   def getTokenBalanceAction(address: ApiAddress, token: TokenId)(implicit
       ec: ExecutionContext
   ): DBActionR[(U256, U256)] =
@@ -204,10 +225,7 @@ object TokenQueries extends StrictLogging {
   ): DBActionW[Int] = {
     sqlu"""
       INSERT INTO fungible_token_metadata (
-        "token",
-        "symbol",
-        "name",
-        "decimals"
+        #$fungibleTokenMetadataFields
         )
       VALUES (${metadata.id},${metadata.symbol},${metadata.name},${metadata.decimals})
       ON CONFLICT
@@ -223,7 +241,7 @@ object TokenQueries extends StrictLogging {
 
       val query =
         s"""
-          SELECT *
+          SELECT $fungibleTokenMetadataFields
           FROM fungible_token_metadata
           WHERE token IN $params
         """
@@ -279,7 +297,7 @@ object TokenQueries extends StrictLogging {
 
       val query =
         s"""
-          SELECT *
+          SELECT $nftMetadataFields
           FROM nft_metadata
           WHERE token IN $params
         """
@@ -307,7 +325,7 @@ object TokenQueries extends StrictLogging {
 
       val query =
         s"""
-          SELECT *
+          SELECT $nftCollectionMetadataFields
           FROM nft_collection_metadata
           WHERE contract IN $params
         """
@@ -332,10 +350,7 @@ object TokenQueries extends StrictLogging {
   ): DBActionW[Int] = {
     sqlu"""
       INSERT INTO nft_metadata (
-        "token",
-        "token_uri",
-        "collection_id",
-        "nft_index"
+        #$nftMetadataFields
         )
       VALUES (${metadata.id},${metadata.tokenUri},${metadata.collectionId},${metadata.nftIndex})
       ON CONFLICT

--- a/app/src/main/scala/org/alephium/explorer/service/TokenSupplyService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/TokenSupplyService.scala
@@ -66,6 +66,15 @@ case object TokenSupplyService extends TokenSupplyService with StrictLogging {
   private val reservedAddresses =
     Source.fromResource("reserved_addresses")(Codec.UTF8).getLines().mkString
 
+  private val tokenSupplyFields: String =
+    """
+      block_timestamp,
+      total,
+      circulating,
+      reserved,
+      locked
+    """
+
   private val launchDay =
     Instant.ofEpochMilli(ALPH.LaunchTimestamp.millis).truncatedTo(ChronoUnit.DAYS)
 
@@ -102,7 +111,7 @@ case object TokenSupplyService extends TokenSupplyService with StrictLogging {
   ): Future[ArraySeq[TokenSupply]] = {
     run(
       sql"""
-        SELECT *
+        SELECT #$tokenSupplyFields
         FROM token_supply
         ORDER BY block_timestamp DESC
       """
@@ -126,7 +135,7 @@ case object TokenSupplyService extends TokenSupplyService with StrictLogging {
   ): Future[Option[TokenSupply]] =
     run(
       sql"""
-        SELECT *
+        SELECT #$tokenSupplyFields
         FROM token_supply
         ORDER BY block_timestamp DESC
         LIMIT 1

--- a/app/src/test/scala/org/alephium/explorer/GenDBModel.scala
+++ b/app/src/test/scala/org/alephium/explorer/GenDBModel.scala
@@ -391,20 +391,24 @@ object GenDBModel {
   @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
   def transactionEntityGen(blockHash: Gen[BlockHash] = blockHashGen): Gen[TransactionEntity] =
     for {
-      hash              <- transactionHashGen
-      blockHash         <- blockHash
-      timestamp         <- timestampGen
-      chainFrom         <- groupIndexGen
-      chainTo           <- groupIndexGen
-      version           <- arbitrary[Byte]
-      networkId         <- arbitrary[Byte]
-      scriptOpt         <- Gen.option(hashGen.map(_.toHexString))
-      gasAmount         <- gasAmountGen
-      gasPrice          <- u256Gen
-      order             <- Gen.posNum[Int]
-      mainChain         <- Arbitrary.arbitrary[Boolean]
-      scriptExecutionOk <- Arbitrary.arbitrary[Boolean]
-      coinbase          <- Arbitrary.arbitrary[Boolean]
+      hash                 <- transactionHashGen
+      blockHash            <- blockHash
+      timestamp            <- timestampGen
+      chainFrom            <- groupIndexGen
+      chainTo              <- groupIndexGen
+      version              <- arbitrary[Byte]
+      networkId            <- arbitrary[Byte]
+      scriptOpt            <- Gen.option(hashGen.map(_.toHexString))
+      gasAmount            <- gasAmountGen
+      gasPrice             <- u256Gen
+      order                <- Gen.posNum[Int]
+      mainChain            <- Arbitrary.arbitrary[Boolean]
+      signaturesSize       <- Gen.choose(0, 3)
+      inputSignatures      <- Gen.option(Gen.listOfN(signaturesSize, hashGen.map(_.bytes)))
+      scriptSignaturesSize <- Gen.choose(0, 3)
+      scriptSignatures     <- Gen.option(Gen.listOfN(scriptSignaturesSize, hashGen.map(_.bytes)))
+      scriptExecutionOk    <- Arbitrary.arbitrary[Boolean]
+      coinbase             <- Arbitrary.arbitrary[Boolean]
     } yield TransactionEntity(
       hash = hash,
       blockHash = blockHash,
@@ -420,8 +424,8 @@ object GenDBModel {
       mainChain = mainChain,
       conflicted = None,
       scriptExecutionOk = scriptExecutionOk,
-      inputSignatures = None,
-      scriptSignatures = None,
+      inputSignatures = inputSignatures.map(ArraySeq.from),
+      scriptSignatures = scriptSignatures.map(ArraySeq.from),
       coinbase = coinbase
     )
 

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/TransactionQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/TransactionQueriesSpec.scala
@@ -210,7 +210,7 @@ class TransactionQueriesSpec
     txs should contain allElementsOf expected
   }
 
-  "output's spent info should only take the input from the main chain " in new Fixture {
+  "output's spent info should only take the input from the main chain" in new Fixture {
 
     val tx1 = transactionEntityGen().sample.get.copy(mainChain = true)
     val tx2 = transactionEntityGen().sample.get


### PR DESCRIPTION
We were using `SELECT *` in several queries and mapping the results directly to entity models. This approach is fragile and led to issues on testnet/mainnet.

For example, when we added the `conflicted` field to the transaction entity (positioned below `main_chain` in the model), a fresh database created the column in the expected order. However, in testnet/mainnet, where `conflicted` was added via migration, the column was placed at the end. As a result, `SELECT *` returned columns in the wrong order, causing `CustomGetResult` to misalign fields.

This commit replaces `SELECT *` with explicit column selection to ensure correct field mapping regardless of column order in the database schema.

This was also not catch by our test as some models where not creating all data (see first commit).

Only the [getTransactionAction](https://github.com/alephium/explorer-backend/compare/fix-field-order-in-queries?expand=1#diff-4bff8d7d0a817ed4688ba4879cd265dc01e72c52b6f5fddf69654f094d72b1d6R109-R114) was throwing an error, but I took the opportunity to remove all our `SELECT *`.