### PR TITLE
Add active addresses history (daily/monthly)  endpoint

### DIFF
--- a/app/src/main/resources/application.conf
+++ b/app/src/main/resources/application.conf
@@ -31,6 +31,10 @@ explorer {
     token-supply-service-schedule-time = "02:00"
     token-supply-service-schedule-time = ${?EXPLORER_TOKEN_SUPPLY_SERVICE_SCHEDULE_TIME}
 
+    # Schedule time for ActiveAddressHistoryService
+    active-address-history-service-schedule-time = "03:00"
+    active-address-history-service-schedule-time = ${?EXPLORER_ACTIVE_ADDRESS_HISTORY_SERVICE_SCHEDULE_TIME}
+
     # Sync interval for HashRateService
     hash-rate-service-sync-period = 1 hours
     hash-rate-service-sync-period = ${?EXPLORER_HASH_RATE_SERVICE_SYNC_PERIOD}
@@ -64,6 +68,8 @@ explorer {
             daily = ${?EXPLORER_AMOUNT_HISTORY_MAX_TIME_INTERVAL_DAILY}
             weekly = 366 days
             weekly = ${?EXPLORER_AMOUNT_HISTORY_MAX_TIME_INTERVAL_WEEKLY}
+            monthly = 1830 days
+            monthly = ${?EXPLORER_AMOUNT_HISTORY_MAX_TIME_INTERVAL_MONTHLY}
         }
         charts = {
             hourly = 30 days
@@ -72,6 +78,8 @@ explorer {
             daily = ${?EXPLORER_CHARTS_MAX_TIME_INTERVAL_DAILY}
             weekly = 366 days
             weekly = ${?EXPLORER_CHARTS_MAX_TIME_INTERVAL_WEEKLY}
+            monthly = 1830 days
+            monthly = ${?EXPLORER_AMOUNT_HISTORY_MAX_TIME_INTERVAL_MONTHLY}
         },
         export-txs = 366 days
         export-txs = ${?EXPLORER_MAX_TIME_INTERVAL_EXPORT_TXS}

--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -2035,7 +2035,7 @@
           {
             "name": "toTs",
             "in": "query",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "integer",
               "format": "int64",
@@ -3916,7 +3916,7 @@
           {
             "name": "toTs",
             "in": "query",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "integer",
               "format": "int64",
@@ -4054,7 +4054,7 @@
           {
             "name": "toTs",
             "in": "query",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "integer",
               "format": "int64",
@@ -4066,7 +4066,12 @@
             "in": "query",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/IntervalType"
+              "type": "string",
+              "enum": [
+                "hourly",
+                "daily",
+                "weekly"
+              ]
             }
           }
         ],
@@ -6831,7 +6836,6 @@
           "Charts"
         ],
         "summary": "Get hashrate chart in H/s",
-        "description": "`interval-type` query param: hourly, daily",
         "operationId": "getChartsHashrates",
         "parameters": [
           {
@@ -6847,7 +6851,7 @@
           {
             "name": "toTs",
             "in": "query",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "integer",
               "format": "int64",
@@ -6859,7 +6863,11 @@
             "in": "query",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/IntervalType"
+              "type": "string",
+              "enum": [
+                "hourly",
+                "daily"
+              ]
             }
           }
         ],
@@ -6977,7 +6985,6 @@
           "Charts"
         ],
         "summary": "Get transaction count history",
-        "description": "`interval-type` query param: hourly, daily",
         "operationId": "getChartsTransactions-count",
         "parameters": [
           {
@@ -6993,7 +7000,7 @@
           {
             "name": "toTs",
             "in": "query",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "integer",
               "format": "int64",
@@ -7005,7 +7012,11 @@
             "in": "query",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/IntervalType"
+              "type": "string",
+              "enum": [
+                "hourly",
+                "daily"
+              ]
             }
           }
         ],
@@ -7121,7 +7132,6 @@
           "Charts"
         ],
         "summary": "Get transaction count history per chain",
-        "description": "`interval-type` query param: hourly, daily",
         "operationId": "getChartsTransactions-count-per-chain",
         "parameters": [
           {
@@ -7137,7 +7147,7 @@
           {
             "name": "toTs",
             "in": "query",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "integer",
               "format": "int64",
@@ -7149,7 +7159,11 @@
             "in": "query",
             "required": true,
             "schema": {
-              "$ref": "#/components/schemas/IntervalType"
+              "type": "string",
+              "enum": [
+                "hourly",
+                "daily"
+              ]
             }
           }
         ],
@@ -7194,6 +7208,172 @@
                         "count": 10000000
                       }
                     ]
+                  }
+                ]
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequest"
+                },
+                "example": {
+                  "detail": "Something bad in the request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unauthorized"
+                },
+                "example": {
+                  "detail": "You shall not pass"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFound"
+                },
+                "example": {
+                  "resource": "wallet-name",
+                  "detail": "wallet-name not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                },
+                "example": {
+                  "detail": "Ouch"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailable"
+                },
+                "example": {
+                  "detail": "Self clique unsynced"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "GatewayTimeout",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GatewayTimeout"
+                },
+                "example": {
+                  "detail": "The network is slow"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/charts/active-addresses": {
+      "get": {
+        "tags": [
+          "Charts"
+        ],
+        "summary": "Get active addresses history",
+        "operationId": "getChartsActive-addresses",
+        "parameters": [
+          {
+            "name": "fromTs",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "toTs",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "interval-type",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "daily",
+                "monthly"
+              ]
+            }
+          },
+          {
+            "name": "export-type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/ExportType"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "text/csv": {
+                "schema": {
+                  "description": "CSV with timestamp (unix ms) and count columns",
+                  "examples": [
+                    [
+                      "1767225600000,10879"
+                    ]
+                  ],
+                  "type": "string"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TimedCount"
+                  }
+                },
+                "example": [
+                  {
+                    "timestamp": 1611041396892,
+                    "totalCountAllChains": 10000000
+                  },
+                  {
+                    "timestamp": 1611041396892,
+                    "totalCountAllChains": 10000000
                   }
                 ]
               }
@@ -9322,6 +9502,14 @@
           }
         }
       },
+      "ExportType": {
+        "title": "ExportType",
+        "type": "string",
+        "enum": [
+          "csv",
+          "json"
+        ]
+      },
       "FungibleToken": {
         "title": "FungibleToken",
         "type": "object",
@@ -9482,15 +9670,6 @@
             "type": "string"
           }
         }
