### PR TITLE
Protect decode-unsigned-tx from oversized input amplification

### DIFF
--- a/app/src/main/scala/org/alephium/explorer/persistence/queries/OutputQueries.scala
+++ b/app/src/main/scala/org/alephium/explorer/persistence/queries/OutputQueries.scala
@@ -321,6 +321,33 @@ object OutputQueries {
      """.as[OutputFromTxQR].headOption
   }
 
+  def getOutputsFromKeys(
+      keys: ArraySeq[Hash]
+  ): DBActionR[ArraySeq[OutputFromTxQR]] = {
+    if (keys.isEmpty) {
+      DBIOAction.successful(ArraySeq.empty)
+    } else {
+      val params = paramPlaceholder(1, keys.size)
+
+      val query =
+        s"""
+           SELECT ${OutputFromTxQR.selectFields}
+           FROM outputs
+           WHERE main_chain = true
+           AND ${notConflicted()}
+           AND key IN $params
+           """
+
+      val parameters: SetParameter[Unit] =
+        (_: Unit, params: PositionedParameters) => keys.foreach(params >> _)
+
+      SQLActionBuilder(
+        sql = query,
+        setParameter = parameters
+      ).asAS[OutputFromTxQR]
+    }
+  }
+
   def outputsFromTxs(
       hashes: ArraySeq[(TransactionId, BlockHash)]
   ): DBActionR[ArraySeq[OutputFromTxQR]] =

--- a/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
+++ b/app/src/main/scala/org/alephium/explorer/service/TransactionService.scala
@@ -20,14 +20,11 @@ import org.alephium.api.model.{Address => ApiAddress}
 import org.alephium.explorer.RichAVector._
 import org.alephium.explorer.api.model._
 import org.alephium.explorer.cache._
-import org.alephium.explorer.foldFutures
 import org.alephium.explorer.persistence.DBRunner._
 import org.alephium.explorer.persistence.dao.{MempoolDao, TransactionDao}
 import org.alephium.explorer.persistence.queries.{InputQueries, OutputQueries, TokenQueries}
 import org.alephium.explorer.persistence.queries.TransactionQueries._
-import org.alephium.explorer.persistence.queries.result.OutputFromTxQR
 import org.alephium.protocol
-import org.alephium.protocol.Hash
 import org.alephium.protocol.config.GroupConfig
 import org.alephium.protocol.model.{TokenId, TransactionId}
 import org.alephium.serde._
@@ -331,41 +328,22 @@ object TransactionService extends TransactionService {
       ec: ExecutionContext,
       dc: DatabaseConfig[PostgresProfile]
   ): Future[ArraySeq[Input]] =
-    foldFutures(inputs) { input =>
-      val key = input.outputRef.key.value
-      TransactionService
-        .getInputFromOutputRef(key)
-        .map {
-          case Some(output) =>
-            Input(
-              OutputRef(input.outputRef.hint.value, key),
-              Some(serialize(input.unlockScript)),
-              txHashRef = Some(output.txHash),
-              address = Some(output.address),
-              attoAlphAmount = Some(output.amount),
-              tokens = output.tokens,
-              contractInput = false
-            )
-          case None =>
-            Input(
-              OutputRef(input.outputRef.hint.value, key),
-              Some(serialize(input.unlockScript)),
-              txHashRef = None,
-              address = None,
-              attoAlphAmount = None,
-              tokens = None,
-              contractInput = false
-            )
-        }
+    run(OutputQueries.getOutputsFromKeys(inputs.map(_.outputRef.key.value))).map { outputs =>
+      val outputsByKey = outputs.iterator.map(output => output.key -> output).toMap
+      inputs.map { input =>
+        val key    = input.outputRef.key.value
+        val output = outputsByKey.get(key)
+        Input(
+          OutputRef(input.outputRef.hint.value, key),
+          Some(serialize(input.unlockScript)),
+          txHashRef = output.map(_.txHash),
+          address = output.map(_.address),
+          attoAlphAmount = output.map(_.amount),
+          tokens = output.flatMap(_.tokens),
+          contractInput = false
+        )
+      }
     }
-
-  private def getInputFromOutputRef(outputRef: Hash)(implicit
-      dc: DatabaseConfig[PostgresProfile]
-  ): Future[Option[OutputFromTxQR]] =
-    run(
-      OutputQueries
-        .getOutputFromKey(outputRef)
-    )
 
   def getUnlockScript(address: ApiAddress)(implicit
       ec: ExecutionContext,

--- a/app/src/main/scala/org/alephium/explorer/web/TransactionServer.scala
+++ b/app/src/main/scala/org/alephium/explorer/web/TransactionServer.scala
@@ -17,6 +17,7 @@ import org.alephium.explorer.api.TransactionEndpoints
 import org.alephium.explorer.api.model.DecodeUnsignedTxResult
 import org.alephium.explorer.service.TransactionService
 import org.alephium.protocol
+import org.alephium.protocol.ALPH
 import org.alephium.protocol.model.GroupIndex
 import org.alephium.serde._
 import org.alephium.util.Hex
@@ -35,6 +36,7 @@ class TransactionServer(implicit
     route(decodeUnsignedTx.serverLogic[Future] { decodeUTX =>
       (for {
         utx       <- deserializeUnsignedTx(decodeUTX.unsignedTx)
+        _         <- validateInputCount(utx)
         fromGroup <- fromGroup(utx)
         toGroup   <- toGroup(utx)
       } yield {
@@ -72,5 +74,19 @@ class TransactionServer(implicit
     deserialize[protocol.model.UnsignedTransaction](
       Hex.unsafe(rawUtx)
     ).left.map(e => ApiError.BadRequest(e.getMessage))
+
+  private def validateInputCount(
+      utx: protocol.model.UnsignedTransaction
+  ): Either[ApiError[_ <: StatusCode], Unit] = {
+    if (utx.inputs.length > ALPH.MaxTxInputNum) {
+      Left(
+        ApiError.BadRequest(
+          s"Too many inputs in unsigned transaction, max ${ALPH.MaxTxInputNum}"
+        )
+      )
+    } else {
+      Right(())
+    }
+  }
 
 }

--- a/app/src/test/scala/org/alephium/explorer/web/TransactionServerSpec.scala
+++ b/app/src/test/scala/org/alephium/explorer/web/TransactionServerSpec.scala
@@ -1,0 +1,38 @@
+// Copyright (c) Alephium
+// SPDX-License-Identifier: LGPL-3.0-only
+
+package org.alephium.explorer.web
+
+import org.alephium.api.ApiError
+import org.alephium.explorer._
+import org.alephium.explorer.HttpFixture._
+import org.alephium.explorer.persistence.DatabaseFixtureForAll
+import org.alephium.protocol.ALPH
+import org.alephium.protocol.model.UnsignedTransaction
+import org.alephium.serde._
+import org.alephium.util.{AVector, Hex}
+
+class TransactionServerSpec()
+    extends AlephiumFutureSpec
+    with DatabaseFixtureForAll
+    with HttpServerFixture {
+
+  val server = new TransactionServer()
+  val routes = server.routes
+  val rawUtxHex = {
+    val raw =
+      "00040080004e20c1174876e8000137a44447cfff0c6c3951889e73ae1a3b0b1b2bb284cfb01e77cd910bf17cda8f3dcee82b000381818e63bd9e35a5489b52a430accefc608fd60aa2c7c0d1b393b5239aedf6b003c41bc16d674ec8000000622990ad7be0a3d163562c10fd7985ef40a3e41857e7a1583406a785efc9273a00000000000000000000c429a2241af62c00000000dd2354976f12629cfbc141e16f3592927f06c78bdc27d3f7a429602cc27d1200000000000000000000c6d3b40169eefd092ce00000bee85f379545a2ed9f6cceb331288842f378cf0f04012ad4ac8824aae7d6f80a00000000000000000000"
+    val protocolUnsignedTx = deserialize[UnsignedTransaction](Hex.unsafe(raw)).toOption.get
+    val oversizedInputs    = AVector.fill(ALPH.MaxTxInputNum + 1)(protocolUnsignedTx.inputs.head)
+    Hex.toHexString(serialize(protocolUnsignedTx.copy(inputs = oversizedInputs)))
+  }
+
+  "reject unsigned transactions with too many inputs" in {
+    Post(s"/transactions/decode-unsigned-tx", s"""{"unsignedTx":"$rawUtxHex"}""") check {
+      response =>
+        response.as[ApiError.BadRequest] is ApiError.BadRequest(
+          s"Too many inputs in unsigned transaction, max ${ALPH.MaxTxInputNum}"
+        )
+    }
+  }
+}


### PR DESCRIPTION
Reject unsigned transactions with more than ALPH.MaxTxInputNum inputs before any DB lookup, and batch input output-ref resolution into one query instead of one sequential lookup per input.