### PR TITLE
Add `AURA` to coingecko list

### DIFF
--- a/app/src/main/resources/application.conf
+++ b/app/src/main/resources/application.conf
@@ -97,6 +97,7 @@ explorer {
             "APAD"    = "alphpad"
             "EX"      = "elexium"
             "ONION"   = "myonion-fun"
+            "AURA"    = "aura-3"
         }
         chart-symbol-name {
             "ALPH" = "alephium"


### PR DESCRIPTION
Resolves: https://github.com/alephium/explorer-backend/issues/654

Result without mobula API key:

```bash
curl -X 'POST' \                                                                                                                                            
  'https://backend.mainnet.alephium.org/market/prices?currency=usd' \
  -d '[
  "AURA"
]'

[0.0029083128946028568]  