-      },
-      "IntervalType": {
-        "title": "IntervalType",
-        "type": "string",
-        "enum": [
-          "daily",
-          "hourly",
-          "weekly"
-        ]
       },
       "ListBlocks": {
         "title": "ListBlocks",
@@ -10464,6 +10643,16 @@
           "hkd",
           "thb",
           "cny"
+        ]
+      },
+      "IntervalType": {
+        "title": "IntervalType",
+        "type": "string",
+        "enum": [
+          "hourly",
+          "daily",
+          "weekly",
+          "monthly"
         ]
       }
     }

--- a/app/src/main/scala/org/alephium/explorer/SyncServices.scala
+++ b/app/src/main/scala/org/alephium/explorer/SyncServices.scala
@@ -52,6 +52,8 @@ object SyncServices extends StrictLogging {
             peers = peers,
             syncPeriod = config.syncPeriod,
             holderServiceScheduleTime = config.holderServiceScheduleTime,
+            activeAddressHistoryServiceScheduleTime =
+              config.activeAddressHistoryServiceScheduleTime,
             tokenSupplyServiceScheduleTime = config.tokenSupplyServiceScheduleTime,
             hashRateServiceSyncPeriod = config.hashRateServiceSyncPeriod,
             finalizerServiceSyncPeriod = config.finalizerServiceSyncPeriod,
@@ -67,6 +69,7 @@ object SyncServices extends StrictLogging {
       peers: ArraySeq[Uri],
       syncPeriod: FiniteDuration,
       holderServiceScheduleTime: LocalTime,
+      activeAddressHistoryServiceScheduleTime: LocalTime,
       tokenSupplyServiceScheduleTime: LocalTime,
       hashRateServiceSyncPeriod: FiniteDuration,
       finalizerServiceSyncPeriod: FiniteDuration,
@@ -92,6 +95,7 @@ object SyncServices extends StrictLogging {
               HashrateService.start(hashRateServiceSyncPeriod),
               FinalizerService.start(finalizerServiceSyncPeriod),
               HolderService.start(holderServiceScheduleTime),
+              ActiveAddressHistoryService.start(activeAddressHistoryServiceScheduleTime),
               TransactionHistoryService.start(transactionHistoryServiceSyncPeriod)
             )
           )

--- a/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
@@ -157,7 +157,9 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
     addressesLikeEndpoint.get
       .in("amount-history")
       .in(timeIntervalQuery)
-      .in(intervalTypeQuery)
+      .in(
+        intervalTypeSubsetQuery(Set(IntervalType.Hourly, IntervalType.Daily, IntervalType.Weekly))
+      )
       .out(jsonBody[AmountHistory])
       .deprecated()
 

--- a/app/src/main/scala/org/alephium/explorer/api/BaseEndpoint.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/BaseEndpoint.scala
@@ -52,4 +52,10 @@ trait BaseEndpoint extends ErrorExamples with TapirCodecs with TapirSchemasLike 
       .jsonBody[ArraySeq[T]]
       .validate(Validator.maxSize(maxSize))
       .description(s"List of $tpe, max items: $maxSize")
+
+  type CsvCodec[T] = Codec[String, T, Codecs.TextCsv]
+
+  def csvBody[T: CsvCodec]: EndpointIO.Body[String, T] =
+    stringBodyUtf8AnyFormat(implicitly[Codec[String, T, Codecs.TextCsv]])
+
 }

--- a/app/src/main/scala/org/alephium/explorer/api/ChartsEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/ChartsEndpoints.scala
@@ -10,13 +10,14 @@ import sttp.tapir.generic.auto._
 
 import org.alephium.api.Endpoints.jsonBody
 import org.alephium.api.model.TimeInterval
+import org.alephium.explorer.api.Codecs._
 import org.alephium.explorer.api.EndpointExamples._
 import org.alephium.explorer.api.model.{Hashrate, IntervalType, PerChainTimedCount, TimedCount}
 
