### PR TITLE
Add `/transactions/decode-unsigned-tx` endpoint with inputs details

### DIFF
--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -791,6 +791,175 @@
         }
       }
     },
+    "/transactions/decode-unsigned-tx": {
+      "post": {
+        "tags": [
+          "Transactions"
+        ],
+        "summary": "Decode an unsigned transaction",
+        "operationId": "postTransactionsDecode-unsigned-tx",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DecodeUnsignedTx"
+              },
+              "example": {
+                "unsignedTx": "35d1b2a520a0da34c5eb8d712aa9cc"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DecodeUnsignedTxResult"
+                },
+                "example": {
+                  "fromGroup": 1,
+                  "toGroup": 2,
+                  "unsignedTx": {
+                    "hash": "503bfb16230888af4924aa8f8250d7d348b862e267d75d3147f1998050b6da69",
+                    "version": 1,
+                    "networkId": 0,
+                    "gasAmount": 20000,
+                    "gasPrice": "100000000000",
+                    "inputs": [
+                      {
+                        "outputRef": {
+                          "hint": 23412,
+                          "key": "798e9e137aec7c2d59d9655b4ffa640f301f628bf7c365083bb255f6aa5f89ef"
+                        },
+                        "unlockScript": "d1b70d2226308b46da297486adb6b4f1a8c1842cb159ac5ec04f384fe2d6f5da28",
+                        "txHashRef": "503bfb16230888af4924aa8f8250d7d348b862e267d75d3147f1998050b6da69",
+                        "address": "1AujpupFP4KWeZvqA7itsHY9cLJmx4qTzojVZrg8W9y",
+                        "attoAlphAmount": "2",
+                        "tokens": [
+                          {
+                            "id": "2d11fd6c12435ffb07aaed4d190a505b621b927a5f6e51b61ce0ebe186397bdd",
+                            "amount": "42000000000000000000"
+                          },
+                          {
+                            "id": "bd165d20bd063c7a023d22232a1e75bf46e904067f92b49323fe89fa0fd586bf",
+                            "amount": "1000000000000000000000"
+                          }
+                        ],
+                        "contractInput": false
+                      }
+                    ],
+                    "outputs": [
+                      {
+                        "type": "AssetOutput",
+                        "hint": 1,
+                        "key": "798e9e137aec7c2d59d9655b4ffa640f301f628bf7c365083bb255f6aa5f89ef",
+                        "attoAlphAmount": "2",
+                        "address": "1AujpupFP4KWeZvqA7itsHY9cLJmx4qTzojVZrg8W9y",
+                        "tokens": [
+                          {
+                            "id": "2d11fd6c12435ffb07aaed4d190a505b621b927a5f6e51b61ce0ebe186397bdd",
+                            "amount": "42000000000000000000"
+                          },
+                          {
+                            "id": "bd165d20bd063c7a023d22232a1e75bf46e904067f92b49323fe89fa0fd586bf",
+                            "amount": "1000000000000000000000"
+                          }
+                        ],
+                        "lockTime": 1611041396892,
+                        "message": "798e9e137aec7c2d59d9655b4ffa640f301f628bf7c365083bb255f6aa5f89ef",
+                        "fixedOutput": true
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequest"
+                },
+                "example": {
+                  "detail": "Something bad in the request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unauthorized"
+                },
+                "example": {
+                  "detail": "You shall not pass"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFound"
+                },
+                "example": {
+                  "resource": "wallet-name",
+                  "detail": "wallet-name not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                },
+                "example": {
+                  "detail": "Ouch"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailable"
+                },
+                "example": {
+                  "detail": "Self clique unsynced"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "GatewayTimeout",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GatewayTimeout"
+                },
+                "example": {
+                  "detail": "The network is slow"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/addresses/{address}": {
       "get": {
         "tags": [
@@ -8747,6 +8916,40 @@
           }
         }
       },
+      "DecodeUnsignedTx": {
+        "title": "DecodeUnsignedTx",
+        "type": "object",
+        "required": [
+          "unsignedTx"
+        ],
+        "properties": {
+          "unsignedTx": {
+            "type": "string"
+          }
+        }
+      },
+      "DecodeUnsignedTxResult": {
+        "title": "DecodeUnsignedTxResult",
+        "type": "object",
+        "required": [
+          "fromGroup",
+          "toGroup",
+          "unsignedTx"
+        ],
+        "properties": {
+          "fromGroup": {
+            "type": "integer",
+            "format": "group-index"
+          },
+          "toGroup": {
+            "type": "integer",
+            "format": "group-index"
+          },
+          "unsignedTx": {
+            "$ref": "#/components/schemas/UnsignedTransaction"
+          }
+        }
+      },
       "Event": {
         "title": "Event",
         "type": "object",
@@ -9714,6 +9917,52 @@
           },
           "type": {
             "type": "string"
+          }
+        }
+      },
+      "UnsignedTransaction": {
+        "title": "UnsignedTransaction",
+        "type": "object",
+        "required": [
+          "hash",
+          "version",
+          "networkId",
+          "gasAmount",
+          "gasPrice"
+        ],
+        "properties": {
+          "hash": {
+            "type": "string",
+            "format": "32-byte-hash"
+          },
+          "version": {
+            "type": "integer"
+          },
+          "networkId": {
+            "type": "integer"
+          },
+          "scriptOpt": {
+            "type": "string"
+          },
+          "gasAmount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "gasPrice": {
+            "type": "string",
+            "format": "uint256"
+          },
+          "inputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Input"
+            }
+          },
+          "outputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Output"
+            }
           }
         }
       },

