### PR TITLE
Add `POST /addresses/latest-transactions` endpoint

### DIFF
--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -2554,6 +2554,139 @@
         }
       }
     },
+    "/addresses/latest-transactions": {
+      "post": {
+        "tags": [
+          "Addresses"
+        ],
+        "summary": "Get latest transaction information for given addresses",
+        "operationId": "postAddressesLatest-transactions",
+        "requestBody": {
+          "description": "List of addresses, max items: 80",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "maxItems": 80,
+                "items": {
+                  "type": "string",
+                  "format": "address"
+                }
+              },
+              "example": [
+                "1AujpupFP4KWeZvqA7itsHY9cLJmx4qTzojVZrg8W9y"
+              ]
+            }
+          },
+          "required": false
+        },
+        "responses": {
+          "200": {
+            "description": "Ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TransactionInfoPerAddress"
+                  }
+                },
+                "example": [
+                  {
+                    "address": "1AujpupFP4KWeZvqA7itsHY9cLJmx4qTzojVZrg8W9y",
+                    "transactionInfo": {
+                      "hash": "503bfb16230888af4924aa8f8250d7d348b862e267d75d3147f1998050b6da69",
+                      "blockHash": "bdaf9dc514ce7d34b6474b8ca10a3dfb93ba997cb9d5ff1ea724ebe2af48abe5",
+                      "timestamp": 1611041396892,
+                      "coinbase": false
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          "400": {
+            "description": "BadRequest",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequest"
+                },
+                "example": {
+                  "detail": "Something bad in the request"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unauthorized"
+                },
+                "example": {
+                  "detail": "You shall not pass"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFound",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFound"
+                },
+                "example": {
+                  "resource": "wallet-name",
+                  "detail": "wallet-name not found"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerError"
+                },
+                "example": {
+                  "detail": "Ouch"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailable"
+                },
+                "example": {
+                  "detail": "Self clique unsynced"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "GatewayTimeout",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GatewayTimeout"
+                },
+                "example": {
+                  "detail": "The network is slow"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/addresses/{address}/mempool/transactions": {
       "get": {
         "tags": [
@@ -10178,6 +10311,23 @@
           },
           "coinbase": {
             "type": "boolean"
+          }
+        }
+      },
+      "TransactionInfoPerAddress": {
+        "title": "TransactionInfoPerAddress",
+        "type": "object",
+        "required": [
+          "address",
+          "transactionInfo"
+        ],
+        "properties": {
+          "address": {
+            "type": "string",
+            "format": "address"
+          },
+          "transactionInfo": {
+            "$ref": "#/components/schemas/TransactionInfo"
           }
         }
       },

--- a/app/src/main/resources/explorer-backend-openapi.json
+++ b/app/src/main/resources/explorer-backend-openapi.json
@@ -2560,6 +2560,7 @@
           "Addresses"
         ],
         "summary": "Get latest transaction information for given addresses",
+        "description": "Returns the latest transaction for each address. Duplicate addresses are deduplicated. Addresses with no transactions are omitted from the result.",
         "operationId": "postAddressesLatest-transactions",
         "requestBody": {
           "description": "List of addresses, max items: 80",

--- a/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
@@ -91,6 +91,14 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
       .out(jsonBody[TransactionInfo])
       .summary("Get latest transaction information of a given address")
 
+  lazy val getLatestTransactionInfos
+      : BaseEndpoint[ArraySeq[ApiAddress], ArraySeq[TransactionInfoPerAddress]] =
+    baseAddressesEndpoint.post
+      .in(arrayBody[ApiAddress]("addresses", maxSizeAddresses))
+      .in("latest-transactions")
+      .out(jsonBody[ArraySeq[TransactionInfoPerAddress]])
+      .summary("Get latest transaction information for given addresses")
+
   val addressMempoolTransactions: BaseEndpoint[ApiAddress, ArraySeq[MempoolTransaction]] =
     addressesLikeEndpoint.get
       .in("mempool")

--- a/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/AddressesEndpoints.scala
@@ -98,6 +98,9 @@ trait AddressesEndpoints extends BaseEndpoint with QueryParams {
       .in("latest-transactions")
       .out(jsonBody[ArraySeq[TransactionInfoPerAddress]])
       .summary("Get latest transaction information for given addresses")
+      .description(
+        "Returns the latest transaction for each address. Duplicate addresses are deduplicated. Addresses with no transactions are omitted from the result."
+      )
 
   val addressMempoolTransactions: BaseEndpoint[ApiAddress, ArraySeq[MempoolTransaction]] =
     addressesLikeEndpoint.get

--- a/app/src/main/scala/org/alephium/explorer/api/EndpointExamples.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/EndpointExamples.scala
@@ -499,6 +499,22 @@ object EndpointExamples extends EndpointsExamples {
       )
     )
 
+  implicit val transactionInfoPerAddressesExample
+      : List[Example[ArraySeq[TransactionInfoPerAddress]]] =
+    simpleExample(
+      ArraySeq(
+        TransactionInfoPerAddress(
+          address = address1,
+          transactionInfo = TransactionInfo(
+            hash = txId,
+            blockHash = blockHash,
+            timestamp = ts,
+            coinbase = false
+          )
+        )
+      )
+    )
+
   implicit val amountHistory: List[Example[AmountHistory]] =
     simpleExample(AmountHistory(ArraySeq(TimedAmount(ts, U256.One.v))))
 

--- a/app/src/main/scala/org/alephium/explorer/api/model/TransactionInfoPerAddress.scala
+++ b/app/src/main/scala/org/alephium/explorer/api/model/TransactionInfoPerAddress.scala
@@ -1,0 +1,17 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.explorer.api.model
+
+import org.alephium.explorer.api.Json._
+import org.alephium.json.Json._
+import org.alephium.protocol.model.Address
+
+final case class TransactionInfoPerAddress(
+    address: Address,
+    transactionInfo: TransactionInfo
+)
+
+object TransactionInfoPerAddress {
+  implicit val readWriter: ReadWriter[TransactionInfoPerAddress] = macroRW
+}

--- a/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
+++ b/app/src/main/scala/org/alephium/explorer/docs/Documentation.scala
@@ -43,6 +43,7 @@ trait Documentation
         getTransactionsByAddressTimeRanged,
         getTotalTransactionsByAddress,
         getLatestTransactionInfo,
+        getLatestTransactionInfos,
         addressMempoolTransactions,
         getAddressBalance,
         listAddressTokens,

--- a/app/src/main/scala/org/alephium/explorer/persistence/dao/TransactionDao.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/dao/TransactionDao.scala
@@ -12,6 +12,7 @@ import slick.jdbc.PostgresProfile
 import org.alephium.api.model.{Address => ApiAddress}
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.cache.AddressTxCountCache
+import org.alephium.explorer.config.Default.groupConfig
 import org.alephium.explorer.persistence.DBRunner._
 import org.alephium.explorer.persistence.model.{AddressTotalTransactionsEntity, AppState}
 import org.alephium.explorer.persistence.queries.AppStateQueries
@@ -65,6 +66,27 @@ object TransactionDao {
     run(getLatestTransactionInfoByAddressAction(address).map(_.map { tx =>
       TransactionInfo(tx.txHash, tx.blockHash, tx.blockTimestamp, tx.coinbase)
     }))
+
+  def getLatestTransactionInfoByAddresses(addresses: ArraySeq[ApiAddress])(implicit
+      ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile]
+  ): Future[ArraySeq[TransactionInfoPerAddress]] =
+    run(getLatestTransactionInfoByAddressesAction(addresses).map { rows =>
+      val infosByAddress = rows.map(row => row.lookupAddress -> row).toMap
+      addresses.flatMap { address =>
+        infosByAddress.get(address.toBase58).map { row =>
+          TransactionInfoPerAddress(
+            row.address,
+            TransactionInfo(
+              row.tx.txHash,
+              row.tx.blockHash,
+              row.tx.blockTimestamp,
+              row.tx.coinbase
+            )
+          )
+        }
+      }
+    })
 
   def getNumberByAddress(
       address: ApiAddress,

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
@@ -421,7 +421,6 @@ object TransactionQueries extends StrictLogging {
         s"""
            SELECT lookup_address, address, ${TxByAddressQR.selectFields}
            FROM (${branches.map(branch => s"($branch)").mkString(" UNION ALL ")}) matches
-           ORDER BY lookup_address
          """
 
       val parameters: SetParameter[Unit] =

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/TransactionQueries.scala
@@ -398,6 +398,43 @@ object TransactionQueries extends StrictLogging {
       .headOrNone
   }
 
+  def getLatestTransactionInfoByAddressesAction(
+      addresses: ArraySeq[ApiAddress]
+  ): DBActionSR[LatestTxInfoByAddressQR] =
+    if (addresses.isEmpty) {
+      DBIOAction.successful(ArraySeq.empty)
+    } else {
+      val branches =
+        addresses.map { address =>
+          s"""
+             SELECT ? AS lookup_address, address, ${TxByAddressQR.selectFields}
+             FROM transaction_per_addresses
+             WHERE main_chain = true
+             AND ${notConflicted()}
+             AND ${addressColumn(address)} = ?
+             ORDER BY block_timestamp DESC, tx_order
+             LIMIT 1
+           """
+        }
+
+      val query =
+        s"""
+           SELECT lookup_address, address, ${TxByAddressQR.selectFields}
+           FROM (${branches.map(branch => s"($branch)").mkString(" UNION ALL ")}) matches
+           ORDER BY lookup_address
+         """
+
+      val parameters: SetParameter[Unit] =
+        (_: Unit, params: PositionedParameters) => {
+          addresses.foreach { address =>
+            params >> address
+            params >> address
+          }
+        }
+
+      SQLActionBuilder(query, parameters).asAS[LatestTxInfoByAddressQR]
+    }
+
   def getTransactionsByAddressTimeRanged(
       address: ApiAddress,
       fromTime: TimeStamp,

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/result/LatestTxInfoByAddressQR.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/result/LatestTxInfoByAddressQR.scala
@@ -1,0 +1,25 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.explorer.persistence.queries.result
+
+import slick.jdbc.GetResult
+
+import org.alephium.explorer.persistence.schema.CustomGetResult._
+import org.alephium.protocol.model.Address
+
+  final case class LatestTxInfoByAddressQR(
+      lookupAddress: String,
+      address: Address,
+      tx: TxByAddressQR
+  )
+
+  object LatestTxInfoByAddressQR{
+  implicit val latestTxInfoByAddressGetResult: GetResult[LatestTxInfoByAddressQR] =
+    result =>
+      LatestTxInfoByAddressQR(
+        result.<<,
+        result.<<,
+        TxByAddressQR.transactionByAddressQRGetResult(result)
+      )
+  }

--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/result/LatestTxInfoByAddressQR.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/result/LatestTxInfoByAddressQR.scala
@@ -8,13 +8,13 @@ import slick.jdbc.GetResult
 import org.alephium.explorer.persistence.schema.CustomGetResult._
 import org.alephium.protocol.model.Address
 
-  final case class LatestTxInfoByAddressQR(
-      lookupAddress: String,
-      address: Address,
-      tx: TxByAddressQR
-  )
+final case class LatestTxInfoByAddressQR(
+    lookupAddress: String,
+    address: Address,
+    tx: TxByAddressQR
+)
 
-  object LatestTxInfoByAddressQR{
+object LatestTxInfoByAddressQR {
   implicit val latestTxInfoByAddressGetResult: GetResult[LatestTxInfoByAddressQR] =
     result =>
       LatestTxInfoByAddressQR(
@@ -22,4 +22,4 @@ import org.alephium.protocol.model.Address
         result.<<,
         TxByAddressQR.transactionByAddressQRGetResult(result)
       )
-  }
+}

--- a/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
@@ -68,6 +68,11 @@ trait TransactionService {
       dc: DatabaseConfig[PostgresProfile]
   ): Future[Option[TransactionInfo]]
 
+  def getLatestTransactionInfoByAddresses(addresses: ArraySeq[ApiAddress])(implicit
+      ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile]
+  ): Future[ArraySeq[TransactionInfoPerAddress]]
+
   def getTransactionsByAddresses(
       addresses: ArraySeq[ApiAddress],
       fromTime: Option[TimeStamp],
@@ -197,6 +202,12 @@ object TransactionService extends TransactionService {
       dc: DatabaseConfig[PostgresProfile]
   ): Future[Option[TransactionInfo]] =
     TransactionDao.getLatestTransactionInfoByAddress(address)
+
+  def getLatestTransactionInfoByAddresses(addresses: ArraySeq[ApiAddress])(implicit
+      ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile]
+  ): Future[ArraySeq[TransactionInfoPerAddress]] =
+    TransactionDao.getLatestTransactionInfoByAddresses(addresses)
 
   def getTransactionsByAddresses(
       addresses: ArraySeq[ApiAddress],

--- a/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/AddressServer.scala
@@ -90,6 +90,9 @@ class AddressServer(
           case Some(txInfo) => Right(txInfo)
         }
       }),
+      route(getLatestTransactionInfos.serverLogicSuccess[Future] { addresses =>
+        transactionService.getLatestTransactionInfoByAddresses(addresses.distinct)
+      }),
       route(getAddressBalance.serverLogicSuccess[Future] { address =>
         for {
           (balance, locked) <- transactionService

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/TransactionQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/TransactionQueriesSpec.scala
@@ -11,6 +11,7 @@ import slick.jdbc.PostgresProfile.api._
 
 import org.alephium.api.model.{Address => ApiAddress}
 import org.alephium.explorer.{AlephiumFutureSpec, TestQueries}
+import org.alephium.explorer.ConfigDefaults.groupSetting
 import org.alephium.explorer.GenApiModel._
 import org.alephium.explorer.GenCoreProtocol._
 import org.alephium.explorer.GenCoreUtil._
@@ -208,6 +209,55 @@ class TransactionQueriesSpec
 
     txs.size is 3
     txs should contain allElementsOf expected
+  }
+
+  "get latest tx info by addresses" in new Fixture {
+    val lockup          = p2pkLockupGen(chainFrom).sample.get
+    val protocolAddress = Address.Asset(lockup)
+    val fullAddress     = ApiAddress.fromProtocol(protocolAddress)
+    val halfAddress     = ApiAddress(ApiAddress.HalfDecodedP2PK(lockup.publicKey))
+
+    val older = TransactionPerAddressEntity(
+      address = protocolAddress,
+      grouplessAddress = AddressUtil.convertToGrouplessAddress(protocolAddress),
+      hash = transactionHashGen.sample.get,
+      blockHash = blockHashGen.sample.get,
+      timestamp = TimeStamp.unsafe(1),
+      txOrder = 1,
+      mainChain = true,
+      conflicted = None,
+      coinbase = false
+    )
+    val newer = older.copy(
+      hash = transactionHashGen.sample.get,
+      blockHash = blockHashGen.sample.get,
+      timestamp = TimeStamp.unsafe(2),
+      txOrder = 0
+    )
+
+    exec(TransactionPerAddressSchema.table.delete)
+    exec(TransactionPerAddressSchema.table ++= ArraySeq(older, newer))
+
+    val actual = exec(
+      TransactionQueries.getLatestTransactionInfoByAddressesAction(
+        ArraySeq(fullAddress, halfAddress)
+      )
+    )
+
+    val expectedTx = TxByAddressQR(
+      newer.hash,
+      newer.blockHash,
+      newer.timestamp,
+      newer.txOrder,
+      newer.coinbase,
+      newer.conflicted
+    )
+    val expected = ArraySeq(
+      LatestTxInfoByAddressQR(fullAddress.toBase58, protocolAddress, expectedTx),
+      LatestTxInfoByAddressQR(halfAddress.toBase58, protocolAddress, expectedTx)
+    )
+
+    actual should contain theSameElementsAs expected
   }
 
   "output's spent info should only take the input from the main chain" in new Fixture {

--- a/app/src/test/scala/org/alephium/explorer/persistence/queries/TransactionQueriesSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/persistence/queries/TransactionQueriesSpec.scala
@@ -260,6 +260,39 @@ class TransactionQueriesSpec
     actual should contain theSameElementsAs expected
   }
 
+  "address with no txs is omitted from result" in new Fixture {
+    val lockup          = p2pkLockupGen(chainFrom).sample.get
+    val protocolAddress = Address.Asset(lockup)
+    val addressWithTx   = ApiAddress.fromProtocol(protocolAddress)
+
+    val emptyLockup = p2pkLockupGen(chainFrom).sample.get
+    val addressNoTx = ApiAddress.fromProtocol(Address.Asset(emptyLockup))
+
+    val txEntity = TransactionPerAddressEntity(
+      address = protocolAddress,
+      grouplessAddress = AddressUtil.convertToGrouplessAddress(protocolAddress),
+      hash = transactionHashGen.sample.get,
+      blockHash = blockHashGen.sample.get,
+      timestamp = TimeStamp.unsafe(1),
+      txOrder = 0,
+      mainChain = true,
+      conflicted = None,
+      coinbase = false
+    )
+
+    exec(TransactionPerAddressSchema.table.delete)
+    exec(TransactionPerAddressSchema.table += txEntity)
+
+    val actual = exec(
+      TransactionQueries.getLatestTransactionInfoByAddressesAction(
+        ArraySeq(addressWithTx, addressNoTx)
+      )
+    )
+
+    actual.map(_.lookupAddress) should contain only addressWithTx.toBase58
+    actual.map(_.lookupAddress) should not contain addressNoTx.toBase58
+  }
+
   "output's spent info should only take the input from the main chain" in new Fixture {
 
     val tx1 = transactionEntityGen().sample.get.copy(mainChain = true)

--- a/app/src/test/scala/org/alephium/explorer/service/EmptyTransactionService.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/EmptyTransactionService.scala
@@ -83,6 +83,12 @@ trait EmptyTransactionService extends TransactionService {
   ): Future[Option[TransactionInfo]] =
     Future.successful(None)
 
+  override def getLatestTransactionInfoByAddresses(addresses: ArraySeq[ApiAddress])(implicit
+      ec: ExecutionContext,
+      dc: DatabaseConfig[PostgresProfile]
+  ): Future[ArraySeq[TransactionInfoPerAddress]] =
+    Future.successful(ArraySeq.empty)
+
   override def listMempoolTransactionsByAddress(address: ApiAddress)(implicit
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]

--- a/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
@@ -142,6 +142,16 @@ class AddressServerSpec()
     ): Future[Option[TransactionInfo]] =
       Future.successful(transactionInfo)
 
+    override def getLatestTransactionInfoByAddresses(addresses: ArraySeq[ApiAddress])(implicit
+        ec: ExecutionContext,
+        dc: DatabaseConfig[PostgresProfile]
+    ): Future[ArraySeq[TransactionInfoPerAddress]] =
+      Future.successful(
+        ArraySeq.fill(addresses.size)(
+          TransactionInfoPerAddress(publicKeyAddresses.head._1, transactionInfo.get)
+        )
+      )
+
     override def getAmountHistory(
         address: ApiAddress,
         from: TimeStamp,
@@ -233,6 +243,34 @@ class AddressServerSpec()
     forAll(addressGen) { case address =>
       Get(s"/addresses/${address}/latest-transaction") check { response =>
         response.as[TransactionInfo] is transactionInfo.get
+      }
+    }
+  }
+
+  "get latest transaction info for multiple addresses" should {
+    "return all different addresses info" in {
+      val addresses = ArraySeq.fill(3)(addressGen.sample.get)
+      val entity    = addresses.map(address => s""""$address"""").mkString("[", ",", "]")
+
+      Post("/addresses/latest-transactions", Some(entity)) check { response =>
+        // We take only distinct addresses
+        response.as[ArraySeq[TransactionInfoPerAddress]] is ArraySeq.fill(addresses.size)(
+          TransactionInfoPerAddress(publicKeyAddresses.head._1, transactionInfo.get)
+        )
+      }
+    }
+    "return only 1 info for when using multiple time the same address" in {
+
+      val address       = addressGen.sample.get
+      val sameAddresses = ArraySeq.fill(3)(address)
+      val sameAddresseEntity =
+        sameAddresses.map(address => s""""$address"""").mkString("[", ",", "]")
+
+      Post("/addresses/latest-transactions", Some(sameAddresseEntity)) check { response =>
+        // We take only distinct addresses
+        response.as[ArraySeq[TransactionInfoPerAddress]] is ArraySeq(
+          TransactionInfoPerAddress(publicKeyAddresses.head._1, transactionInfo.get)
+        )
       }
     }
   }

--- a/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/AddressServerSpec.scala
@@ -249,7 +249,7 @@ class AddressServerSpec()
 
   "get latest transaction info for multiple addresses" should {
     "return all different addresses info" in {
-      val addresses = ArraySeq.fill(3)(addressGen.sample.get)
+      val addresses = LazyList.continually(addressGen.sample.get).distinct.take(3).to(ArraySeq)
       val entity    = addresses.map(address => s""""$address"""").mkString("[", ",", "]")
 
       Post("/addresses/latest-transactions", Some(entity)) check { response =>


### PR DESCRIPTION
Resolves https://github.com/alephium/explorer-backend/issues/669

Super fast even with our top 10 addresses by number of txs

```bash
 curltime -X 'POST' \                                                                                                                                                                                            15:51:01
  'http://localhost:9090/addresses/latest-transactions' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '[
   "1Gzp3Wc42fanrbAqknYmSaZLfC567bP3JWprDCiuJ8rbP",
 "1EbUwQWRfuXnEkvPTYxubp5cYsGo3foAMA9g9zvNQNSwW",
 "12jK2jHyyJTJyuRMRya7QJSojgVnb5yh4HVzNNw6BTBDF",
 "19WzSnmNC1SQ6v7RpFFXhpcMcFSiwM4nKTSdbwgSJfSHy",
 "14kSoi8pFMn2wMJFZJgGpFSA7GyNMtwWKnsKc1KidZ8Bu",
 "1PZonix2UoaguUfbbBnWevk4vod1m9MeJXBnkr7aqN76",
 "15AkQjovigzbQXGoHekLMb1prs1MTyRXFKSLw8VRy4quJ",
 "1LzhJdLG1SMMCPqRpnUJRs5wgLqRYcWZcRdG8baLeFbT",
 "1Ba2L3oUn6B9SR6DcwzyD1EK26JptfkoyXngKwG5s6XeP",
 "15AG4h7gy9EThb1riPwzzZh5v1yvPJwJ2ZaYieVJ4e1YE"
]
'

time_total: 0.107701
```