-// scalastyle:off magic.number
 trait ChartsEndpoints extends BaseEndpoint with QueryParams {
 
-  val intervalTypes: String = IntervalType.all.dropRight(1).map(_.string).mkString(", ")
+  private val hourlyDaily: Set[IntervalType]  = Set(IntervalType.Hourly, IntervalType.Daily)
+  private val dailyMonthly: Set[IntervalType] = Set(IntervalType.Daily, IntervalType.Monthly)
 
   private val chartsEndpoint =
     baseEndpoint
@@ -27,26 +28,23 @@ trait ChartsEndpoints extends BaseEndpoint with QueryParams {
     chartsEndpoint.get
       .in("hashrates")
       .in(timeIntervalQuery)
-      .in(intervalTypeQuery)
+      .in(intervalTypeSubsetQuery(hourlyDaily))
       .out(jsonBody[ArraySeq[Hashrate]])
       .summary("Get hashrate chart in H/s")
-      .description(s"`interval-type` query param: $intervalTypes")
 
   val getAllChainsTxCount: BaseEndpoint[(TimeInterval, IntervalType), ArraySeq[TimedCount]] =
     chartsEndpoint.get
       .in("transactions-count")
       .in(timeIntervalQuery)
-      .in(intervalTypeQuery)
+      .in(intervalTypeSubsetQuery(hourlyDaily))
       .out(jsonBody[ArraySeq[TimedCount]])
       .summary("Get transaction count history")
-      .description(s"`interval-type` query param: ${intervalTypes}")
 
   val getPerChainTxCount: BaseEndpoint[(TimeInterval, IntervalType), ArraySeq[PerChainTimedCount]] =
     chartsEndpoint.get
       .in("transactions-count-per-chain")
       .in(timeIntervalQuery)
-      .in(intervalTypeQuery)
+      .in(intervalTypeSubsetQuery(hourlyDaily))
       .out(jsonBody[ArraySeq[PerChainTimedCount]])
       .summary("Get transaction count history per chain")
-      .description(s"`interval-type` query param: ${intervalTypes}")
 }

--- a/app/src/main/scala/org/alephium/explorer/api/ChartsEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/ChartsEndpoints.scala
@@ -12,7 +12,14 @@ import org.alephium.api.Endpoints.jsonBody
 import org.alephium.api.model.TimeInterval
 import org.alephium.explorer.api.Codecs._
 import org.alephium.explorer.api.EndpointExamples._
-import org.alephium.explorer.api.model.{Hashrate, IntervalType, PerChainTimedCount, TimedCount}
+import org.alephium.explorer.api.model.{
+  ActiveAddressesCount,
+  ExportType,
+  Hashrate,
+  IntervalType,
+  PerChainTimedCount,
+  TimedCount
+}
 
 trait ChartsEndpoints extends BaseEndpoint with QueryParams {
 
@@ -47,4 +54,20 @@ trait ChartsEndpoints extends BaseEndpoint with QueryParams {
       .in(intervalTypeSubsetQuery(hourlyDaily))
       .out(jsonBody[ArraySeq[PerChainTimedCount]])
       .summary("Get transaction count history per chain")
+
+  val getActiveAddresses
+      : BaseEndpoint[(TimeInterval, IntervalType, Option[ExportType]), ActiveAddressesCount] =
+    chartsEndpoint.get
+      .in("active-addresses")
+      .in(timeIntervalQuery)
+      .in(intervalTypeSubsetQuery(dailyMonthly))
+      .in(optionalExportTypeQuery)
+      .out(
+        oneOf[ActiveAddressesCount](
+          oneOfVariant[ActiveAddressesCount.Csv](csvBody[ActiveAddressesCount.Csv]),
+          oneOfVariant(jsonBody[Seq[TimedCount]].map(ActiveAddressesCount.Json(_))(_.data))
+        )
+      )
+      .summary("Get active addresses history")
+
 }

--- a/app/src/main/scala/org/alephium/explorer/api/Codecs.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/Codecs.scala
@@ -5,6 +5,7 @@ package org.alephium.explorer.api
 
 import scala.util.{Failure, Success, Try}
 
+import sttp.model.MediaType
 import sttp.tapir.{Codec, CodecFormat, DecodeResult}
 import sttp.tapir.Codec.PlainCodec
 import upickle.core.Abort
@@ -17,6 +18,10 @@ import org.alephium.json.Json._
 import org.alephium.protocol.config.GroupConfig
 
 object Codecs extends TapirCodecs {
+
+  final case class TextCsv() extends CodecFormat {
+    override val mediaType: MediaType = MediaType.TextCsv
+  }
 
   implicit val groupConfig: GroupConfig = Default.groupConfig
 

--- a/app/src/main/scala/org/alephium/explorer/api/Codecs.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/Codecs.scala
@@ -67,6 +67,22 @@ object Codecs extends TapirCodecs {
       "org.wartremover.warts.Product",
       "org.wartremover.warts.Serializable"
     )
+  )
+  implicit val exportTypeCodec: PlainCodec[ExportType] =
+    Codec.derivedEnumeration[String, ExportType](
+      ExportType.validate(_).toOption,
+      {
+        case ExportType.CSV  => "csv"
+        case ExportType.JSON => "json"
+      }
+    )
+
+  @SuppressWarnings(
+    Array(
+      "org.wartremover.warts.JavaSerializable",
+      "org.wartremover.warts.Product",
+      "org.wartremover.warts.Serializable"
+    )
   ) // Wartremover is complaining, maybe beacause of tapir macros
   implicit val txStatusTypeCodec: PlainCodec[TxStatusType] =
     Codec.derivedEnumeration[String, TxStatusType](

--- a/app/src/main/scala/org/alephium/explorer/api/Codecs.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/Codecs.scala
@@ -114,4 +114,10 @@ object Codecs extends TapirCodecs {
         case other          => write(other)
       }
     }
+
+  implicit val activeAddressesOutputCsvCodec: Codec[String, ActiveAddressesCount.Csv, TextCsv] =
+    Codec
+      .id(TextCsv(), ActiveAddressesCount.Csv.schema)
+      .map(ActiveAddressesCount.Csv(_))(_.data)
+
 }

--- a/app/src/main/scala/org/alephium/explorer/api/Codecs.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/Codecs.scala
@@ -34,11 +34,32 @@ object Codecs extends TapirCodecs {
       "org.wartremover.warts.Serializable"
     )
   ) // Wartremover is complaining, maybe beacause of tapir macros
-  implicit val timeIntervalCodec: PlainCodec[IntervalType] =
+  implicit val intervalTypeCodec: PlainCodec[IntervalType] =
     Codec.derivedEnumeration[String, IntervalType](
       IntervalType.validate,
       _.string
     )
