### PR TITLE
Fix export transactions

### DIFF
--- a/app/src/main/resources/application.conf
+++ b/app/src/main/resources/application.conf
@@ -52,6 +52,10 @@ explorer {
     #How many transaction can be exported at max
     export-txs-number-threshold = 10000
 
+    #Number of batch while streaming
+    stream-batch-size = 100
+    stream-batch-size = ${?EXPLORER_STREAM_BATCH_SIZE}
+
     #Number of allowed parallelism when using `mapAsync` on streams.
     stream-parallelism = 8
     stream-parallelism = ${?EXPLORER_STREAM_PARALLELISM}

--- a/app/src/main/scala/org/alephium/explorer/AppServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/AppServer.scala
@@ -21,6 +21,7 @@ object AppServer {
   def routes(
       marketService: market.MarketService,
       exportTxsNumberThreshold: Int,
+      streamBatchSize: Int,
       streamParallelism: Int,
       maxTimeIntervals: ExplorerConfig.MaxTimeIntervals,
       marketConfig: ExplorerConfig.Market
@@ -41,6 +42,7 @@ object AppServer {
         TransactionService,
         TokenService,
         exportTxsNumberThreshold,
+        streamBatchSize,
         streamParallelism,
         maxTimeIntervals.amountHistory,
         maxTimeIntervals.exportTxs

--- a/app/src/main/scala/org/alephium/explorer/ExplorerState.scala
+++ b/app/src/main/scala/org/alephium/explorer/ExplorerState.scala
@@ -79,6 +79,7 @@ sealed trait ExplorerStateRead extends ExplorerState {
       .routes(
         marketService,
         config.exportTxsNumberThreshold,
+        config.streamBatchSize,
         config.streamParallelism,
         config.maxTimeInterval,
         config.market

--- a/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
@@ -7,6 +7,7 @@ import scala.collection.immutable.ArraySeq
 
 import io.vertx.core.buffer.Buffer
 import io.vertx.core.streams.ReadStream
+import io.vertx.ext.web.RoutingContext
 import sttp.model.{HeaderNames, MediaType}
 import sttp.tapir._
 import sttp.tapir.generic.auto._
@@ -143,12 +144,14 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
       .out(jsonBody[ArraySeq[Boolean]])
       .summary("Are the addresses used (at least 1 transaction)")
 
+  @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   lazy val exportTransactionsCsvByAddress
-      : BaseEndpoint[(ApiAddress, TimeInterval), (String, ReadStream[Buffer])] =
+      : BaseEndpoint[(ApiAddress, TimeInterval, RoutingContext), (String, ReadStream[Buffer])] =
     addressesLikeEndpoint.get
       .in("export-transactions")
       .in("csv")
       .in(timeIntervalWithMaxQuery(maxTimeIntervalExportTxs))
+      .in(extractFromRequest(request => request.underlying.asInstanceOf[RoutingContext]))
       .out(header[String](HeaderNames.ContentDisposition))
       .out(streamTextBody(VertxStreams)(TextCsv()))
 

--- a/app/src/main/scala/org/alephium/explorer/config/ExplorerConfig.scala
+++ b/app/src/main/scala/org/alephium/explorer/config/ExplorerConfig.scala
@@ -238,6 +238,7 @@ object ExplorerConfig {
           explorer.cacheLatestBlocksReloadPeriod,
           explorer.cacheMetricsReloadPeriod,
           explorer.exportTxsNumberThreshold,
+          explorer.streamBatchSize,
           explorer.streamParallelism,
           explorer.maxTimeIntervals,
           explorer.market
@@ -315,6 +316,7 @@ object ExplorerConfig {
       cacheLatestBlocksReloadPeriod: FiniteDuration,
       cacheMetricsReloadPeriod: FiniteDuration,
       exportTxsNumberThreshold: Int,
+      streamBatchSize: Int,
       streamParallelism: Int,
       maxTimeIntervals: MaxTimeIntervals,
       market: Market
@@ -350,6 +352,7 @@ final case class ExplorerConfig private (
     cacheLatestBlocksReloadPeriod: FiniteDuration,
     cacheMetricsReloadPeriod: FiniteDuration,
     exportTxsNumberThreshold: Int,
+    streamBatchSize: Int,
     streamParallelism: Int,
     maxTimeInterval: ExplorerConfig.MaxTimeIntervals,
     market: ExplorerConfig.Market

--- a/app/src/main/scala/org/alephium/explorer/service/CancelToken.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/CancelToken.scala
@@ -1,0 +1,25 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.explorer.service
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+import io.reactivex.rxjava3.core.Flowable
+import io.reactivex.rxjava3.processors.PublishProcessor
+
+final class CancelToken {
+  private val cancelledRef = new AtomicBoolean(false)
+  private val processor    = PublishProcessor.create[Unit]()
+
+  def cancel(): Unit = {
+    if (cancelledRef.compareAndSet(false, true)) {
+      processor.onNext(())
+      processor.onComplete()
+    }
+  }
+
+  def isCancelled: Boolean = cancelledRef.get()
+
+  def signal: Flowable[Unit] = processor
+}

--- a/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
@@ -131,7 +131,8 @@ trait TransactionService {
       fromTime: TimeStamp,
       toTime: TimeStamp,
       batchSize: Int,
-      paralellism: Int
+      paralellism: Int,
+      cancelToken: CancelToken
   )(implicit ec: ExecutionContext, dc: DatabaseConfig[PostgresProfile]): Flowable[Buffer]
 
   def getAmountHistory(
@@ -261,21 +262,21 @@ object TransactionService extends TransactionService {
   ): Future[Boolean] = {
     run(hasAddressMoreTxsThanQuery(address, from, to, threshold))
   }
+
   def exportTransactionsByAddress(
       address: ApiAddress,
       fromTime: TimeStamp,
       toTime: TimeStamp,
       batchSize: Int,
-      paralellism: Int
+      paralellism: Int,
+      cancelToken: CancelToken
   )(implicit ec: ExecutionContext, dc: DatabaseConfig[PostgresProfile]): Flowable[Buffer] = {
-
     transactionsFlowable(
       address,
-      transactionSource(address, fromTime, toTime, batchSize, paralellism)
+      transactionSource(address, fromTime, toTime, batchSize, paralellism, cancelToken),
+      cancelToken
     )
-
   }
-
   def convertProtocolUnsignedTx(
       utx: protocol.model.UnsignedTransaction
   )(implicit
@@ -425,33 +426,41 @@ object TransactionService extends TransactionService {
       from: TimeStamp,
       to: TimeStamp,
       batchSize: Int,
-      paralellism: Int
+      paralellism: Int,
+      cancelToken: CancelToken
   )(implicit
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]
   ): Flowable[(ArraySeq[Transaction], Map[TokenId, FungibleTokenMetadata])] = {
     Flowable
       .fromPublisher(stream(streamTxByAddressQR(address, from, to)))
+      .takeUntil(cancelToken.signal)
       .buffer(batchSize)
       .concatMapEager(
         { hashes =>
-          Flowable.fromCompletionStage(
-            (for {
-              txs      <- run(getTransactions(ArraySeq.from(hashes.asScala)))
-              metadata <- getTokenMetadata(txs)
-            } yield {
-              (txs, metadata)
-            }).asJava
-          )
+          if (cancelToken.isCancelled || hashes.isEmpty) {
+            Flowable.empty()
+          } else {
+
+            Flowable.fromCompletionStage(
+              (for {
+                txs <- run(getTransactions(ArraySeq.from(hashes.asScala)))
+                metadata <-
+                  if (cancelToken.isCancelled) {
+                    Future.successful(Map.empty[TokenId, FungibleTokenMetadata])
+                  } else {
+                    getTokenMetadata(txs)
+                  }
+              } yield {
+                (txs, metadata)
+              }).asJava
+            )
+          }
         },
         paralellism,
         1
       )
-  }
-
-  private def bufferFlowable(source: Flowable[String]): Flowable[Buffer] = {
-    source
-      .map(Buffer.buffer)
+      .takeUntil(cancelToken.signal)
   }
 
   def getTokenMetadata(transactions: ArraySeq[Transaction])(implicit
@@ -468,20 +477,20 @@ object TransactionService extends TransactionService {
 
   def transactionsFlowable(
       address: ApiAddress,
-      source: Flowable[(ArraySeq[Transaction], Map[TokenId, FungibleTokenMetadata])]
+      source: Flowable[(ArraySeq[Transaction], Map[TokenId, FungibleTokenMetadata])],
+      cancelToken: CancelToken
   ): Flowable[Buffer] = {
-    bufferFlowable {
-      val headerSource = Flowable.just(Transaction.csvHeader)
-      val csvSource = source.map { case (txs, metadatas) =>
-        txs.map(_.toCsv(address, metadatas)).mkString
-      }
-      headerSource.mergeWith(csvSource)
-    }
-  }
+    val header = Flowable.just(Buffer.buffer(Transaction.csvHeader))
 
-  def outputsFlowable(source: Flowable[ArraySeq[Output]]): Flowable[Buffer] = {
-    bufferFlowable {
-      source.map(_.map(_.toString()).mkString)
-    }
+    val csvSource =
+      source
+        .takeUntil(cancelToken.signal)
+        .map { case (txs, metadatas) =>
+          Buffer.buffer(
+            txs.iterator.map(_.toCsv(address, metadatas)).mkString
+          )
+        }
+
+    header.concatWith(csvSource)
   }
 }

--- a/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
@@ -23,7 +23,7 @@ import org.alephium.explorer.api.model._
 import org.alephium.explorer.cache._
 import org.alephium.explorer.config.Default.groupConfig
 import org.alephium.explorer.config.ExplorerConfig
-import org.alephium.explorer.service.{TokenService, TransactionService}
+import org.alephium.explorer.service.{CancelToken, TokenService, TransactionService}
 import org.alephium.protocol.PublicKey
 import org.alephium.protocol.model.Address
 import org.alephium.protocol.vm.{LockupScript, PublicKeyLike, UnlockScript}
@@ -121,8 +121,8 @@ class AddressServer(
       route(areAddressesActive.serverLogicSuccess[Future] { addresses =>
         transactionService.areAddressesActive(addresses)
       }),
-      route(exportTransactionsCsvByAddress.serverLogic[Future] { case (address, timeInterval) =>
-        exportTransactions(address, timeInterval).map(_.map { stream =>
+      route(exportTransactionsCsvByAddress.serverLogic[Future] { case (address, timeInterval, rc) =>
+        exportTransactions(address, timeInterval, rc).map(_.map { stream =>
           (AddressServer.exportFileNameHeader(address, timeInterval), stream)
         })
       }),
@@ -164,9 +164,11 @@ class AddressServer(
       })
     )
 
+  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
   private def exportTransactions(
       address: ApiAddress,
-      timeInterval: TimeInterval
+      timeInterval: TimeInterval,
+      rc: RoutingContext
   ): Future[Either[ApiError[_ <: StatusCode], ReadStream[Buffer]]] = {
     transactionService
       .hasAddressMoreTxsThan(address, timeInterval.from, timeInterval.to, exportTxsNumberThreshold)
@@ -178,13 +180,20 @@ class AddressServer(
             )
           )
         } else {
-          val flowable = transactionService.exportTransactionsByAddress(
-            address,
-            timeInterval.from,
-            timeInterval.to,
-            1,
-            streamParallelism
-          )
+          val cancelToken = new CancelToken
+
+          rc.request().connection().closeHandler(_ => cancelToken.cancel())
+          rc.response().exceptionHandler(_ => cancelToken.cancel())
+
+          val flowable = transactionService
+            .exportTransactionsByAddress(
+              address,
+              timeInterval.from,
+              timeInterval.to,
+              1,
+              streamParallelism,
+              cancelToken
+            )
           Right(FlowableHelper.toReadStream(flowable))
         }
       }

--- a/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
@@ -34,6 +34,7 @@ class AddressServer(
     transactionService: TransactionService,
     tokenService: TokenService,
     exportTxsNumberThreshold: Int,
+    streamBatchSize: Int,
     streamParallelism: Int,
     maxTimeInterval: ExplorerConfig.MaxTimeInterval,
     val maxTimeIntervalExportTxs: Duration
@@ -190,7 +191,7 @@ class AddressServer(
               address,
               timeInterval.from,
               timeInterval.to,
-              1,
+              streamBatchSize,
               streamParallelism,
               cancelToken
             )

--- a/app/src/test/scala/org/alephium/explorer/service/EmptyTransactionService.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/EmptyTransactionService.scala
@@ -129,10 +129,11 @@ trait EmptyTransactionService extends TransactionService {
 
   def exportTransactionsByAddress(
       address: ApiAddress,
-      from: TimeStamp,
-      to: TimeStamp,
+      fromTime: TimeStamp,
+      toTime: TimeStamp,
       batchSize: Int,
-      paralellism: Int
+      paralellism: Int,
+      cancelToken: CancelToken
   )(implicit ec: ExecutionContext, dc: DatabaseConfig[PostgresProfile]): Flowable[Buffer] = ???
 
   def getAmountHistory(

--- a/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TransactionServiceSpec.scala
@@ -421,7 +421,7 @@ class TransactionServiceSpec
   "export transactions by address" in new TxsByAddressFixture {
     forAll(Gen.choose(1, 4)) { batchSize =>
       val flowable = TransactionService
-        .exportTransactionsByAddress(address, fromTs, toTs, batchSize, 8)
+        .exportTransactionsByAddress(address, fromTs, toTs, batchSize, 8, new CancelToken)
 
       val result: Seq[Buffer] =
         flowable.toList().blockingGet().asScala

--- a/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
@@ -31,6 +31,7 @@ import org.alephium.explorer.cache._
 import org.alephium.explorer.config.Default.groupConfig
 import org.alephium.explorer.persistence.DatabaseFixtureForAll
 import org.alephium.explorer.service.{
+  CancelToken,
   EmptyTokenService,
   EmptyTransactionService,
   TransactionService
@@ -119,17 +120,19 @@ class AddressServerSpec()
 
     override def exportTransactionsByAddress(
         address: ApiAddress,
-        from: TimeStamp,
-        to: TimeStamp,
+        fromTime: TimeStamp,
+        toTime: TimeStamp,
         batchSize: Int,
-        streamParallelism: Int
+        paralellism: Int,
+        cancelToken: CancelToken
     )(implicit ec: ExecutionContext, dc: DatabaseConfig[PostgresProfile]): Flowable[Buffer] = {
       TransactionService.transactionsFlowable(
         address,
         Flowable
           .fromIterable(transactions.asJava)
           .buffer(batchSize)
-          .map(l => (ArraySeq.from(l.asScala), Map.empty))
+          .map(l => (ArraySeq.from(l.asScala), Map.empty)),
+        new CancelToken
       )
     }
 

--- a/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
@@ -187,6 +187,7 @@ class AddressServerSpec()
       transactionService,
       tokenService,
       exportTxsNumberThreshold = 1000,
+      streamBatchSize = 100,
       streamParallelism = 8,
       maxTimeInterval = ConfigDefaults.maxTimeIntervals.amountHistory,
       maxTimeIntervalExportTxs = ConfigDefaults.maxTimeIntervals.exportTxs

--- a/app/src/test/scala/org/alephium/explorer/web/StatementTimeoutSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/StatementTimeoutSpec.scala
@@ -34,6 +34,7 @@ class StatementTimeoutSpec()
       StatementTimeoutSpec.transactionService(),
       new EmptyTokenService {},
       exportTxsNumberThreshold = 1000,
+      streamBatchSize = 100,
       streamParallelism = 8,
       maxTimeInterval = ConfigDefaults.maxTimeIntervals.amountHistory,
       maxTimeIntervalExportTxs = ConfigDefaults.maxTimeIntervals.exportTxs


### PR DESCRIPTION
Previously, if a transaction export started but the user canceled it (or the connection dropped), the backend would just keep churning away in the background. This resulted in a ton of zombie DB calls and wasted CPU.

We saw this hit us in prod: EB was a bit slow, Nginx timed out the download, and the user (rightfully) clicked retry multiple times. This created a "stack" of simultaneous exports for the same request, which blew up our RAM.

**Changes**:

* We now listen for the Vert.x closeHandler. If the connection drops, we trigger a cancelToken.
* The internal export process is now reactive to this token and will kill the DB stream immediately.
* I changed the `batchSize` from 1 to 100. Previously, we were doing a DB round-trip for every single transaction, which was super inefficient (because I thought we wouldn't preserve transactions order with batch, which I was wrong). Now we fetch and process in chunks of 100, which significantly reduces the IO overhead and helps the stream keep up with Nginx timeouts.
* 
**Testing**:

I simulated the prod failure by setting a 1s Nginx timeout and [forcing a 2s delay between batches in EB](https://github.com/alephium/explorer-backend/blob/1d4d495cdaa6957668b4dfe6951b4e7f4d40b334/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala#L493-L502). The internal process now correctly catches the disconnect and stops immediately.