--- a/app/src/main/scala/org/alephium/explorer/api/EndpointExamples.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/EndpointExamples.scala
@@ -160,6 +160,18 @@ object EndpointExamples extends EndpointsExamples {
       conflicted = None
     )
 
+  private val unsignedTx: UnsignedTransaction =
+    UnsignedTransaction(
+      hash = txId,
+      version = version,
+      networkId = networkId,
+      scriptOpt = None,
+      gasAmount = org.alephium.protocol.model.minimalGas.value,
+      gasPrice = org.alephium.protocol.model.nonCoinbaseMinGasPrice.value,
+      inputs = ArraySeq(input),
+      outputs = ArraySeq(outputAsset)
+    )
+
   private val acceptedTransaction: AcceptedTransaction =
     AcceptedTransaction(
       hash = txId,
@@ -362,6 +374,9 @@ object EndpointExamples extends EndpointsExamples {
 
   implicit val transactionsExample: List[Example[ArraySeq[Transaction]]] =
     simpleExample(ArraySeq(transaction, transaction))
+
+  implicit val decodeUnsignedTxExample: List[Example[DecodeUnsignedTxResult]] =
+    simpleExample(DecodeUnsignedTxResult(groupIndex1, groupIndex2, unsignedTx))
 
   implicit val listOfBlocksExample: List[Example[ListBlocks]] =
     simpleExample(ListBlocks(2, ArraySeq(blockEntryLite, blockEntryLite)))

--- a/app/src/main/scala/org/alephium/explorer/api/TransactionEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/TransactionEndpoints.scala
@@ -7,6 +7,7 @@ import sttp.tapir._
 import sttp.tapir.generic.auto._
 
 import org.alephium.api.Endpoints.jsonBody
+import org.alephium.api.model.DecodeUnsignedTx
 import org.alephium.explorer.api.EndpointExamples._
 import org.alephium.explorer.api.model._
 import org.alephium.protocol.model.TransactionId
@@ -23,4 +24,11 @@ trait TransactionEndpoints extends BaseEndpoint {
       .in(path[TransactionId]("transaction_hash"))
       .out(jsonBody[TransactionLike])
       .summary("Get a transaction with hash")
+
+  val decodeUnsignedTx: BaseEndpoint[DecodeUnsignedTx, DecodeUnsignedTxResult] =
+    transactionsEndpoint.post
+      .in("decode-unsigned-tx")
+      .in(jsonBody[DecodeUnsignedTx])
+      .out(jsonBody[DecodeUnsignedTxResult])
+      .summary("Decode an unsigned transaction")
 }

--- a/app/src/main/scala/org/alephium/explorer/api/model/DecodeUnsignedTxResult.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/DecodeUnsignedTxResult.scala
@@ -1,0 +1,22 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.explorer.api.model
+
+import sttp.tapir.Schema
+
+import org.alephium.api.TapirSchemas._
+import org.alephium.explorer.api.Json._
+import org.alephium.json.Json._
+import org.alephium.protocol.model.GroupIndex
+
+final case class DecodeUnsignedTxResult(
+    fromGroup: GroupIndex,
+    toGroup: GroupIndex,
+    unsignedTx: UnsignedTransaction
+)
+
+object DecodeUnsignedTxResult {
+  implicit val decodeResultRW: ReadWriter[DecodeUnsignedTxResult] = macroRW
+  implicit val schema: Schema[DecodeUnsignedTxResult] = Schema.derived[DecodeUnsignedTxResult]
+}

--- a/app/src/main/scala/org/alephium/explorer/api/model/UnsignedTransaction.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/UnsignedTransaction.scala
@@ -1,0 +1,33 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.explorer.api.model
+
+import scala.collection.immutable.ArraySeq
+
+import sttp.tapir.Schema
+
+import org.alephium.api.TapirSchemas._
+import org.alephium.explorer.api.Json._
+import org.alephium.json.Json._
+import org.alephium.protocol.model.TransactionId
+import org.alephium.util.U256
+
+final case class UnsignedTransaction(
+    hash: TransactionId,
+    version: Byte,
+    networkId: Byte,
+    scriptOpt: Option[String],
+    gasAmount: Int,
+    gasPrice: U256,
+    inputs: ArraySeq[Input],
+    outputs: ArraySeq[Output]
+) {
+  def chainFrom: Option[Int] =
+    inputs.headOption.map(_.toProtocol().outputRef.toTxOutputRef().hint.scriptHint.groupIndex.value)
+}
+
+object UnsignedTransaction {
+  implicit val unsignedTxRW: ReadWriter[UnsignedTransaction] = macroRW
+  implicit val schema: Schema[UnsignedTransaction]           = Schema.derived[UnsignedTransaction]
+}

--- a/app/src/main/scala/org/alephium/explorer/api/model/UnsignedTransaction.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/UnsignedTransaction.scala
@@ -22,10 +22,7 @@ final case class UnsignedTransaction(
     gasPrice: U256,
     inputs: ArraySeq[Input],
     outputs: ArraySeq[Output]
-) {
-  def chainFrom: Option[Int] =
-    inputs.headOption.map(_.toProtocol().outputRef.toTxOutputRef().hint.scriptHint.groupIndex.value)
-}
+)
 
 object UnsignedTransaction {
   implicit val unsignedTxRW: ReadWriter[UnsignedTransaction] = macroRW

--- a/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
+++ b/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
@@ -35,6 +35,7 @@ trait Documentation
         getBlockByHash,
         getBlockTransactions,
         getTransactionById,
+        decodeUnsignedTx,
         getAddressInfo,
         getTransactionsByAddress,
         getTransactionsByAddresses,

--- a/app/src/main/scala/org/alephium/explorer/web/TransactionServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/TransactionServer.scala
@@ -5,14 +5,21 @@ package org.alephium.explorer.web
 
 import scala.collection.immutable.ArraySeq
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
 
 import io.vertx.ext.web._
 import slick.basic.DatabaseConfig
 import slick.jdbc.PostgresProfile
+import sttp.model.StatusCode
 
 import org.alephium.api.ApiError
 import org.alephium.explorer.api.TransactionEndpoints
+import org.alephium.explorer.api.model.DecodeUnsignedTxResult
 import org.alephium.explorer.service.TransactionService
+import org.alephium.protocol
+import org.alephium.protocol.model.GroupIndex
+import org.alephium.serde._
+import org.alephium.util.Hex
 
 class TransactionServer(implicit
     val executionContext: ExecutionContext,
@@ -24,7 +31,41 @@ class TransactionServer(implicit
       TransactionService
         .getTransaction(hash)
         .map(_.toRight(ApiError.NotFound(hash.value.toHexString)))
+    }),
+    route(decodeUnsignedTx.serverLogic[Future] { decodeUTX =>
+      (for {
+        utx       <- deserializeUnsignedTx(decodeUTX.unsignedTx)
+        fromGroup <- fromGroup(utx)
+        toGroup   <- toGroup(utx)
+      } yield {
+        (fromGroup, toGroup, utx)
+      }) match {
+        case Right((fromGroup, toGroup, utx)) =>
+          TransactionService.convertProtocolUnsignedTx(utx).map { unsignedTx =>
+            Right(DecodeUnsignedTxResult(fromGroup, toGroup, unsignedTx))
+          }
+        case Left(err) => Future.successful(Left(err))
+      }
     })
   )
+
+  private def fromGroup(
+      utx: protocol.model.UnsignedTransaction
+  ): Either[ApiError[_ <: StatusCode], GroupIndex] =
+    Try(utx.fromGroup).toEither.left.map(_ =>
+      ApiError.BadRequest("Cannot get `fromGroup` from inputs")
+    )
+
+  private def toGroup(
+      utx: protocol.model.UnsignedTransaction
+  ): Either[ApiError[_ <: StatusCode], GroupIndex] =
+    Try(utx.toGroup).toEither.left.map(_ => ApiError.BadRequest("Cannot get `toGroup` from inputs"))
+
+  private def deserializeUnsignedTx(
+      rawUtx: String
+  ): Either[ApiError[_ <: StatusCode], protocol.model.UnsignedTransaction] =
+    deserialize[protocol.model.UnsignedTransaction](
+      Hex.unsafe(rawUtx)
+    ).left.map(e => ApiError.BadRequest(e.getMessage))
 
 }

--- a/app/src/test/scala/org/alephium/explorer/service/EmptyTransactionService.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/EmptyTransactionService.scala
@@ -18,6 +18,7 @@ import org.alephium.api.model.{Address => ApiAddress}
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.cache._
 import org.alephium.explorer.service.TransactionService
+import org.alephium.protocol
 import org.alephium.protocol.config.GroupConfig
 import org.alephium.protocol.model.TransactionId
 import org.alephium.util.{TimeStamp, U256}
@@ -137,4 +138,11 @@ trait EmptyTransactionService extends TransactionService {
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]
   ): Future[ArraySeq[(TimeStamp, BigInteger)]] = ???
+
+  def convertProtocolUnsignedTx(
+      unsignedTx: protocol.model.UnsignedTransaction
+  )(implicit
+      ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile]
+  ): Future[UnsignedTransaction] = ???
 }


### PR DESCRIPTION
Using the same format as the node, the only difference is that we can provide then input details.

Resolves https://github.com/alephium/explorer-backend/issues/642