### PR TITLE
Drop unused database indexes

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/persistence/DBInitializer.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/DBInitializer.scala
@@ -102,9 +102,6 @@ object DBInitializer extends StrictLogging {
     logger.info("Create Indexes")
     run(for {
       _ <- BlockHeaderSchema.createBlockHeadersIndexes()
-      _ <- TransactionSchema.createMainChainIndex()
-      _ <- InputSchema.createMainChainIndex()
-      _ <- OutputSchema.createMainChainIndex()
       _ <- TransactionPerAddressSchema.createIndexes()
       _ <- OutputSchema.createNonSpentIndex()
       _ <- InputSchema.createOutputRefAddressNullIndex()

--- a/app/src/main/scala/org/alephium/explorer/persistence/Migrations.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/Migrations.scala
@@ -29,7 +29,7 @@ import org.alephium.util.discard
 object Migrations extends StrictLogging {
 
   // scalastyle:off magic.number
-  val latestVersion: MigrationVersion = MigrationVersion(11)
+  val latestVersion: MigrationVersion = MigrationVersion(12)
 
   def migration1(implicit ec: ExecutionContext): DBActionAll[Unit] = {
     // We retrigger the download of fungible and non-fungible tokens' metadata that have sub-category
@@ -222,6 +222,41 @@ object Migrations extends StrictLogging {
     """.map(_ => ())
   }
 
+  private val unusedIndexes: ArraySeq[String] =
+    ArraySeq(
+      "utransactions_last_seen_idx",
+      "token_info_category_idx",
+      "contracts_std_interface_id_guessed_idx",
+      "contracts_category_idx",
+      "transactions_history_interval_type_idx",
+      "token_tx_per_address_token_idx",
+      "token_outputs_token_idx",
+      "token_outputs_spent_timestamp_idx",
+      "token_tx_per_addresses_timestamp_idx",
+      "transaction_per_token_hash_idx",
+      "token_tx_per_addresses_block_timestamp_tx_order_idx",
+      "token_tx_per_address_hash_idx",
+      "token_tx_per_address_groupless_idx",
+      "inputs_main_chain_idx",
+      "block_headers_main_chain_idx",
+      "outputs_main_chain_idx",
+      "transaction_per_addresses_main_chain_idx",
+      "transactions_main_chain_idx",
+      "txs_chain_to_idx",
+      "txs_chain_from_idx",
+      "txs_per_address_tx_hash_idx"
+    )
+
+  private def dropUnusedIndex(indexName: String)(implicit
+      ec: ExecutionContext
+  ): DBActionAll[Unit] =
+    sqlu"DROP INDEX IF EXISTS public.#$indexName".map(_ => ())
+
+  def migration12(implicit ec: ExecutionContext): DBActionAll[Unit] =
+    DBIOAction
+      .sequence(unusedIndexes.map(indexName => dropUnusedIndex(indexName)))
+      .map(_ => ())
+
   private def migrations(implicit
       explorerConfig: ExplorerConfig,
       ec: ExecutionContext
@@ -236,7 +271,8 @@ object Migrations extends StrictLogging {
     migration8,
     migration9,
     migration10,
-    migration11
+    migration11,
+    migration12
   )
 
   def backgroundCoinbaseMigration()(implicit

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/BlockQueries.scala
@@ -68,12 +68,13 @@ object BlockQueries extends StrictLogging {
 
   def explainMainChainQuery()(implicit ec: ExecutionContext): DBActionR[ExplainResult] =
     mainChainQuery.result.explainAnalyze() map { explain =>
+      val fullIndexUsed = explain.mkString contains "block_headers_full_index"
       ExplainResult(
         queryName = "mainChainQuery",
         queryInput = "Unit",
         explain = explain,
-        messages = Iterable.empty,
-        passed = explain.mkString contains "block_headers_main_chain_idx"
+        messages = Iterable(s"Used block_headers_full_index = $fullIndexUsed"),
+        passed = fullIndexUsed
       )
     }
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/OutputQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/OutputQueries.scala
@@ -399,14 +399,11 @@ object OutputQueries {
     key match {
       case Some(key) =>
         getTxnHashBuilder(key).explainAnalyze() map { explain =>
-          val explainString               = explain.mkString
-          val outputs_pk_used             = explainString contains "outputs_pk"
-          val outputs_main_chain_idx_used = explainString contains "outputs_main_chain_idx"
-          val passed                      = outputs_pk_used && outputs_main_chain_idx_used
+          val explainString   = explain.mkString
+          val outputs_pk_used = explainString contains "outputs_pk"
           val message =
             ArraySeq(
-              s"Used outputs_main_chain_idx = $outputs_main_chain_idx_used",
-              s"Used outputs_pk             = $outputs_pk_used"
+              s"Used outputs_pk = $outputs_pk_used"
             )
 
           ExplainResult(
@@ -414,7 +411,7 @@ object OutputQueries {
             queryInput = key.toString(),
             explain = explain,
             messages = message,
-            passed = passed
+            passed = outputs_pk_used
           )
         }
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/BlockHeaderSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/BlockHeaderSchema.scala
@@ -88,7 +88,7 @@ object BlockHeaderSchema extends SchemaMainChain[BlockHeader]("block_headers") {
   /** Joins all indexes created via raw SQL
     */
   def createBlockHeadersIndexes(): DBIO[Unit] =
-    DBIO.seq(fullIndex(), createMainChainIndex())
+    DBIO.seq(fullIndex())
 
   val table: TableQuery[BlockHeaders] = TableQuery[BlockHeaders]
 }

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/ContractSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/ContractSchema.scala
@@ -56,11 +56,8 @@ object ContractSchema extends SchemaMainChain[ContractEntity]("contracts") {
 
     def pk: PrimaryKey = primaryKey("contracts_pk", (contract, creationBlockHash))
 
-    def contractIdx: Index = index("contracts_contract_idx", contract)
-    def parentIdx: Index   = index("contracts_parent_idx", parent)
-    def stdInterfaceIdGuessedIdx: Index =
-      index("contracts_std_interface_id_guessed_idx", stdInterfaceIdGuessed)
-    def categoryIdx: Index    = index("contracts_category_idx", category)
+    def contractIdx: Index    = index("contracts_contract_idx", contract)
+    def parentIdx: Index      = index("contracts_parent_idx", parent)
     def interfaceIdIdx: Index = index("contracts_interface_id_idx", interfaceId)
   }
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/MempoolTransactionSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/MempoolTransactionSchema.scala
@@ -4,7 +4,7 @@
 package org.alephium.explorer.persistence.schema
 
 import slick.jdbc.PostgresProfile.api._
-import slick.lifted.{Index, ProvenShape}
+import slick.lifted.ProvenShape
 
 import org.alephium.explorer.persistence.model.MempoolTransactionEntity
 import org.alephium.explorer.persistence.schema.CustomJdbcTypes._
@@ -22,8 +22,6 @@ object MempoolTransactionSchema extends Schema[MempoolTransactionEntity]("utrans
     def gasPrice: Rep[U256] =
       column[U256]("gas_price", O.SqlType("DECIMAL(80,0)")) // U256.MaxValue has 78 digits
     def lastSeen: Rep[TimeStamp] = column[TimeStamp]("last_seen")
-
-    def lastSeenIdx: Index = index("utransactions_last_seen_idx", lastSeen)
 
     def * : ProvenShape[MempoolTransactionEntity] =
       (hash, chainFrom, chainTo, gasAmount, gasPrice, lastSeen)

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenInfoSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenInfoSchema.scala
@@ -24,7 +24,6 @@ object TokenInfoSchema extends SchemaMainChain[TokenInfoEntity]("token_info") {
       (token, lastUsed, category, interfaceId)
         .<>((TokenInfoEntity.apply _).tupled, TokenInfoEntity.unapply)
 
-    def categoryIdx: Index    = index("token_info_category_idx", category)
     def interfaceIdIdx: Index = index("token_info_interface_id_idx", interfaceId)
   }
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenOutputSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenOutputSchema.scala
@@ -43,13 +43,11 @@ object TokenOutputSchema extends SchemaMainChain[TokenOutputEntity]("token_outpu
 
     def pk: PrimaryKey = primaryKey("token_outputs_pk", (key, token, blockHash))
 
-    def keyIdx: Index            = index("token_outputs_key_idx", key)
-    def blockHashIdx: Index      = index("token_outputs_block_hash_idx", blockHash)
-    def txHashIdx: Index         = index("token_outputs_tx_hash_idx", txHash)
-    def addressIdx: Index        = index("token_outputs_address_idx", address)
-    def timestampIdx: Index      = index("token_outputs_timestamp_idx", timestamp)
-    def tokenIdx: Index          = index("token_outputs_token_idx", token)
-    def spentTimestampIdx: Index = index("token_outputs_spent_timestamp_idx", spentTimestamp)
+    def keyIdx: Index       = index("token_outputs_key_idx", key)
+    def blockHashIdx: Index = index("token_outputs_block_hash_idx", blockHash)
+    def txHashIdx: Index    = index("token_outputs_tx_hash_idx", txHash)
+    def addressIdx: Index   = index("token_outputs_address_idx", address)
+    def timestampIdx: Index = index("token_outputs_timestamp_idx", timestamp)
 
     def * : ProvenShape[TokenOutputEntity] =
       (

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenTxPerAddressSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TokenTxPerAddressSchema.scala
@@ -31,10 +31,8 @@ object TokenPerAddressSchema
 
     def pk: PrimaryKey = primaryKey("token_tx_per_address_pk", (txHash, blockHash, address, token))
 
-    def hashIdx: Index         = index("token_tx_per_address_hash_idx", txHash)
     def blockHashIdx: Index    = index("token_tx_per_address_block_hash_idx", blockHash)
     def addressIdx: Index      = index("token_tx_per_address_address_idx", address)
-    def tokenIdx: Index        = index("token_tx_per_address_token_idx", token)
     def tokenAddressIdx: Index = index("token_tx_per_address_token_address_idx", (token, address))
 
     def * : ProvenShape[TokenTxPerAddressEntity] =
@@ -53,15 +51,11 @@ object TokenPerAddressSchema
   }
 
   def createIndexes(): DBIO[Unit] =
-    DBIO.seq(
-      CommonIndex.blockTimestampTxOrderIndex(this),
-      CommonIndex.timestampIndex(this)
-    )
+    DBIO.seq()
 
   def createConcurrentIndexes()(implicit ec: ExecutionContext): DBActionW[Unit] =
     for {
       _ <- createTokenGrouplessAddressIndex()
-      _ <- createGrouplessIndex()
     } yield ()
 
   def createTokenGrouplessAddressIndex(): DBActionW[Int] =
@@ -70,15 +64,6 @@ object TokenPerAddressSchema
       ON token_tx_per_addresses (token, groupless_address)
       WHERE groupless_address IS NOT NULL;
     """
-
-  def createGrouplessIndex(): DBActionW[Int] =
-    sqlu"""
-        CREATE INDEX CONCURRENTLY IF NOT EXISTS token_tx_per_address_groupless_idx
-        ON token_tx_per_addresses (
-          token, address, groupless_address, block_timestamp, tx_order, tx_hash, block_hash
-        )
-        WHERE groupless_address is not null AND main_chain = true;
-      """
 
   val table: TableQuery[TokenPerAddresses] = TableQuery[TokenPerAddresses]
 }

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionHistorySchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionHistorySchema.scala
@@ -23,8 +23,7 @@ object TransactionHistorySchema extends Schema[TransactionHistoryEntity]("transa
 
     def pk: PrimaryKey =
       primaryKey("transactions_history_pk", (intervalType, timestamp, chainFrom, chainTo))
-    def intervalTypeIdx: Index = index("transactions_history_interval_type_idx", intervalType)
-    def timestampIdx: Index    = index("transactions_history_timestamp_idx", timestamp)
+    def timestampIdx: Index = index("transactions_history_timestamp_idx", timestamp)
 
     def * : ProvenShape[TransactionHistoryEntity] =
       (timestamp, chainFrom, chainTo, count, intervalType)

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionPerAddressSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionPerAddressSchema.scala
@@ -31,7 +31,6 @@ object TransactionPerAddressSchema
 
     def pk: PrimaryKey = primaryKey("txs_per_address_pk", (txHash, blockHash, address))
 
-    def hashIdx: Index      = index("txs_per_address_tx_hash_idx", txHash)
     def blockHashIdx: Index = index("txs_per_address_block_hash_idx", blockHash)
     def addressIdx: Index   = index("txs_per_address_address_idx", address)
     def addressTimestampIdx: Index =
@@ -54,7 +53,6 @@ object TransactionPerAddressSchema
 
   def createIndexes(): DBIO[Unit] =
     DBIO.seq(
-      createMainChainIndex(),
       CommonIndex.blockTimestampTxOrderIndex(this),
       CommonIndex.timestampIndex(this)
     )

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionPerTokenSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionPerTokenSchema.scala
@@ -25,7 +25,6 @@ object TransactionPerTokenSchema
 
     def pk: PrimaryKey = primaryKey("transaction_per_token_pk", (hash, blockHash, token))
 
-    def hashIdx: Index      = index("transaction_per_token_hash_idx", hash)
     def blockHashIdx: Index = index("transaction_per_token_block_hash_idx", blockHash)
     def tokenIdx: Index     = index("transaction_per_token_token_idx", token)
 

--- a/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionSchema.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/schema/TransactionSchema.scala
@@ -44,8 +44,6 @@ object TransactionSchema extends SchemaMainChain[TransactionEntity]("transaction
 
     def timestampIdx: Index = index("txs_timestamp_idx", timestamp)
     def blockHashIdx: Index = index("txs_block_hash_idx", blockHash)
-    def chainFromIdx: Index = index("txs_chain_from_idx", chainFrom)
-    def chainToIdx: Index   = index("txs_chain_to_idx", chainTo)
 
     def * : ProvenShape[TransactionEntity] =
       (

--- a/app/src/main/scala/org/alephium/explorer/service/IndexChecker.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/IndexChecker.scala
@@ -33,7 +33,6 @@ object IndexChecker {
       b <- BlockQueries.explainListMainChainHeadersWithTxnNumber(
         Pagination.Reversible.unsafe(10000, 20)
       ) // far page
-      c                  <- BlockQueries.explainMainChainQuery()
       oldestOutputEntity <- OutputQueries.getMainChainOutputs(true).headOrEmpty
       latestOutputEntity <- OutputQueries.getMainChainOutputs(false).headOrEmpty
       d                 <- OutputQueries.explainGetTxnHash(oldestOutputEntity.map(_.key).headOption)
@@ -42,6 +41,6 @@ object IndexChecker {
       latestInputEntity <- InputQueries.getMainChainInputs(false).headOrEmpty
       f                 <- InputQueries.explainInputsFromTxs(oldestInputEntity.map(_.hashes()))
       g                 <- InputQueries.explainInputsFromTxs(latestInputEntity.map(_.hashes()))
-    } yield ArraySeq(a, b, c, d, e, f, g).sortBy(_.passed)
+    } yield ArraySeq(a, b, d, e, f, g).sortBy(_.passed)
 
 }


### PR DESCRIPTION
Remove all unused indexes from our prod database. 

You can find the usage of all our indexes for our:
1. WriteOnly instance
2. ReadOnly 
3. Fallback 

[unused_indexes_report-fallback.txt](https://github.com/user-attachments/files/29136930/unused_indexes_report-fallback.txt)
[unused_indexes_report-replica.txt](https://github.com/user-attachments/files/29136932/unused_indexes_report-replica.txt)
[unused_indexes_report.txt](https://github.com/user-attachments/files/29136933/unused_indexes_report.txt)

main + replica have the same unused indexes, fallback differ a bit, which makes sense since fallback instance is used for a limited amount of endpoints.

I heavily tested it with the EB, everything is smooth, but I made [this revert PR](https://github.com/alephium/explorer-backend/pull/665) if anything goes terribly wrong.

Migration 12 drops 21 unused indexes, from the report, it can reclaim ~20 Go per DB instance and ~60 Go across main, replica, and fallback.

resolves https://github.com/alephium/explorer-backend/issues/631