### PR TITLE
Fix contract update

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/service/TokenService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/TokenService.scala
@@ -283,9 +283,9 @@ object TokenService extends TokenService with StrictLogging {
       dc: DatabaseConfig[PostgresProfile]
   ): Future[Unit] = {
     listContractWithoutInterfaceId()
-      .flatMap { tokens =>
+      .flatMap { contracts =>
         Future.sequence(
-          tokens.map(contract => fetchAndStoreContractMetadata(contract, blockFlowClient))
+          contracts.map(contract => fetchAndStoreContractMetadata(contract, blockFlowClient))
         )
       }
       .map(_ => ())

--- a/app/src/main/scala/org/alephium/explorer/service/TokenService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/TokenService.scala
@@ -284,9 +284,9 @@ object TokenService extends TokenService with StrictLogging {
   ): Future[Unit] = {
     listContractWithoutInterfaceId()
       .flatMap { contracts =>
-        Future.sequence(
-          contracts.map(contract => fetchAndStoreContractMetadata(contract, blockFlowClient))
-        )
+        foldFutures(contracts) { contract =>
+          fetchAndStoreContractMetadata(contract, blockFlowClient)
+        }
       }
       .map(_ => ())
   }

--- a/app/src/test/scala/org/alephium/explorer/service/TokenServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TokenServiceSpec.scala
@@ -3,8 +3,6 @@
 
 package org.alephium.explorer.service
 
-import java.util.concurrent.RejectedExecutionException
-
 import scala.collection.immutable.ArraySeq
 import scala.jdk.CollectionConverters._
 
@@ -35,7 +33,7 @@ class TokenServiceSpec extends AlephiumFutureSpec with ScalaFutures {
       .withFallback(ConfigFactory.load())
 
   "updateContractsMetadata" should {
-    "overflow the DB executor when many contracts are pending" in {
+    "not overflow the DB executor when many contracts are pending" in {
       val dbName = "tokenservicespec"
 
       DatabaseFixture.createDb(dbName)
@@ -53,7 +51,12 @@ class TokenServiceSpec extends AlephiumFutureSpec with ScalaFutures {
 
         val client = new EmptyBlockFlowClient {}
 
-        TokenService.updateContractsMetadata(client).failed.futureValue is a[RejectedExecutionException]
+        TokenService.updateContractsMetadata(client).futureValue is ()
+
+        DBRunner
+          .run(ContractQueries.listContractWithoutInterfaceIdQuery())
+          .futureValue is ArraySeq.empty
+
       } finally {
         databaseConfig.db.close()
         DatabaseFixture.dropDb(dbName)

--- a/app/src/test/scala/org/alephium/explorer/service/TokenServiceSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/service/TokenServiceSpec.scala
@@ -1,0 +1,64 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.explorer.service
+
+import java.util.concurrent.RejectedExecutionException
+
+import scala.collection.immutable.ArraySeq
+import scala.jdk.CollectionConverters._
+
+import com.typesafe.config.{Config, ConfigFactory, ConfigValueFactory}
+import org.scalatest.concurrent.ScalaFutures
+import slick.basic.DatabaseConfig
+import slick.jdbc.PostgresProfile
+
+import org.alephium.explorer.AlephiumFutureSpec
+import org.alephium.explorer.ConfigDefaults._
+import org.alephium.explorer.GenApiModel._
+import org.alephium.explorer.GenDBModel._
+import org.alephium.explorer.persistence.{DatabaseFixture, DBRunner}
+import org.alephium.explorer.persistence.queries.ContractQueries
+
+class TokenServiceSpec extends AlephiumFutureSpec with ScalaFutures {
+
+  // A tiny DB executor so the regression stays easy to reproduce.
+  private def smallPoolConfig(dbName: String): Config =
+    ConfigFactory
+      .parseMap(
+        Map[String, AnyRef](
+          "db.db.url"        -> s"jdbc:postgresql://localhost:5432/$dbName",
+          "db.db.numThreads" -> Int.box(2),
+          "db.db.queueSize"  -> Int.box(2)
+        ).view.mapValues(ConfigValueFactory.fromAnyRef).toMap.asJava
+      )
+      .withFallback(ConfigFactory.load())
+
+  "updateContractsMetadata" should {
+    "overflow the DB executor when many contracts are pending" in {
+      val dbName = "tokenservicespec"
+
+      DatabaseFixture.createDb(dbName)
+      val setupDatabaseConfig = DatabaseFixture.createDatabaseConfig(dbName)
+      DatabaseFixture.createTables()(setupDatabaseConfig)
+      setupDatabaseConfig.db.close()
+
+      implicit val databaseConfig: DatabaseConfig[PostgresProfile] =
+        DatabaseConfig.forConfig[PostgresProfile]("db", smallPoolConfig(dbName))
+
+      try {
+        val groupIndex = groupIndexGen.sample.get
+        val events     = ArraySeq.fill(50)(createEventGen(groupIndex).sample.get)
+        DBRunner.run(ContractQueries.insertContractCreation(events, groupIndex)).futureValue
+
+        val client = new EmptyBlockFlowClient {}
+
+        TokenService.updateContractsMetadata(client).failed.futureValue is a[RejectedExecutionException]
+      } finally {
+        databaseConfig.db.close()
+        DatabaseFixture.dropDb(dbName)
+        ()
+      }
+    }
+  }
+}


### PR DESCRIPTION
When we catch up  the syncing, we sync 30min of block at a time, but if suddenly there are a lot of contracts event within those 30min, it was crashing the app as the DB couldn't update in parrallel every contracts.

This commit fix it by applying the same [foldFutures as for tokens](https://github.com/alephium/explorer-backend/blob/612434c14cf99ba8ff655d1ede052e88de1251e0/app/src/main/scala/org/alephium/explorer/service/TokenService.scala#L276)

The first commit show the issue, second commit fix it