+
+  @SuppressWarnings(
+    Array(
+      "org.wartremover.warts.JavaSerializable",
+      "org.wartremover.warts.Product",
+      "org.wartremover.warts.Serializable"
+    )
+  ) // Wartremover is complaining, maybe beacause of tapir macros
+  def intervalTypeSubsetCodec(subset: Set[IntervalType]): PlainCodec[IntervalType] =
+    Codec.string.mapDecode[IntervalType] { raw =>
+      IntervalType.validate(raw) match {
+        case Some(intervalType) if subset.contains(intervalType) => DecodeResult.Value(intervalType)
+        case _ =>
+          DecodeResult.Error(
+            raw,
+            new IllegalArgumentException(
+              s"allowed values: ${subset.map(_.string).mkString(", ")}, but got"
+            )
+          )
+      }
+    }(_.string)
 
   @SuppressWarnings(
     Array(

--- a/app/src/main/scala/org/alephium/explorer/api/QueryParams.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/QueryParams.scala
@@ -67,9 +67,9 @@ trait QueryParams extends TapirCodecs {
 
   val timeIntervalQuery: EndpointInput[TimeInterval] =
     query[TimeStamp]("fromTs")
-      .and(query[TimeStamp]("toTs"))
+      .and(query[Option[TimeStamp]]("toTs"))
       .map { case (from, to) => TimeInterval(from, to) }(timeInterval =>
-        (timeInterval.from, timeInterval.to)
+        (timeInterval.from, timeInterval.toOpt)
       )
       .validate(TimeInterval.validator)
 
@@ -106,4 +106,12 @@ trait QueryParams extends TapirCodecs {
         s"${StdInterfaceId.tokenStdInterfaceIds.map(_.value).mkString(", ")} or any interface id in hex-string format, e.g: 0001"
       )
       .schema(StdInterfaceId.tokenWithHexStringSchema.format("string").asOption)
+
+  def intervalTypeSubsetQuery(subset: Set[IntervalType]): EndpointInput[IntervalType] = {
+    queryAnyFormat[IntervalType, CodecFormat.TextPlain](
+      "interval-type",
+      Codec.listHead(intervalTypeSubsetCodec(subset))
+    )
+      .schema(IntervalType.subsetSchema(subset))
+  }
 }

--- a/app/src/main/scala/org/alephium/explorer/api/QueryParams.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/QueryParams.scala
@@ -97,6 +97,12 @@ trait QueryParams extends TapirCodecs {
   val intervalTypeQuery: EndpointInput[IntervalType] =
     query[IntervalType]("interval-type")
 
+  val exportTypeQuery: EndpointInput[ExportType] =
+    query[ExportType]("export-type")
+
+  val optionalExportTypeQuery: EndpointInput[Option[ExportType]] =
+    query[Option[ExportType]]("export-type")
+
   val optionalTxStatusTypeQuery: EndpointInput[Option[TxStatusType]] =
     query[Option[TxStatusType]]("status")
 

--- a/app/src/main/scala/org/alephium/explorer/api/model/ActiveAddressesCount.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/ActiveAddressesCount.scala
@@ -1,0 +1,20 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.explorer.api.model
+
+import sttp.tapir.Schema
+
+sealed trait ActiveAddressesCount
+object ActiveAddressesCount {
+  final case class Json(data: Seq[TimedCount]) extends ActiveAddressesCount
+  final case class Csv(data: String)                extends ActiveAddressesCount
+
+  object Csv {
+    val schema: Schema[String] =
+      Schema.schemaForString
+        .encodedExample("1767225600000,10879")
+        .description("CSV with timestamp (unix ms) and count columns")
+  }
+}
+

--- a/app/src/main/scala/org/alephium/explorer/api/model/ActiveAddressesCount.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/ActiveAddressesCount.scala
@@ -8,7 +8,7 @@ import sttp.tapir.Schema
 sealed trait ActiveAddressesCount
 object ActiveAddressesCount {
   final case class Json(data: Seq[TimedCount]) extends ActiveAddressesCount
-  final case class Csv(data: String)                extends ActiveAddressesCount
+  final case class Csv(data: String)           extends ActiveAddressesCount
 
   object Csv {
     val schema: Schema[String] =
@@ -17,4 +17,3 @@ object ActiveAddressesCount {
         .description("CSV with timestamp (unix ms) and count columns")
   }
 }
-

--- a/app/src/main/scala/org/alephium/explorer/api/model/ExportType.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/ExportType.scala
@@ -8,4 +8,10 @@ sealed trait ExportType
 object ExportType {
   case object CSV  extends ExportType
   case object JSON extends ExportType
+
+  def validate(exportType: String): Either[String, ExportType] = exportType match {
+    case "csv"  => Right(CSV)
+    case "json" => Right(JSON)
+    case _      => Left(s"Invalid export type: $exportType. Supported types are 'csv' and 'json'.")
+  }
 }

--- a/app/src/main/scala/org/alephium/explorer/api/model/IntervalType.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/IntervalType.scala
@@ -9,6 +9,7 @@ import scala.collection.immutable.ArraySeq
 import scala.concurrent.{ExecutionContext, Future}
 
 import sttp.model.StatusCode
+import sttp.tapir._
 import upickle.core.Abort
 
 import org.alephium.api.ApiError
@@ -125,4 +126,16 @@ object IntervalType {
       case Right(_)    => contd.map(Right(_))
     }
   }
+
+  @SuppressWarnings(
+    Array(
+      "org.wartremover.warts.JavaSerializable",
+      "org.wartremover.warts.Product",
+      "org.wartremover.warts.Serializable"
+    )
+  ) // Wartremover is complaining, maybe beacause of tapir macros
+  def subsetSchema(subset: Set[IntervalType]): Schema[IntervalType] =
+    Schema.string.validate(
+      Validator.enumeration(subset.toList, (it: IntervalType) => Some(it.string))
+    )
 }

--- a/app/src/main/scala/org/alephium/explorer/api/model/IntervalType.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/IntervalType.scala
@@ -23,6 +23,7 @@ sealed trait IntervalType {
   def duration: Duration
 }
 
+//scalastyle:off magic.number
 object IntervalType {
   case object Hourly extends IntervalType {
     val value: Int             = 0
@@ -48,8 +49,16 @@ object IntervalType {
     override def toString()    = string
   }
 
+  case object Monthly extends IntervalType {
+    val value: Int             = 3
+    val string: String         = "monthly"
+    val chronoUnit: ChronoUnit = ChronoUnit.WEEKS
+    val duration: Duration     = Duration.ofDaysUnsafe(31)
+    override def toString()    = string
+  }
+
   val all: ArraySeq[IntervalType] =
-    ArraySeq(Hourly: IntervalType, Daily: IntervalType, Weekly: IntervalType)
+    ArraySeq(Hourly: IntervalType, Daily: IntervalType, Weekly: IntervalType, Monthly: IntervalType)
 
   @SuppressWarnings(Array("org.wartremover.warts.Throw"))
   implicit val reader: Reader[IntervalType] =
@@ -65,10 +74,20 @@ object IntervalType {
 
   def validate(str: String): Option[IntervalType] =
     str match {
-      case Hourly.string => Some(Hourly)
-      case Daily.string  => Some(Daily)
-      case Weekly.string => Some(Weekly)
-      case _             => None
+      case Hourly.string  => Some(Hourly)
+      case Daily.string   => Some(Daily)
+      case Weekly.string  => Some(Weekly)
+      case Monthly.string => Some(Monthly)
+      case _              => None
+    }
+
+  def validateSubset(str: String)(subset: Set[IntervalType]): Option[IntervalType] =
+    str match {
+      case Hourly.string if subset.contains(Hourly)   => Some(Hourly)
+      case Daily.string if subset.contains(Daily)     => Some(Daily)
+      case Weekly.string if subset.contains(Weekly)   => Some(Weekly)
+      case Monthly.string if subset.contains(Monthly) => Some(Monthly)
+      case _                                          => None
     }
 
   implicit val writer: Writer[IntervalType] =
@@ -76,26 +95,30 @@ object IntervalType {
 
   def unsafe(int: Int): IntervalType = {
     int match {
-      case IntervalType.Hourly.value => IntervalType.Hourly
-      case IntervalType.Daily.value  => IntervalType.Daily
-      case IntervalType.Weekly.value => IntervalType.Weekly
+      case IntervalType.Hourly.value  => IntervalType.Hourly
+      case IntervalType.Daily.value   => IntervalType.Daily
+      case IntervalType.Weekly.value  => IntervalType.Weekly
+      case IntervalType.Monthly.value => IntervalType.Monthly
     }
   }
 
+  @SuppressWarnings(Array("org.wartremover.warts.DefaultArguments"))
   def validateTimeInterval[A](
       timeInterval: TimeInterval,
       intervalType: IntervalType,
       maxHourlyTimeSpan: Duration,
       maxDailyTimeSpan: Duration,
-      maxWeeklyTimeSpan: Duration
+      maxWeeklyTimeSpan: Duration,
+      maxMonthlyTimeSpan: Duration
   )(
       contd: => Future[A]
   )(implicit executionContext: ExecutionContext): Future[Either[ApiError[_ <: StatusCode], A]] = {
     val timeSpan =
       intervalType match {
-        case IntervalType.Hourly => maxHourlyTimeSpan
-        case IntervalType.Daily  => maxDailyTimeSpan
-        case IntervalType.Weekly => maxWeeklyTimeSpan
+        case IntervalType.Hourly  => maxHourlyTimeSpan
+        case IntervalType.Daily   => maxDailyTimeSpan
+        case IntervalType.Weekly  => maxWeeklyTimeSpan
+        case IntervalType.Monthly => maxMonthlyTimeSpan
       }
     timeInterval.validateTimeSpan(timeSpan) match {
       case Left(error) => Future.successful(Left(error))

--- a/app/src/main/scala/org/alephium/explorer/config/ExplorerConfig.scala
+++ b/app/src/main/scala/org/alephium/explorer/config/ExplorerConfig.scala
@@ -229,6 +229,7 @@ object ExplorerConfig {
           explorer.forceSynchronousMigrations,
           explorer.syncPeriod,
           explorer.holderServiceScheduleTime,
+          explorer.activeAddressHistoryServiceScheduleTime,
           explorer.tokenSupplyServiceScheduleTime,
           explorer.hashRateServiceSyncPeriod,
           explorer.finalizerServiceSyncPeriod,
@@ -273,7 +274,8 @@ object ExplorerConfig {
   final case class MaxTimeInterval(
       hourly: util.Duration,
       daily: util.Duration,
-      weekly: util.Duration
+      weekly: util.Duration,
+      monthly: util.Duration
   )
 
   final case class MaxTimeIntervals(
@@ -306,6 +308,7 @@ object ExplorerConfig {
       forceSynchronousMigrations: Boolean,
       syncPeriod: FiniteDuration,
       holderServiceScheduleTime: LocalTime,
+      activeAddressHistoryServiceScheduleTime: LocalTime,
       tokenSupplyServiceScheduleTime: LocalTime,
       hashRateServiceSyncPeriod: FiniteDuration,
       finalizerServiceSyncPeriod: FiniteDuration,
@@ -341,6 +344,7 @@ final case class ExplorerConfig private (
     forceSynchronousMigrations: Boolean,
     syncPeriod: FiniteDuration,
     holderServiceScheduleTime: LocalTime,
+    activeAddressHistoryServiceScheduleTime: LocalTime,
     tokenSupplyServiceScheduleTime: LocalTime,
     hashRateServiceSyncPeriod: FiniteDuration,
     finalizerServiceSyncPeriod: FiniteDuration,

--- a/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
+++ b/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
@@ -10,7 +10,7 @@ import sttp.apispec.openapi.OpenAPI
 import sttp.tapir.docs.openapi.OpenAPIDocsInterpreter
 
 import org.alephium.explorer.api._
-import org.alephium.explorer.api.model.Pagination
+import org.alephium.explorer.api.model.{IntervalType, Pagination}
 
 trait Documentation
     extends BlockEndpoints
@@ -159,6 +159,14 @@ trait Documentation
           Schema(
             `type` = Some(List(SchemaType.String)),
             enum = Some(currencies.map { name => ExampleSingleValue(name) }.toList)
+          )
+        )
+        .addSchema(
+          "IntervalType",
+          Schema(
+            title = Some("IntervalType"),
+            `type` = Some(List(SchemaType.String)),
+            enum = Some(IntervalType.all.map { name => ExampleSingleValue(name) }.toList)
           )
         )
     )

--- a/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
+++ b/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
@@ -75,6 +75,7 @@ trait Documentation
         getHashrates,
         getAllChainsTxCount,
         getPerChainTxCount,
+        getActiveAddresses,
         getEventsByTxId,
         getEventsByContractAddress,
         getEventsByContractAndInputAddress,

--- a/app/src/main/scala/org/alephium/explorer/persistence/DBInitializer.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/DBInitializer.scala
@@ -47,6 +47,7 @@ object DBInitializer extends StrictLogging {
       TokenPerAddressSchema.table,
       TokenInfoSchema.table,
       TransactionHistorySchema.table,
+      ActiveAddressHistorySchema.table,
       EventSchema.table,
       AlphHolderSchema.table,
       TokenHolderSchema.table,

--- a/app/src/main/scala/org/alephium/explorer/persistence/model/ActiveAddressEntity.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/model/ActiveAddressEntity.scala
@@ -1,0 +1,13 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.explorer.persistence.model
+
+import org.alephium.explorer.api.model.IntervalType
+import org.alephium.util.TimeStamp
+
+final case class ActiveAddressHistoryEntity(
+    timestamp: TimeStamp,
+    count: Long,
+    intervalType: IntervalType
+)

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/QueryUtil.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/QueryUtil.scala
@@ -37,5 +37,7 @@ object QueryUtil {
       case IntervalType.Hourly => hourlyQuery
       case IntervalType.Daily  => dailyQuery
       case IntervalType.Weekly => weeklyQuery
+      case IntervalType.Monthly =>
+        throw new IllegalArgumentException("Monthly interval type is not supported")
     }
 }

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/ActiveAddressHistorySchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/ActiveAddressHistorySchema.scala
@@ -1,0 +1,33 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.explorer.persistence.schema
+
+import slick.jdbc.PostgresProfile.api._
+import slick.lifted.{Index, PrimaryKey, ProvenShape}
+
+import org.alephium.explorer.api.model.IntervalType
+import org.alephium.explorer.persistence.model.ActiveAddressHistoryEntity
+import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
+import org.alephium.util.TimeStamp
+
+object ActiveAddressHistorySchema
+    extends Schema[ActiveAddressHistoryEntity]("active_address_history") {
+
+  class ActiveAddressHistories(tag: Tag) extends Table[ActiveAddressHistoryEntity](tag, name) {
+    def timestamp: Rep[TimeStamp]       = column[TimeStamp]("timestamp")
+    def count: Rep[Long]                = column[Long]("value")
+    def intervalType: Rep[IntervalType] = column[IntervalType]("interval_type")
+
+    def pk: PrimaryKey =
+      primaryKey("active_address_history_pk", (intervalType, timestamp))
+    def intervalTypeIdx: Index = index("active_address_history_interval_type_idx", intervalType)
+    def timestampIdx: Index    = index("active_address_history_timestamp_idx", timestamp)
+
+    def * : ProvenShape[ActiveAddressHistoryEntity] =
+      (timestamp, count, intervalType)
+        .<>((ActiveAddressHistoryEntity.apply _).tupled, ActiveAddressHistoryEntity.unapply)
+  }
+
+  val table: TableQuery[ActiveAddressHistories] = TableQuery[ActiveAddressHistories]
+}

--- a/app/src/main/scala/org/alephium/explorer/service/ActiveAddressHistoryService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/ActiveAddressHistoryService.scala
@@ -1,0 +1,308 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.explorer.service
+
+import java.time.{Instant, LocalTime, ZonedDateTime, ZoneOffset}
+
+import scala.collection.immutable.ArraySeq
+import scala.concurrent.{ExecutionContext, Future}
+
+import com.typesafe.scalalogging.StrictLogging
+import slick.basic.DatabaseConfig
+import slick.jdbc.{PositionedParameters, PostgresProfile, SetParameter, SQLActionBuilder}
+import slick.jdbc.PostgresProfile.api._
+
+import org.alephium.explorer.api.model.IntervalType
+import org.alephium.explorer.persistence._
+import org.alephium.explorer.persistence.DBRunner._
+import org.alephium.explorer.persistence.queries.QuerySplitter
+import org.alephium.explorer.persistence.schema.CustomGetResult._
+import org.alephium.explorer.persistence.schema.CustomSetParameter._
+import org.alephium.explorer.util.Scheduler
+import org.alephium.explorer.util.SlickUtil._
+import org.alephium.explorer.util.TimeUtil._
+import org.alephium.protocol.ALPH
+import org.alephium.util.TimeStamp
+
+case object ActiveAddressHistoryService extends StrictLogging {
+
+  def start(scheduleTime: LocalTime)(implicit
+      executionContext: ExecutionContext,
+      databaseConfig: DatabaseConfig[PostgresProfile],
+      scheduler: Scheduler
+  ): Future[Unit] = {
+    Future.successful{
+      scheduler.scheduleDailyAt(
+        taskId = TokenSupplyService.productPrefix,
+        at = ZonedDateTime
+          .ofInstant(Instant.EPOCH, ZoneOffset.UTC)
+          .plusSeconds(scheduleTime.toSecondOfDay().toLong)
+      )(syncOnce())
+    }
+  }
+
+  def syncOnce()(implicit
+      ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile]
+  ): Future[Unit] = {
+    logger.debug("Updating transactions count")
+    val startedAt = TimeStamp.now()
+    update().map { _ =>
+      val duration = TimeStamp.now().deltaUnsafe(startedAt)
+      logger.debug(s"Active Address history updated in ${duration.millis} ms")
+    }
+  }
+
+  private def update()(implicit
+      ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile]
+  ): Future[Unit] = {
+    run(
+      findLatestTransationTimestamp().flatMap {
+        case None => DBIO.successful(())
+        case Some(latestTxTs) =>
+          for {
+            _ <- updateDAA(latestTxTs)
+            _ <- updateMAA(latestTxTs)
+          } yield ()
+      }
+    )
+  }
+
+  private def updateDAA(
+      latestTxTs: TimeStamp
+  )(implicit ec: ExecutionContext): DBActionRW[Unit] = {
+    findLatestHistoryTimestamp(IntervalType.Daily).flatMap { histTsOpt =>
+      val start = histTsOpt
+        .map { histTs =>
+          stepBack(histTs, IntervalType.Daily)
+        }
+        .getOrElse(ALPH.LaunchTimestamp)
+
+      val rangesTmp = getTimeRanges(start, latestTxTs, IntervalType.Daily)
+
+      val ranges = (for {
+        head <- rangesTmp.headOption
+        last <- rangesTmp.lastOption
+      } yield {
+        Seq((head._1, last._2))
+      }).getOrElse(Seq.empty)
+
+      DBIO
+        .sequence(
+          ranges.map { range =>
+            range match {
+              case (from, to) =>
+                computeDAA(from, to)
+            }
+          }
+        )
+        .map(_ => ())
+    }
+  }
+
+  private def updateMAA(
+      latestTxTs: TimeStamp
+  )(implicit ec: ExecutionContext): DBActionRW[Unit] = {
+    findLatestHistoryTimestamp(IntervalType.Monthly).flatMap { histTsOpt =>
+      val start = histTsOpt
+        .map { histTs =>
+          stepBack(histTs, IntervalType.Monthly)
+        }
+        .getOrElse(ALPH.LaunchTimestamp)
+
+      val rangesTmp = getTimeRanges(start, latestTxTs, IntervalType.Monthly)
+
+      val ranges = (for {
+        head <- rangesTmp.headOption
+        last <- rangesTmp.lastOption
+      } yield {
+        Seq((head._1, last._2))
+      }).getOrElse(Seq.empty)
+
+      DBIO
+        .sequence(
+          ranges.map { range =>
+            range match {
+              case (from, to) =>
+                computeMAA(from, to)
+            }
+          }
+        )
+        .map(_ => ())
+    }
+  }
+
+  private def computeDAA(
+      from: TimeStamp,
+      to: TimeStamp
+  )(implicit
+      ec: ExecutionContext
+  ): DBActionRW[Int] = {
+    logger.debug("Starting computation of Daily Active Addresses (DAA)")
+    computeDAAQuery(from, to).flatMap { results =>
+      logger.debug(s"Computed ${results.size} daily active addresses")
+      insertDAA(results) // Insert results into the database
+    }
+  }
+
+  private def computeMAA(
+      from: TimeStamp,
+      to: TimeStamp
+  )(implicit
+      ec: ExecutionContext
+  ): DBActionRW[Int] = {
+    logger.debug("Starting computation of Monthly Active Addresses (MAA)")
+    computeMAAQuery(from, to).flatMap { results =>
+      logger.debug(s"Computed ${results.size} monthly active addresses")
+      insertMAA(results) // Insert results into the database
+    }
+  }
+
+  private def computeDAAQuery(
+      from: TimeStamp,
+      to: TimeStamp
+  ): DBActionSR[(TimeStamp, Long)] = {
+    sql"""
+      WITH daily_active_addresses AS (
+          SELECT
+              (EXTRACT(EPOCH FROM DATE_TRUNC('day', to_timestamp(block_timestamp / 1000) AT TIME ZONE 'UTC')) * 1000)::BIGINT AS transaction_date_unix,
+              address,
+              COUNT(DISTINCT tx_hash) AS tx_count
+          FROM
+              transaction_per_addresses
+          WHERE
+              main_chain = true -- Only consider transactions in the main chain
+          AND
+            block_timestamp >= $from
+          AND
+            block_timestamp < $to
+          GROUP BY
+              transaction_date_unix, address
+      )
+      SELECT
+          transaction_date_unix AS transaction_date,
+          COUNT(DISTINCT address) AS daily_count
+      FROM
+          daily_active_addresses
+      GROUP BY
+          transaction_date_unix
+      ORDER BY
+          transaction_date_unix;
+
+      """.asAS[(TimeStamp, Long)]
+  }
+
+  private def computeMAAQuery(
+      from: TimeStamp,
+      to: TimeStamp
+  ): DBActionSR[(TimeStamp, Long)] = {
+    sql"""
+      WITH monthly_active_addresses AS (
+          SELECT
+              (EXTRACT(EPOCH FROM DATE_TRUNC('month', to_timestamp(block_timestamp / 1000) AT TIME ZONE 'UTC')) * 1000)::BIGINT AS transaction_date_unix,
+              address,
+              COUNT(DISTINCT tx_hash) AS tx_count
+          FROM
+              transaction_per_addresses
+          WHERE
+              main_chain = true -- Only consider transactions in the main chain
+          AND
+              block_timestamp >= $from
+          AND
+              block_timestamp < $to
+          GROUP BY
+              transaction_date_unix, address
+      )
+      SELECT
+          transaction_date_unix AS transaction_date,
+          COUNT(DISTINCT address) AS monthly_count
+      FROM
+          monthly_active_addresses
+      GROUP BY
+          transaction_date_unix
+      ORDER BY
+          transaction_date_unix;
+    """.asAS[(TimeStamp, Long)]
+  }
+
+  private def insertData(
+      values: Seq[(TimeStamp, Long)],
+      intervalType: IntervalType
+  ): DBActionW[Int] = {
+    QuerySplitter.splitUpdates(rows = values, columnsPerRow = 3) { (rows, placeholders) =>
+      val query =
+        s"""
+          INSERT INTO active_address_history(timestamp, value, interval_type)
+          VALUES $placeholders
+          ON CONFLICT (interval_type, timestamp) DO UPDATE
+          SET value = EXCLUDED.value
+        """
+
+      val parameters: SetParameter[Unit] = (_, ps: PositionedParameters) =>
+        rows.foreach { case (timestamp, count) =>
+          ps >> timestamp
+          ps >> count
+          ps >> intervalType
+        }
+
+      SQLActionBuilder(query, parameters).asUpdate
+    }
+  }
+
+  private def insertDAA(values: Seq[(TimeStamp, Long)]): DBActionW[Int] = {
+    insertData(values, IntervalType.Daily)
+  }
+
+  private def insertMAA(values: Seq[(TimeStamp, Long)]): DBActionW[Int] = {
+    insertData(values, IntervalType.Monthly)
+  }
+
+  private def findLatestHistoryTimestamp(
+      intervalType: IntervalType
+  )(implicit ec: ExecutionContext): DBActionR[Option[TimeStamp]] = {
+    sql"""
+      SELECT MAX(timestamp) FROM active_address_history
+      WHERE interval_type = $intervalType
+    """.asAS[Option[TimeStamp]].exactlyOne
+  }
+
+  private def findLatestTransationTimestamp()(implicit
+      ec: ExecutionContext
+  ): DBActionR[Option[TimeStamp]] = {
+    sql"""
+    SELECT MAX(block_timestamp) FROM latest_blocks
+    """.asAS[Option[TimeStamp]].exactlyOne
+  }
+
+  def getActiveAddressesQuery(
+      from: TimeStamp,
+      to: TimeStamp,
+      intervalType: IntervalType
+  ): DBActionSR[(TimeStamp, Long)] = {
+    sql"""
+      SELECT timestamp, value FROM active_address_history
+      WHERE interval_type = ${intervalType}
+      AND timestamp >= $from
+      AND timestamp <= $to
+      ORDER BY timestamp
+    """.asAS[(TimeStamp, Long)]
+  }
+
+  def getActiveAddresses(
+      from: TimeStamp,
+      to: TimeStamp,
+      intervalType: IntervalType
+  )(implicit
+      ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile]
+  ): Future[ArraySeq[(TimeStamp, Long)]] = {
+    intervalType match {
+      case IntervalType.Daily | IntervalType.Monthly =>
+        run(getActiveAddressesQuery(from, to, intervalType)).map(ArraySeq.from(_))
+      case _ =>
+        Future.failed(new IllegalArgumentException("Unsupported interval type"))
+    }
+  }
+}

--- a/app/src/main/scala/org/alephium/explorer/service/ActiveAddressHistoryService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/ActiveAddressHistoryService.scala
@@ -32,7 +32,7 @@ case object ActiveAddressHistoryService extends StrictLogging {
       databaseConfig: DatabaseConfig[PostgresProfile],
       scheduler: Scheduler
   ): Future[Unit] = {
-    Future.successful{
+    Future.successful {
       scheduler.scheduleDailyAt(
         taskId = TokenSupplyService.productPrefix,
         at = ZonedDateTime

--- a/app/src/main/scala/org/alephium/explorer/service/TransactionHistoryService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/TransactionHistoryService.scala
@@ -242,46 +242,16 @@ case object TransactionHistoryService extends StrictLogging {
       ).asUpdate
     }
 
-  private def truncate(timestamp: TimeStamp, intervalType: IntervalType): TimeStamp =
-    intervalType match {
-      case IntervalType.Hourly => truncatedToHour(timestamp)
-      case IntervalType.Daily  => truncatedToDay(timestamp)
-      case IntervalType.Weekly => truncatedToWeek(timestamp)
-    }
-
-  @SuppressWarnings(Array("org.wartremover.warts.OptionPartial"))
-  def getTimeRanges(
-      histTs: TimeStamp,
-      latestTxTs: TimeStamp,
-      intervalType: IntervalType
-  ): ArraySeq[(TimeStamp, TimeStamp)] = {
-
-    val oneMillis = Duration.ofMillisUnsafe(1)
-    val start     = truncate(histTs, intervalType)
-    val end       = truncate(latestTxTs, intervalType).minusUnsafe(oneMillis)
-
-    if (start == end || end.isBefore(start)) {
-      ArraySeq.empty
-    } else {
-      val step = (intervalType match {
-        case IntervalType.Hourly => Duration.ofHoursUnsafe(1)
-        case IntervalType.Daily  => Duration.ofDaysUnsafe(1)
-        case IntervalType.Weekly => Duration.ofDaysUnsafe(7)
-      }).-(oneMillis).get
-
-      buildTimestampRange(start, end, step)
-    }
-  }
-
   /*
    * Step back a bit in time to recompute some latest values,
    * to be sure we didn't miss some unsynced blocks
    */
   private def stepBack(timestamp: TimeStamp, intervalType: IntervalType): TimeStamp =
     intervalType match {
-      case IntervalType.Hourly => timestamp.minusUnsafe(hourlyStepBack)
-      case IntervalType.Daily  => timestamp.minusUnsafe(dailyStepBack)
-      case IntervalType.Weekly => timestamp.minusUnsafe(weeklyStepBack)
+      case IntervalType.Hourly  => timestamp.minusUnsafe(hourlyStepBack)
+      case IntervalType.Daily   => timestamp.minusUnsafe(dailyStepBack)
+      case IntervalType.Weekly  => timestamp.minusUnsafe(weeklyStepBack)
+      case IntervalType.Monthly => timestamp.minusUnsafe(monthlyStepBack)
     }
 
   private def findLatestTransationTimestamp()(implicit

--- a/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
@@ -198,7 +198,8 @@ class AddressServer(
       intervalType,
       maxTimeInterval.hourly,
       maxTimeInterval.daily,
-      maxTimeInterval.weekly
+      maxTimeInterval.weekly,
+      maxTimeInterval.monthly
     )(contd)
 }
 

--- a/app/src/main/scala/org/alephium/explorer/web/ChartsServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/ChartsServer.scala
@@ -60,6 +60,8 @@ class ChartsServer(
       intervalType,
       maxTimeInterval.hourly,
       maxTimeInterval.daily,
-      maxTimeInterval.weekly
+      maxTimeInterval.weekly,
+      maxTimeInterval.monthly
     )(contd)
+
 }

--- a/app/src/test/scala/org/alephium/explorer/ConfigDefaults.scala
+++ b/app/src/test/scala/org/alephium/explorer/ConfigDefaults.scala
@@ -25,12 +25,14 @@ object ConfigDefaults {
       amountHistory = MaxTimeInterval(
         hourly = Duration.ofDaysUnsafe(7),
         daily = Duration.ofDaysUnsafe(366),
-        weekly = Duration.ofDaysUnsafe(366)
+        weekly = Duration.ofDaysUnsafe(366),
+        monthly = Duration.ofDaysUnsafe(1830)
       ),
       charts = MaxTimeInterval(
         hourly = Duration.ofDaysUnsafe(30),
         daily = Duration.ofDaysUnsafe(366),
-        weekly = Duration.ofDaysUnsafe(366)
+        weekly = Duration.ofDaysUnsafe(366),
+        monthly = Duration.ofDaysUnsafe(1830)
       ),
       exportTxs = Duration.ofDaysUnsafe(366)
     )

--- a/app/src/test/scala/org/alephium/explorer/api/model/IntervalTypeSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/api/model/IntervalTypeSpec.scala
@@ -23,7 +23,7 @@ class IntervalTypeSpec() extends AlephiumFutureSpec {
         val timeInterval = TimeInterval(now, to)
 
         IntervalType
-          .validateTimeInterval(timeInterval, intervalType, duration, duration, duration)(
+          .validateTimeInterval(timeInterval, intervalType, duration, duration, duration, duration)(
             Future.successful(())
           )
           .futureValue is Right(())
@@ -34,6 +34,7 @@ class IntervalTypeSpec() extends AlephiumFutureSpec {
           .validateTimeInterval(
             timeInterval,
             intervalType,
+            shorterDuration,
             shorterDuration,
             shorterDuration,
             shorterDuration

--- a/app/src/test/scala/org/alephium/explorer/service/TransactionHistoryServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TransactionHistoryServiceSpec.scala
@@ -28,53 +28,6 @@ class TransactionHistoryServiceSpec
     TimeStamp.unsafe(Instant.parse(str).toEpochMilli)
   }
 
-  "getTimeRanges" should {
-    "build daily time ranges" in {
-      TransactionHistoryService.getTimeRanges(
-        ts("2022-01-08T09:54:32.101Z"),
-        ts("2022-01-10T12:34:56.789Z"),
-        IntervalType.Daily
-      ) is
-        ArraySeq(
-          (ts("2022-01-08T00:00:00.000Z"), ts("2022-01-08T23:59:59.999Z")),
-          (ts("2022-01-09T00:00:00.000Z"), ts("2022-01-09T23:59:59.999Z"))
-          // 2022-01-10 isn't done, so we don't count it
-        )
-    }
-
-    "build hourly time ranges" in {
-      TransactionHistoryService.getTimeRanges(
-        ts("2022-01-08T09:54:32.101Z"),
-        ts("2022-01-08T12:34:56.789Z"),
-        IntervalType.Hourly
-      ) is
-        ArraySeq(
-          (ts("2022-01-08T09:00:00.000Z"), ts("2022-01-08T09:59:59.999Z")),
-          (ts("2022-01-08T10:00:00.000Z"), ts("2022-01-08T10:59:59.999Z")),
-          (ts("2022-01-08T11:00:00.000Z"), ts("2022-01-08T11:59:59.999Z"))
-          // 12:34:56 isn't done, so we don't count it
-        )
-    }
-
-    "return empty range when start is after end" in {
-
-      TransactionHistoryService.getTimeRanges(
-        ts("2022-01-08T00:00:00.000Z"),
-        ts("2022-01-07T00:00:00.000Z"),
-        IntervalType.Hourly
-      ) is ArraySeq.empty
-    }
-
-    "return empty range when end == start" in {
-
-      TransactionHistoryService.getTimeRanges(
-        ts("2022-01-08T00:00:00.000Z"),
-        ts("2022-01-08T00:00:00.000Z"),
-        IntervalType.Hourly
-      ) is ArraySeq.empty
-    }
-  }
-
   "countAndInsert" should {
     "handle per chains and all chains counting" in {
 

--- a/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
@@ -324,9 +324,10 @@ class AddressServerSpec()
     val intervalTypes = ArraySeq[IntervalType](IntervalType.Hourly, IntervalType.Daily)
     val fromTs        = timestamps.head
     def maxTimeSpan(intervalType: IntervalType) = intervalType match {
-      case IntervalType.Hourly => Duration.ofDaysUnsafe(7)
-      case IntervalType.Daily  => Duration.ofDaysUnsafe(366)
-      case IntervalType.Weekly => Duration.ofDaysUnsafe(366)
+      case IntervalType.Hourly  => Duration.ofDaysUnsafe(7)
+      case IntervalType.Daily   => Duration.ofDaysUnsafe(366)
+      case IntervalType.Weekly  => Duration.ofDaysUnsafe(366)
+      case IntervalType.Monthly => Duration.ofDaysUnsafe(366)
     }
     def getToTs(intervalType: IntervalType) =
       fromTs + maxTimeSpan(intervalType).millis


### PR DESCRIPTION
New chart endpoint to get daily and monthly active users, will be used by our marketing/community team.

I took the opportunity to clean and make more precise our `IntervalType` query param, as some endpoint use only `hourly` and `daily`, while user have `daily` and `monthly`. Before that the openapi file was accepting every case but was returning an error. Now in the swagger you can only choose the data you can pass.

I also added the possibility to return the active addresses count as csv, as it's more practical for some of our users.

Lots of commit, but I tried to make small once.

<img width="976" height="612" alt="image" src="https://github.com/user-attachments/assets/4dc82450-fb15-4d02-8654-f41f4880eed0" />
<img width="905" height="182" alt="image" src="https://github.com/user-attachments/assets/0ebe703f-8a76-4a12-b5ba-52e9f77cd73e" />
